### PR TITLE
feat: 上下集和剧集列表支持jellyfin媒体

### DIFF
--- a/lib/pages/settings/jellyfin_mapping_management_page.dart
+++ b/lib/pages/settings/jellyfin_mapping_management_page.dart
@@ -1,0 +1,444 @@
+import 'package:flutter/material.dart';
+import 'dart:ui';
+import 'package:kmbal_ionicons/kmbal_ionicons.dart';
+import '../../services/jellyfin_episode_mapping_service.dart';
+import '../../widgets/blur_snackbar.dart';
+import '../../widgets/blur_dialog.dart';
+
+class JellyfinMappingManagementPage extends StatefulWidget {
+  const JellyfinMappingManagementPage({super.key});
+
+  @override
+  State<JellyfinMappingManagementPage> createState() => _JellyfinMappingManagementPageState();
+}
+
+class _JellyfinMappingManagementPageState extends State<JellyfinMappingManagementPage> {
+  Map<String, dynamic> _stats = {};
+  bool _isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadMappingStats();
+  }
+
+  Future<void> _loadMappingStats() async {
+    try {
+      final stats = await JellyfinEpisodeMappingService.instance.getMappingStats();
+      if (mounted) {
+        setState(() {
+          _stats = stats;
+          _isLoading = false;
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+        BlurSnackBar.show(context, '加载映射统计失败: $e');
+      }
+    }
+  }
+
+  Future<void> _clearAllMappings() async {
+    final confirm = await BlurDialog.show<bool>(
+      context: context,
+      title: '清除所有映射',
+      content: '确定要清除所有Jellyfin剧集映射吗？这将删除所有已建立的智能映射关系，无法恢复。',
+      actions: [
+        TextButton(
+          child: const Text('取消', style: TextStyle(color: Colors.white70)),
+          onPressed: () => Navigator.of(context).pop(false),
+        ),
+        TextButton(
+          child: const Text('确定清除', style: TextStyle(color: Colors.red)),
+          onPressed: () => Navigator.of(context).pop(true),
+        ),
+      ],
+    );
+
+    if (confirm == true) {
+      try {
+        await JellyfinEpisodeMappingService.instance.clearAllMappings();
+        BlurSnackBar.show(context, '所有映射已清除');
+        await _loadMappingStats(); // 重新加载统计信息
+      } catch (e) {
+        BlurSnackBar.show(context, '清除映射失败: $e');
+      }
+    }
+  }
+
+  Future<void> _showMappingAnalysis() async {
+    if (_stats.isEmpty || _stats['accuracyStats'] == null) {
+      BlurSnackBar.show(context, '请先加载统计数据');
+      return;
+    }
+
+    final List<dynamic> accuracyStats = _stats['accuracyStats'] as List;
+    
+    if (accuracyStats.isEmpty) {
+      BlurDialog.show(
+        context: context,
+        title: '映射分析',
+        content: '暂无映射数据可供分析。\n\n请先使用Jellyfin播放器观看动画并手动匹配弹幕，系统将自动建立映射关系。',
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('知道了', style: TextStyle(color: Colors.white)),
+          ),
+        ],
+      );
+      return;
+    }
+
+    final StringBuffer content = StringBuffer();
+    content.writeln('映射准确性分析：\n');
+
+    for (final stat in accuracyStats.take(10)) { // 显示前10个
+      final seriesName = stat['jellyfin_series_name'] as String? ?? '未知系列';
+      final totalEpisodes = stat['total_episodes'] as int? ?? 0;
+      final confirmedEpisodes = stat['confirmed_episodes'] as int? ?? 0;
+      final baseOffset = stat['base_episode_offset'] as int? ?? 0;
+      
+      final accuracy = totalEpisodes > 0 
+          ? (confirmedEpisodes / totalEpisodes * 100).toStringAsFixed(1)
+          : '0.0';
+      
+      content.writeln('📺 $seriesName');
+      content.writeln('   剧集总数: $totalEpisodes');
+      content.writeln('   已确认: $confirmedEpisodes');
+      content.writeln('   准确率: $accuracy%');
+      content.writeln('   基础偏移: $baseOffset');
+      content.writeln('');
+    }
+
+    if (accuracyStats.length > 10) {
+      content.writeln('... 还有 ${accuracyStats.length - 10} 个映射');
+    }
+
+    BlurDialog.show(
+      context: context,
+      title: '映射分析报告',
+      content: content.toString(),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('关闭', style: TextStyle(color: Colors.white)),
+        ),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      children: [
+        // 映射统计信息
+        _buildStatisticsCard(),
+        
+        const SizedBox(height: 16),
+        
+        // 管理操作
+        _buildManagementCard(),
+        
+        const SizedBox(height: 16),
+        
+        // 说明信息
+        _buildHelpCard(),
+      ],
+    );
+  }
+
+  Widget _buildStatisticsCard() {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(12),
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: 25, sigmaY: 25),
+        child: Container(
+          margin: const EdgeInsets.symmetric(horizontal: 16),
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: Colors.white.withOpacity(0.1),
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(
+              color: Colors.white.withOpacity(0.3),
+              width: 0.5,
+            ),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Row(
+                children: [
+                  Icon(Ionicons.stats_chart_outline, color: Colors.white, size: 20),
+                  SizedBox(width: 8),
+                  Text(
+                    '映射统计',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              
+              if (_isLoading)
+                const Center(
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                  ),
+                )
+              else ...[
+                _buildStatItem('动画映射', _stats['animeCount'] ?? 0, Icons.tv),
+                const SizedBox(height: 8),
+                _buildStatItem('剧集映射', _stats['episodeCount'] ?? 0, Icons.video_library),
+                const SizedBox(height: 8),
+                _buildStatItem('已确认映射', _stats['confirmedCount'] ?? 0, Icons.verified),
+                const SizedBox(height: 8),
+                _buildStatItem('预测映射', _stats['predictedCount'] ?? 0, Icons.auto_awesome),
+                
+                // 显示最近映射活动
+                if (_stats['recentMappings'] != null && (_stats['recentMappings'] as List).isNotEmpty) ...[
+                  const SizedBox(height: 16),
+                  const Divider(color: Colors.white12),
+                  const SizedBox(height: 8),
+                  const Text(
+                    '最近活动',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontSize: 14,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  ...(_stats['recentMappings'] as List).take(3).map((mapping) => 
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 4),
+                      child: Text(
+                        '${mapping['jellyfin_series_name']} ↔ ${mapping['dandanplay_anime_title']}',
+                        style: const TextStyle(
+                          color: Colors.white70,
+                          fontSize: 12,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  ),
+                ],
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildStatItem(String label, int count, IconData icon) {
+    return Row(
+      children: [
+        Icon(icon, color: Colors.white70, size: 16),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Text(
+            label,
+            style: const TextStyle(color: Colors.white70, fontSize: 14),
+          ),
+        ),
+        Text(
+          count.toString(),
+          style: const TextStyle(
+            color: Colors.white,
+            fontSize: 16,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildManagementCard() {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(12),
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: 25, sigmaY: 25),
+        child: Container(
+          margin: const EdgeInsets.symmetric(horizontal: 16),
+          decoration: BoxDecoration(
+            color: Colors.white.withOpacity(0.1),
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(
+              color: Colors.white.withOpacity(0.3),
+              width: 0.5,
+            ),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Padding(
+                padding: EdgeInsets.all(16),
+                child: Row(
+                  children: [
+                    Icon(Ionicons.settings_outline, color: Colors.white, size: 20),
+                    SizedBox(width: 8),
+                    Text(
+                      '映射管理',
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              
+              ListTile(
+                leading: const Icon(Ionicons.refresh_outline, color: Colors.white),
+                title: const Text(
+                  '重新加载统计',
+                  style: TextStyle(color: Colors.white, fontWeight: FontWeight.w500),
+                ),
+                subtitle: const Text(
+                  '刷新映射统计信息',
+                  style: TextStyle(color: Colors.white70),
+                ),
+                onTap: () {
+                  setState(() {
+                    _isLoading = true;
+                  });
+                  _loadMappingStats();
+                },
+              ),
+              
+              const Divider(color: Colors.white12, height: 1),
+              
+              ListTile(
+                leading: const Icon(Ionicons.analytics_outline, color: Colors.white),
+                title: const Text(
+                  '映射分析',
+                  style: TextStyle(color: Colors.white, fontWeight: FontWeight.w500),
+                ),
+                subtitle: const Text(
+                  '查看映射准确性和使用情况',
+                  style: TextStyle(color: Colors.white70),
+                ),
+                onTap: _showMappingAnalysis,
+              ),
+              
+              const Divider(color: Colors.white12, height: 1),
+              
+              ListTile(
+                leading: const Icon(Ionicons.trash_outline, color: Colors.red),
+                title: const Text(
+                  '清除所有映射',
+                  style: TextStyle(color: Colors.red, fontWeight: FontWeight.w500),
+                ),
+                subtitle: const Text(
+                  '删除所有已建立的映射关系',
+                  style: TextStyle(color: Colors.white70),
+                ),
+                onTap: _clearAllMappings,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHelpCard() {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(12),
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: 25, sigmaY: 25),
+        child: Container(
+          margin: const EdgeInsets.symmetric(horizontal: 16),
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: Colors.white.withOpacity(0.1),
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(
+              color: Colors.white.withOpacity(0.3),
+              width: 0.5,
+            ),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Row(
+                children: [
+                  Icon(Ionicons.help_circle_outline, color: Colors.white, size: 20),
+                  SizedBox(width: 8),
+                  Text(
+                    '关于智能映射',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              
+              const Text(
+                '智能映射系统自动记录Jellyfin剧集与DandanPlay弹幕的对应关系，实现以下功能：',
+                style: TextStyle(color: Colors.white, fontSize: 14),
+              ),
+              const SizedBox(height: 12),
+              
+              _buildHelpItem('🎯', '自动匹配', '为新剧集自动匹配弹幕，无需重复选择'),
+              _buildHelpItem('⏭️', '集数导航', '支持Jellyfin剧集的上一话/下一话导航'),
+              _buildHelpItem('🧠', '智能预测', '基于已有映射预测新剧集的弹幕ID'),
+              _buildHelpItem('💾', '持久化存储', '映射关系永久保存，重启应用后仍然有效'),
+              
+              const SizedBox(height: 12),
+              
+              const Text(
+                '映射会在手动匹配弹幕时自动创建，无需手动配置。',
+                style: TextStyle(color: Colors.white70, fontSize: 12),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHelpItem(String emoji, String title, String description) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(emoji, style: const TextStyle(fontSize: 16)),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 14,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+                Text(
+                  description,
+                  style: const TextStyle(color: Colors.white70, fontSize: 13),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/services/episode_navigation_service.dart
+++ b/lib/services/episode_navigation_service.dart
@@ -3,6 +3,10 @@ import 'package:flutter/foundation.dart';
 import 'package:path/path.dart' as path;
 import '../models/watch_history_model.dart';
 import '../models/watch_history_database.dart';
+import '../models/jellyfin_model.dart';
+import '../services/jellyfin_service.dart';
+import '../services/jellyfin_episode_mapping_service.dart';
+import '../services/dandanplay_service.dart';
 
 /// 剧集导航结果
 class EpisodeNavigationResult {
@@ -76,6 +80,16 @@ class EpisodeNavigationService {
   }) async {
     debugPrint('[剧集导航] 开始获取上一话：$currentFilePath, animeId=$animeId, episodeId=$episodeId');
 
+    // 检查是否为Jellyfin流媒体，如果是则使用Jellyfin专用导航
+    if (_isJellyfinUrl(currentFilePath)) {
+      final jellyfinResult = await _getPreviousEpisodeFromJellyfin(currentFilePath, animeId, episodeId);
+      if (jellyfinResult.success) {
+        debugPrint('[剧集导航] Jellyfin模式成功找到上一话');
+        return jellyfinResult;
+      }
+      debugPrint('[剧集导航] Jellyfin模式未找到上一话，原因：${jellyfinResult.message}');
+    }
+
     // 模式1：优先尝试基于文件系统的导航
     final fileSystemResult = await _getPreviousEpisodeFromFileSystem(currentFilePath);
     if (fileSystemResult.success) {
@@ -106,6 +120,16 @@ class EpisodeNavigationService {
   }) async {
     debugPrint('[剧集导航] 开始获取下一话：$currentFilePath, animeId=$animeId, episodeId=$episodeId');
 
+    // 检查是否为Jellyfin流媒体，如果是则使用Jellyfin专用导航
+    if (_isJellyfinUrl(currentFilePath)) {
+      final jellyfinResult = await _getNextEpisodeFromJellyfin(currentFilePath, animeId, episodeId);
+      if (jellyfinResult.success) {
+        debugPrint('[剧集导航] Jellyfin模式成功找到下一话');
+        return jellyfinResult;
+      }
+      debugPrint('[剧集导航] Jellyfin模式未找到下一话，原因：${jellyfinResult.message}');
+    }
+
     // 模式1：优先尝试基于文件系统的导航
     final fileSystemResult = await _getNextEpisodeFromFileSystem(currentFilePath);
     if (fileSystemResult.success) {
@@ -131,6 +155,45 @@ class EpisodeNavigationService {
   /// 模式2：从数据库获取上一话（回退模式）
   Future<EpisodeNavigationResult> _getPreviousEpisodeFromDatabase(int animeId, int episodeId) async {
     try {
+      // 首先尝试使用映射服务查找上一集
+      final previousMapping = await JellyfinEpisodeMappingService.instance.getPreviousEpisodeMappingByDanmakuIds(
+        currentAnimeId: animeId,
+        currentEpisodeId: episodeId,
+      );
+
+      if (previousMapping != null) {
+        final previousJellyfinIndexNumber = previousMapping['jellyfin_index_number'] as int?;
+        final previousDandanplayEpisodeId = previousMapping['dandanplay_episode_id'] as int?;
+        final previousDandanplayAnimeId = previousMapping['dandanplay_anime_id'] as int?; // 获取上一集的动画ID
+        final seriesId = previousMapping['jellyfin_series_id'] as String?;
+        final seasonId = previousMapping['jellyfin_season_id'] as String?;
+
+        if (previousJellyfinIndexNumber != null && previousDandanplayEpisodeId != null && seriesId != null && seasonId != null) {
+          debugPrint('[数据库导航] 通过映射服务找到上一集: 第${previousJellyfinIndexNumber}集，弹幕ID=${previousDandanplayEpisodeId}，动画ID=${previousDandanplayAnimeId}');
+          
+          // 通过Jellyfin API获取上一集的详细信息
+          try {
+            final episodes = await JellyfinService.instance.getSeasonEpisodes(seriesId, seasonId);
+            final matchingEpisodes = episodes.where((ep) => ep.indexNumber == previousJellyfinIndexNumber).toList();
+            final previousEpisode = matchingEpisodes.isNotEmpty ? matchingEpisodes.first : null;
+            
+            if (previousEpisode != null) {
+              // 使用上一集的正确动画ID和剧集ID创建历史项
+              final historyItem = await _createJellyfinHistoryItem(previousEpisode, previousDandanplayAnimeId ?? animeId, previousDandanplayEpisodeId);
+              
+              debugPrint('[数据库导航] 成功创建上一集历史项: ${previousEpisode.name}，使用弹幕ID: animeId=${previousDandanplayAnimeId ?? animeId}, episodeId=${previousDandanplayEpisodeId}');
+              return EpisodeNavigationResult.success(
+                historyItem: historyItem,
+                message: '从映射服务找到上一话：${previousEpisode.name}',
+              );
+            }
+          } catch (e) {
+            debugPrint('[数据库导航] 获取Jellyfin剧集详情失败: $e');
+          }
+        }
+      }
+
+      // 回退到原有的数据库导航逻辑
       final database = WatchHistoryDatabase.instance;
       
       // 获取该动画的所有剧集列表，按episode_id排序
@@ -178,6 +241,45 @@ class EpisodeNavigationService {
   /// 模式2：从数据库获取下一话（回退模式）
   Future<EpisodeNavigationResult> _getNextEpisodeFromDatabase(int animeId, int episodeId) async {
     try {
+      // 首先尝试使用映射服务查找下一集
+      final nextMapping = await JellyfinEpisodeMappingService.instance.getNextEpisodeMappingByDanmakuIds(
+        currentAnimeId: animeId,
+        currentEpisodeId: episodeId,
+      );
+
+      if (nextMapping != null) {
+        final nextJellyfinIndexNumber = nextMapping['jellyfin_index_number'] as int?;
+        final nextDandanplayEpisodeId = nextMapping['dandanplay_episode_id'] as int?;
+        final nextDandanplayAnimeId = nextMapping['dandanplay_anime_id'] as int?; // 获取下一集的动画ID
+        final seriesId = nextMapping['jellyfin_series_id'] as String?;
+        final seasonId = nextMapping['jellyfin_season_id'] as String?;
+
+        if (nextJellyfinIndexNumber != null && nextDandanplayEpisodeId != null && seriesId != null && seasonId != null) {
+          debugPrint('[数据库导航] 通过映射服务找到下一集: 第${nextJellyfinIndexNumber}集，弹幕ID=${nextDandanplayEpisodeId}，动画ID=${nextDandanplayAnimeId}');
+          
+          // 通过Jellyfin API获取下一集的详细信息
+          try {
+            final episodes = await JellyfinService.instance.getSeasonEpisodes(seriesId, seasonId);
+            final matchingEpisodes = episodes.where((ep) => ep.indexNumber == nextJellyfinIndexNumber).toList();
+            final nextEpisode = matchingEpisodes.isNotEmpty ? matchingEpisodes.first : null;
+            
+            if (nextEpisode != null) {
+              // 使用下一集的正确动画ID和剧集ID创建历史项
+              final historyItem = await _createJellyfinHistoryItem(nextEpisode, nextDandanplayAnimeId ?? animeId, nextDandanplayEpisodeId);
+              
+              debugPrint('[数据库导航] 成功创建下一集历史项: ${nextEpisode.name}，使用弹幕ID: animeId=${nextDandanplayAnimeId ?? animeId}, episodeId=${nextDandanplayEpisodeId}');
+              return EpisodeNavigationResult.success(
+                historyItem: historyItem,
+                message: '从映射服务找到下一话：${nextEpisode.name}',
+              );
+            }
+          } catch (e) {
+            debugPrint('[数据库导航] 获取Jellyfin剧集详情失败: $e');
+          }
+        }
+      }
+
+      // 回退到原有的数据库导航逻辑
       final database = WatchHistoryDatabase.instance;
       
       // 获取该动画的所有剧集列表，按episode_id排序
@@ -357,6 +459,358 @@ class EpisodeNavigationService {
     return filePath.startsWith('http') || 
            filePath.startsWith('jellyfin://') || 
            filePath.startsWith('emby://');
+  }
+
+  /// 检查是否为Jellyfin URL
+  bool _isJellyfinUrl(String filePath) {
+    return filePath.startsWith('jellyfin://');
+  }
+
+  /// Jellyfin模式：获取上一话
+  Future<EpisodeNavigationResult> _getPreviousEpisodeFromJellyfin(String currentFilePath, int? animeId, int? episodeId) async {
+    try {
+      if (!JellyfinService.instance.isConnected) {
+        return EpisodeNavigationResult.failure('Jellyfin服务器未连接');
+      }
+
+      // 从jellyfin://协议URL中提取episodeId等信息
+      final urlParts = _parseJellyfinUrl(currentFilePath);
+      if (urlParts == null) {
+        return EpisodeNavigationResult.failure('无法解析Jellyfin URL');
+      }
+
+      final currentEpisodeId = urlParts['episodeId'];
+      if (currentEpisodeId == null) {
+        return EpisodeNavigationResult.failure('Jellyfin URL缺少episodeId');
+      }
+
+      String? seriesId = urlParts['seriesId'];
+      String? seasonId = urlParts['seasonId'];
+
+      // 如果URL中没有seriesId和seasonId，需要通过API获取
+      if (seriesId == null || seasonId == null) {
+        try {
+          final episodeInfo = await JellyfinService.instance.getEpisodeDetails(currentEpisodeId);
+          if (episodeInfo != null) {
+            seriesId = episodeInfo.seriesId;
+            seasonId = episodeInfo.seasonId;
+            debugPrint('[Jellyfin导航] 通过API获取到系列信息: seriesId=$seriesId, seasonId=$seasonId');
+          } else {
+            return EpisodeNavigationResult.failure('无法获取当前剧集的系列信息');
+          }
+        } catch (e) {
+          debugPrint('[Jellyfin导航] 获取剧集信息失败: $e');
+          return EpisodeNavigationResult.failure('获取剧集信息失败: $e');
+        }
+      }
+
+      if (seriesId == null || seasonId == null) {
+        return EpisodeNavigationResult.failure('无法确定系列和季节信息');
+      }
+
+      // 获取该季的所有剧集
+      final episodes = await JellyfinService.instance.getSeasonEpisodes(seriesId, seasonId);
+      if (episodes.isEmpty) {
+        return EpisodeNavigationResult.failure('该季没有剧集');
+      }
+
+      // 按集数排序
+      episodes.sort((a, b) => (a.indexNumber ?? 0).compareTo(b.indexNumber ?? 0));
+
+      // 找到当前剧集的位置
+      final currentIndex = episodes.indexWhere((ep) => ep.id == currentEpisodeId);
+      if (currentIndex == -1) {
+        return EpisodeNavigationResult.failure('找不到当前剧集');
+      }
+
+      // 查找上一集
+      if (currentIndex > 0) {
+        final previousEpisode = episodes[currentIndex - 1];
+        
+        // 通过映射服务获取上一集的正确弹幕ID
+        int? previousAnimeId;
+        int? previousEpisodeId;
+        
+        try {
+          // 如果有当前剧集的弹幕ID，使用它们来预测上一集的映射
+          if (animeId != null && episodeId != null) {
+            final previousMapping = await JellyfinEpisodeMappingService.instance.getPreviousEpisodeMappingByDanmakuIds(
+              currentAnimeId: animeId,
+              currentEpisodeId: episodeId,
+            );
+            
+            if (previousMapping != null) {
+              previousAnimeId = previousMapping['dandanplay_anime_id'] as int?;
+              previousEpisodeId = previousMapping['dandanplay_episode_id'] as int?;
+              debugPrint('[Jellyfin导航] 通过映射服务预测到上一集: animeId=$previousAnimeId, episodeId=$previousEpisodeId');
+              
+              // 立即保存预测的映射到数据库中
+              try {
+                final mappingId = previousMapping['mapping_id'] as int;
+                await JellyfinEpisodeMappingService.instance.recordEpisodeMapping(
+                  jellyfinEpisodeId: previousEpisode.id,
+                  jellyfinIndexNumber: previousEpisode.indexNumber ?? 0,
+                  dandanplayEpisodeId: previousEpisodeId!,
+                  mappingId: mappingId,
+                  confirmed: false, // 标记为预测映射
+                );
+                debugPrint('[Jellyfin导航] 已保存上一集的预测映射到数据库');
+              } catch (e) {
+                debugPrint('[Jellyfin导航] 保存预测映射失败: $e');
+              }
+            } else {
+              debugPrint('[Jellyfin导航] 映射服务无法预测上一集，将进行自动匹配');
+            }
+          } else {
+            // 如果没有当前剧集的弹幕ID，尝试直接查找上一集的映射
+            final mapping = await JellyfinEpisodeMappingService.instance.getEpisodeMapping(previousEpisode.id);
+            if (mapping != null) {
+              previousAnimeId = mapping['dandanplay_anime_id'] as int?;
+              previousEpisodeId = mapping['dandanplay_episode_id'] as int?;
+              debugPrint('[Jellyfin导航] 找到上一集的直接映射: animeId=$previousAnimeId, episodeId=$previousEpisodeId');
+            } else {
+              debugPrint('[Jellyfin导航] 没有弹幕ID且无直接映射，将进行自动匹配');
+            }
+          }
+        } catch (e) {
+          debugPrint('[Jellyfin导航] 获取上一集弹幕映射失败: $e');
+          // 出错时不使用任何弹幕ID，让系统进行自动匹配
+          previousAnimeId = null;
+          previousEpisodeId = null;
+        }
+        
+        // 创建播放历史项
+        final historyItem = await _createJellyfinHistoryItem(previousEpisode, previousAnimeId, previousEpisodeId);
+        
+        return EpisodeNavigationResult.success(
+          historyItem: historyItem,
+          message: '找到上一话：${previousEpisode.name}',
+        );
+      }
+
+      return EpisodeNavigationResult.failure('已经是第一集');
+    } catch (e) {
+      debugPrint('[Jellyfin导航] 获取上一话时出错：$e');
+      return EpisodeNavigationResult.failure('Jellyfin导航出错：$e');
+    }
+  }
+
+  /// Jellyfin模式：获取下一话
+  Future<EpisodeNavigationResult> _getNextEpisodeFromJellyfin(String currentFilePath, int? animeId, int? episodeId) async {
+    try {
+      if (!JellyfinService.instance.isConnected) {
+        return EpisodeNavigationResult.failure('Jellyfin服务器未连接');
+      }
+
+      // 从jellyfin://协议URL中提取episodeId等信息
+      final urlParts = _parseJellyfinUrl(currentFilePath);
+      if (urlParts == null) {
+        return EpisodeNavigationResult.failure('无法解析Jellyfin URL');
+      }
+
+      final currentEpisodeId = urlParts['episodeId'];
+      if (currentEpisodeId == null) {
+        return EpisodeNavigationResult.failure('Jellyfin URL缺少episodeId');
+      }
+
+      String? seriesId = urlParts['seriesId'];
+      String? seasonId = urlParts['seasonId'];
+
+      // 如果URL中没有seriesId和seasonId，需要通过API获取
+      if (seriesId == null || seasonId == null) {
+        try {
+          final episodeInfo = await JellyfinService.instance.getEpisodeDetails(currentEpisodeId);
+          if (episodeInfo != null) {
+            seriesId = episodeInfo.seriesId;
+            seasonId = episodeInfo.seasonId;
+            debugPrint('[Jellyfin导航] 通过API获取到系列信息: seriesId=$seriesId, seasonId=$seasonId');
+          } else {
+            return EpisodeNavigationResult.failure('无法获取当前剧集的系列信息');
+          }
+        } catch (e) {
+          debugPrint('[Jellyfin导航] 获取剧集信息失败: $e');
+          return EpisodeNavigationResult.failure('获取剧集信息失败: $e');
+        }
+      }
+
+      if (seriesId == null || seasonId == null) {
+        return EpisodeNavigationResult.failure('无法确定系列和季节信息');
+      }
+
+      // 获取该季的所有剧集
+      final episodes = await JellyfinService.instance.getSeasonEpisodes(seriesId, seasonId);
+      if (episodes.isEmpty) {
+        return EpisodeNavigationResult.failure('该季没有剧集');
+      }
+
+      // 按集数排序
+      episodes.sort((a, b) => (a.indexNumber ?? 0).compareTo(b.indexNumber ?? 0));
+
+      // 找到当前剧集的位置
+      final currentIndex = episodes.indexWhere((ep) => ep.id == currentEpisodeId);
+      if (currentIndex == -1) {
+        return EpisodeNavigationResult.failure('找不到当前剧集');
+      }
+
+      // 查找下一集
+      if (currentIndex < episodes.length - 1) {
+        final nextEpisode = episodes[currentIndex + 1];
+        
+        // 通过映射服务获取下一集的正确弹幕ID
+        int? nextAnimeId;
+        int? nextEpisodeId;
+        
+        try {
+          // 如果有当前剧集的弹幕ID，使用它们来预测下一集的映射
+          if (animeId != null && episodeId != null) {
+            final nextMapping = await JellyfinEpisodeMappingService.instance.getNextEpisodeMappingByDanmakuIds(
+              currentAnimeId: animeId,
+              currentEpisodeId: episodeId,
+            );
+            
+            if (nextMapping != null) {
+              nextAnimeId = nextMapping['dandanplay_anime_id'] as int?;
+              nextEpisodeId = nextMapping['dandanplay_episode_id'] as int?;
+              debugPrint('[Jellyfin导航] 通过映射服务预测到下一集: animeId=$nextAnimeId, episodeId=$nextEpisodeId');
+              
+              // 立即保存预测的映射到数据库中
+              try {
+                final mappingId = nextMapping['mapping_id'] as int;
+                await JellyfinEpisodeMappingService.instance.recordEpisodeMapping(
+                  jellyfinEpisodeId: nextEpisode.id,
+                  jellyfinIndexNumber: nextEpisode.indexNumber ?? 0,
+                  dandanplayEpisodeId: nextEpisodeId!,
+                  mappingId: mappingId,
+                  confirmed: false, // 标记为预测映射
+                );
+                debugPrint('[Jellyfin导航] 已保存下一集的预测映射到数据库');
+              } catch (e) {
+                debugPrint('[Jellyfin导航] 保存预测映射失败: $e');
+              }
+            } else {
+              debugPrint('[Jellyfin导航] 映射服务无法预测下一集，将进行自动匹配');
+            }
+          } else {
+            // 如果没有当前剧集的弹幕ID，尝试直接查找下一集的映射
+            final mapping = await JellyfinEpisodeMappingService.instance.getEpisodeMapping(nextEpisode.id);
+            if (mapping != null) {
+              nextAnimeId = mapping['dandanplay_anime_id'] as int?;
+              nextEpisodeId = mapping['dandanplay_episode_id'] as int?;
+              debugPrint('[Jellyfin导航] 找到下一集的直接映射: animeId=$nextAnimeId, episodeId=$nextEpisodeId');
+            } else {
+              debugPrint('[Jellyfin导航] 没有弹幕ID且无直接映射，将进行自动匹配');
+            }
+          }
+        } catch (e) {
+          debugPrint('[Jellyfin导航] 获取下一集弹幕映射失败: $e');
+          // 出错时不使用任何弹幕ID，让系统进行自动匹配
+          nextAnimeId = null;
+          nextEpisodeId = null;
+        }
+        
+        // 创建播放历史项
+        final historyItem = await _createJellyfinHistoryItem(nextEpisode, nextAnimeId, nextEpisodeId);
+        
+        return EpisodeNavigationResult.success(
+          historyItem: historyItem,
+          message: '找到下一话：${nextEpisode.name}',
+        );
+      }
+
+      return EpisodeNavigationResult.failure('已经是最后一集');
+    } catch (e) {
+      debugPrint('[Jellyfin导航] 获取下一话时出错：$e');
+      return EpisodeNavigationResult.failure('Jellyfin导航出错：$e');
+    }
+  }
+
+  /// 解析Jellyfin URL，提取episodeId
+  Map<String, String>? _parseJellyfinUrl(String url) {
+    if (!url.startsWith('jellyfin://')) {
+      return null;
+    }
+
+    final path = url.substring('jellyfin://'.length);
+    final parts = path.split('/');
+    
+    // 主要支持简化格式：jellyfin://episodeId
+    if (parts.length == 1 && parts[0].isNotEmpty) {
+      return {
+        'episodeId': parts[0],
+      };
+    } 
+    // 兼容完整格式：jellyfin://seriesId/seasonId/episodeId（如果存在）
+    else if (parts.length >= 3) {
+      return {
+        'seriesId': parts[0],
+        'seasonId': parts[1], 
+        'episodeId': parts[2],
+      };
+    }
+
+    return null;
+  }
+
+  /// 创建Jellyfin剧集的历史记录项
+  Future<WatchHistoryItem> _createJellyfinHistoryItem(JellyfinEpisodeInfo episode, int? animeId, int? episodeId) async {
+    try {
+      // 如果有映射的弹幕ID，使用DanDanPlay API获取正确的剧集信息
+      if (animeId != null && episodeId != null) {
+        try {
+          // 使用DanDanPlay API获取准确的剧集标题，保持标题一致性
+          debugPrint('[Jellyfin导航] 使用映射的弹幕ID查询剧集信息: animeId=$animeId, episodeId=$episodeId');
+          
+          // 获取动画详情以获取准确的标题
+          final bangumiDetails = await DandanplayService.getBangumiDetails(animeId);
+          
+          String? animeTitle;
+          String? episodeTitle;
+          
+          if (bangumiDetails['success'] == true && bangumiDetails['bangumi'] != null) {
+            final bangumi = bangumiDetails['bangumi'];
+            animeTitle = bangumi['animeTitle'] as String?;
+            
+            // 查找对应的剧集标题
+            if (bangumi['episodes'] != null && bangumi['episodes'] is List) {
+              final episodes = bangumi['episodes'] as List;
+              final targetEpisode = episodes.firstWhere(
+                (ep) => ep['episodeId'] == episodeId,
+                orElse: () => null,
+              );
+              
+              if (targetEpisode != null) {
+                episodeTitle = targetEpisode['episodeTitle'] as String?;
+                debugPrint('[Jellyfin导航] 从DanDanPlay API获取到剧集标题: $episodeTitle');
+              }
+            }
+          }
+          
+          // 创建包含正确弹幕信息和标题的历史项
+          return WatchHistoryItem(
+            filePath: 'jellyfin://${episode.id}',
+            animeName: animeTitle ?? episode.seriesName ?? 'Unknown',
+            episodeTitle: episodeTitle ?? episode.name,
+            animeId: animeId,
+            episodeId: episodeId,
+            watchProgress: 0.0,
+            lastPosition: 0,
+            duration: 0,
+            lastWatchTime: DateTime.now(),
+            thumbnailPath: null,
+            isFromScan: false,
+          );
+        } catch (e) {
+          debugPrint('[Jellyfin导航] 获取DanDanPlay剧集信息失败: $e，使用基础信息');
+        }
+      }
+      
+      // 如果没有映射的弹幕ID或获取失败，使用基础信息创建历史项
+      debugPrint('[Jellyfin导航] 没有映射的弹幕ID，使用基础信息创建历史项');
+      return episode.toWatchHistoryItem();
+    } catch (e) {
+      debugPrint('[Jellyfin导航] 创建历史项时出错：$e，使用基础历史项');
+      return episode.toWatchHistoryItem();
+    }
   }
 
   /// 检查是否可以使用数据库导航

--- a/lib/services/jellyfin_episode_mapping_service.dart
+++ b/lib/services/jellyfin_episode_mapping_service.dart
@@ -1,0 +1,741 @@
+import 'dart:async';
+import 'package:flutter/foundation.dart';
+import 'package:sqflite/sqflite.dart';
+import '../models/jellyfin_model.dart';
+import '../models/watch_history_database.dart';
+
+/// Jellyfin剧集映射服务
+/// 
+/// 负责管理Jellyfin剧集到DandanPlay剧集的智能映射
+/// 包括：动画级映射、剧集级映射、自动推算和持久化存储
+class JellyfinEpisodeMappingService {
+  static final JellyfinEpisodeMappingService _instance = JellyfinEpisodeMappingService._internal();
+  factory JellyfinEpisodeMappingService() => _instance;
+  JellyfinEpisodeMappingService._internal();
+
+  static JellyfinEpisodeMappingService get instance => _instance;
+
+  Database? _database;
+  
+  // 缓存机制
+  final Map<String, Map<String, dynamic>?> _animeMappingCache = {};
+  final Map<String, int?> _episodePredictionCache = {};
+  DateTime? _lastCacheClean;
+
+  /// 初始化数据库
+  Future<void> initialize() async {
+    if (_database != null) return;
+    
+    final mainDb = await WatchHistoryDatabase.instance.database;
+    _database = mainDb;
+
+    // 创建映射表（简化版本，移除复杂的偏移量字段）
+    await _database!.execute('''
+      CREATE TABLE IF NOT EXISTS jellyfin_dandanplay_mapping (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        jellyfin_series_id TEXT NOT NULL,
+        jellyfin_series_name TEXT,
+        jellyfin_season_id TEXT,
+        dandanplay_anime_id INTEGER NOT NULL,
+        dandanplay_anime_title TEXT,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE(jellyfin_series_id, jellyfin_season_id, dandanplay_anime_id)
+      )
+    ''');
+
+    await _database!.execute('''
+      CREATE TABLE IF NOT EXISTS jellyfin_episode_mapping (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        jellyfin_episode_id TEXT NOT NULL UNIQUE,
+        jellyfin_index_number INTEGER,
+        dandanplay_episode_id INTEGER NOT NULL,
+        mapping_id INTEGER NOT NULL,
+        confirmed BOOLEAN DEFAULT FALSE,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY (mapping_id) REFERENCES jellyfin_dandanplay_mapping (id)
+      )
+    ''');
+
+    debugPrint('[映射服务] 数据库初始化完成');
+    
+    // 清理过期缓存
+    _cleanExpiredCache();
+  }
+
+  /// 清理过期缓存
+  void _cleanExpiredCache() {
+    final now = DateTime.now();
+    if (_lastCacheClean != null && now.difference(_lastCacheClean!).inMinutes < 30) {
+      return; // 30分钟内不重复清理
+    }
+    
+    _animeMappingCache.clear();
+    _episodePredictionCache.clear();
+    _lastCacheClean = now;
+    debugPrint('[映射服务] 缓存已清理');
+  }
+
+  /// 建立或更新动画级映射（简化版本）
+  Future<int> createOrUpdateAnimeMapping({
+    required String jellyfinSeriesId,
+    required String jellyfinSeriesName,
+    String? jellyfinSeasonId,
+    required int dandanplayAnimeId,
+    required String dandanplayAnimeTitle,
+  }) async {
+    await initialize();
+
+    debugPrint('[映射服务] 创建动画映射: $jellyfinSeriesName -> $dandanplayAnimeTitle');
+
+    // 检查是否已存在映射
+    final existing = await _database!.query(
+      'jellyfin_dandanplay_mapping',
+      where: 'jellyfin_series_id = ? AND jellyfin_season_id = ? AND dandanplay_anime_id = ?',
+      whereArgs: [jellyfinSeriesId, jellyfinSeasonId, dandanplayAnimeId],
+    );
+
+    if (existing.isNotEmpty) {
+      // 更新现有映射
+      final mappingId = existing.first['id'] as int;
+      await _database!.update(
+        'jellyfin_dandanplay_mapping',
+        {
+          'jellyfin_series_name': jellyfinSeriesName,
+          'dandanplay_anime_title': dandanplayAnimeTitle,
+          'updated_at': DateTime.now().toIso8601String(),
+        },
+        where: 'id = ?',
+        whereArgs: [mappingId],
+      );
+      debugPrint('[映射服务] 更新现有动画映射: ID=$mappingId');
+      return mappingId;
+    } else {
+      // 创建新映射
+      final mappingId = await _database!.insert(
+        'jellyfin_dandanplay_mapping',
+        {
+          'jellyfin_series_id': jellyfinSeriesId,
+          'jellyfin_series_name': jellyfinSeriesName,
+          'jellyfin_season_id': jellyfinSeasonId,
+          'dandanplay_anime_id': dandanplayAnimeId,
+          'dandanplay_anime_title': dandanplayAnimeTitle,
+        },
+      );
+      debugPrint('[映射服务] 创建新动画映射: ID=$mappingId');
+      return mappingId;
+    }
+  }
+
+  /// 记录剧集级映射（增强版本，会自动优化基础偏移量）
+  Future<void> recordEpisodeMapping({
+    required String jellyfinEpisodeId,
+    required int jellyfinIndexNumber,
+    required int dandanplayEpisodeId,
+    required int mappingId,
+    bool confirmed = true,
+  }) async {
+    await initialize();
+
+    debugPrint('[映射服务] 记录剧集映射: Jellyfin集$jellyfinIndexNumber -> DandanPlay集$dandanplayEpisodeId');
+
+    // 保存剧集映射
+    await _database!.insert(
+      'jellyfin_episode_mapping',
+      {
+        'jellyfin_episode_id': jellyfinEpisodeId,
+        'jellyfin_index_number': jellyfinIndexNumber,
+        'dandanplay_episode_id': dandanplayEpisodeId,
+        'mapping_id': mappingId,
+        'confirmed': confirmed ? 1 : 0,
+      },
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+
+    // 清理相关缓存
+    final cacheKeyToRemove = _episodePredictionCache.keys
+        .where((key) => key.startsWith(jellyfinEpisodeId))
+        .toList();
+    for (final key in cacheKeyToRemove) {
+      _episodePredictionCache.remove(key);
+    }
+
+    // 如果是确认的映射，更新相关统计信息
+    if (confirmed) {
+      debugPrint('[映射服务] 已确认剧集映射，更新统计信息');
+    }
+  }
+
+  /// 获取动画映射（带缓存）
+  Future<Map<String, dynamic>?> getAnimeMapping({
+    required String jellyfinSeriesId,
+    String? jellyfinSeasonId,
+  }) async {
+    await initialize();
+
+    // 生成缓存键
+    final cacheKey = '${jellyfinSeriesId}_${jellyfinSeasonId ?? 'null'}';
+    
+    // 检查缓存
+    if (_animeMappingCache.containsKey(cacheKey)) {
+      debugPrint('[映射服务] 从缓存获取动画映射: $cacheKey');
+      return _animeMappingCache[cacheKey];
+    }
+
+    final results = await _database!.query(
+      'jellyfin_dandanplay_mapping',
+      where: 'jellyfin_series_id = ? AND (jellyfin_season_id = ? OR jellyfin_season_id IS NULL)',
+      whereArgs: [jellyfinSeriesId, jellyfinSeasonId],
+      orderBy: 'jellyfin_season_id IS NULL, updated_at DESC', // 优先匹配指定季节
+    );
+
+    final result = results.isNotEmpty ? results.first : null;
+    
+    // 缓存结果
+    _animeMappingCache[cacheKey] = result;
+    
+    debugPrint('[映射服务] 动画映射已缓存: $cacheKey');
+    return result;
+  }
+
+  /// 智能预测剧集映射（基于已有映射规律推算）
+  Future<int?> predictEpisodeMapping({
+    required JellyfinEpisodeInfo jellyfinEpisode,
+  }) async {
+    await initialize();
+
+    // 如果没有集号信息，无法预测
+    if (jellyfinEpisode.indexNumber == null) {
+      debugPrint('[映射服务] Jellyfin剧集缺少集号信息，无法预测映射');
+      return null;
+    }
+
+    // 生成缓存键
+    final cacheKey = '${jellyfinEpisode.id}_${jellyfinEpisode.indexNumber}';
+    
+    // 检查缓存
+    if (_episodePredictionCache.containsKey(cacheKey)) {
+      debugPrint('[映射服务] 从缓存获取剧集预测: $cacheKey');
+      return _episodePredictionCache[cacheKey];
+    }
+
+    debugPrint('[映射服务] 预测剧集映射: ${jellyfinEpisode.seriesName} 第${jellyfinEpisode.indexNumber}集');
+
+    // 1. 查找动画级映射
+    final animeMapping = await getAnimeMapping(
+      jellyfinSeriesId: jellyfinEpisode.seriesId!,
+      jellyfinSeasonId: jellyfinEpisode.seasonId,
+    );
+
+    if (animeMapping == null) {
+      debugPrint('[映射服务] 未找到动画级映射');
+      _episodePredictionCache[cacheKey] = null;
+      return null;
+    }
+
+    final mappingId = animeMapping['id'] as int;
+
+    // 2. 检查是否有直接的剧集映射
+    final directMapping = await _database!.query(
+      'jellyfin_episode_mapping',
+      where: 'jellyfin_episode_id = ?',
+      whereArgs: [jellyfinEpisode.id],
+    );
+
+    if (directMapping.isNotEmpty) {
+      final dandanplayEpisodeId = directMapping.first['dandanplay_episode_id'] as int;
+      debugPrint('[映射服务] 找到直接剧集映射: $dandanplayEpisodeId');
+      _episodePredictionCache[cacheKey] = dandanplayEpisodeId;
+      return dandanplayEpisodeId;
+    }
+
+    // 3. 基于已有映射推算剧集ID（核心逻辑）
+    final targetJellyfinIndex = jellyfinEpisode.indexNumber!;
+    
+    // 查找同一个映射中已有的剧集映射记录，用于推算规律
+    final existingMappings = await _database!.query(
+      'jellyfin_episode_mapping',
+      where: 'mapping_id = ?',
+      whereArgs: [mappingId],
+      orderBy: 'jellyfin_index_number ASC',
+    );
+    
+    if (existingMappings.isNotEmpty) {
+      // 使用已有的映射推算新的剧集ID
+      final referenceMapping = existingMappings.first;
+      final referenceJellyfinIndex = referenceMapping['jellyfin_index_number'] as int;
+      final referenceDandanplayEpisodeId = referenceMapping['dandanplay_episode_id'] as int;
+      
+      // 计算偏移量并推算目标剧集ID
+      final offset = targetJellyfinIndex - referenceJellyfinIndex;
+      final predictedEpisodeId = referenceDandanplayEpisodeId + offset;
+      
+      debugPrint('[映射服务] 基于已有映射推算: 参考第${referenceJellyfinIndex}集(ID=${referenceDandanplayEpisodeId}) -> 预测第${targetJellyfinIndex}集(ID=${predictedEpisodeId})');
+      
+      // 自动记录这个预测的映射
+      await recordEpisodeMapping(
+        jellyfinEpisodeId: jellyfinEpisode.id,
+        jellyfinIndexNumber: targetJellyfinIndex,
+        dandanplayEpisodeId: predictedEpisodeId,
+        mappingId: mappingId,
+        confirmed: false, // 标记为未确认的预测映射
+      );
+      
+      // 缓存结果
+      _episodePredictionCache[cacheKey] = predictedEpisodeId;
+      return predictedEpisodeId;
+    } else {
+      debugPrint('[映射服务] 没有已有映射记录，无法推算');
+    }
+
+    _episodePredictionCache[cacheKey] = null;
+    return null;
+  }
+
+  /// 根据当前剧集获取下一集的映射
+  Future<Map<String, dynamic>?> getNextEpisodeMapping({
+    required JellyfinEpisodeInfo currentEpisode,
+  }) async {
+    await initialize();
+
+    debugPrint('[映射服务] 查找下一集: ${currentEpisode.seriesName} 当前第${currentEpisode.indexNumber}集');
+
+    // 查找同一系列的所有剧集映射
+    final animeMapping = await getAnimeMapping(
+      jellyfinSeriesId: currentEpisode.seriesId!,
+      jellyfinSeasonId: currentEpisode.seasonId,
+    );
+
+    if (animeMapping == null) {
+      debugPrint('[映射服务] 未找到动画映射，无法预测下一集');
+      return null;
+    }
+
+    // 查询数据库中该系列的所有剧集映射
+    final episodeMappings = await _database!.rawQuery('''
+      SELECT jem.*, jdm.dandanplay_anime_id, jdm.dandanplay_anime_title
+      FROM jellyfin_episode_mapping jem
+      INNER JOIN jellyfin_dandanplay_mapping jdm ON jem.mapping_id = jdm.id
+      WHERE jem.mapping_id = ? AND jem.jellyfin_index_number > ?
+      ORDER BY jem.jellyfin_index_number ASC
+      LIMIT 1
+    ''', [animeMapping['id'], currentEpisode.indexNumber ?? 0]);
+
+    if (episodeMappings.isNotEmpty) {
+      final nextMapping = episodeMappings.first;
+      debugPrint('[映射服务] 找到下一集映射: 第${nextMapping['jellyfin_index_number']}集');
+      return Map<String, dynamic>.from(nextMapping);
+    }
+
+    debugPrint('[映射服务] 未找到下一集的现有映射');
+    return null;
+  }
+
+  /// 根据当前剧集获取上一集的映射
+  Future<Map<String, dynamic>?> getPreviousEpisodeMapping({
+    required JellyfinEpisodeInfo currentEpisode,
+  }) async {
+    await initialize();
+
+    debugPrint('[映射服务] 查找上一集: ${currentEpisode.seriesName} 当前第${currentEpisode.indexNumber}集');
+
+    final animeMapping = await getAnimeMapping(
+      jellyfinSeriesId: currentEpisode.seriesId!,
+      jellyfinSeasonId: currentEpisode.seasonId,
+    );
+
+    if (animeMapping == null) {
+      debugPrint('[映射服务] 未找到动画映射，无法预测上一集');
+      return null;
+    }
+
+    final episodeMappings = await _database!.rawQuery('''
+      SELECT jem.*, jdm.dandanplay_anime_id, jdm.dandanplay_anime_title
+      FROM jellyfin_episode_mapping jem
+      INNER JOIN jellyfin_dandanplay_mapping jdm ON jem.mapping_id = jdm.id
+      WHERE jem.mapping_id = ? AND jem.jellyfin_index_number < ?
+      ORDER BY jem.jellyfin_index_number DESC
+      LIMIT 1
+    ''', [animeMapping['id'], currentEpisode.indexNumber ?? 0]);
+
+    if (episodeMappings.isNotEmpty) {
+      final prevMapping = episodeMappings.first;
+      debugPrint('[映射服务] 找到上一集映射: 第${prevMapping['jellyfin_index_number']}集');
+      return Map<String, dynamic>.from(prevMapping);
+    }
+
+    debugPrint('[映射服务] 未找到上一集的现有映射');
+    return null;
+  }
+
+  /// 根据弹幕ID获取下一集的映射
+  Future<Map<String, dynamic>?> getNextEpisodeMappingByDanmakuIds({
+    required int currentAnimeId,
+    required int currentEpisodeId,
+  }) async {
+    await initialize();
+
+    debugPrint('[映射服务] ========== 开始查找下一集映射 ==========');
+    debugPrint('[映射服务] 输入参数: animeId=$currentAnimeId, episodeId=$currentEpisodeId');
+
+    try {
+      // 1. 首先根据当前弹幕ID找到对应的Jellyfin剧集映射
+      debugPrint('[映射服务] 第1步: 查找当前剧集的映射记录');
+      final currentMappingResults = await _database!.rawQuery('''
+        SELECT jem.*, jdm.jellyfin_series_id, jdm.jellyfin_season_id, jdm.dandanplay_anime_id
+        FROM jellyfin_episode_mapping jem
+        INNER JOIN jellyfin_dandanplay_mapping jdm ON jem.mapping_id = jdm.id
+        WHERE jem.dandanplay_episode_id = ? AND jdm.dandanplay_anime_id = ?
+      ''', [currentEpisodeId, currentAnimeId]);
+
+      debugPrint('[映射服务] 查询结果数量: ${currentMappingResults.length}');
+      if (currentMappingResults.isNotEmpty) {
+        debugPrint('[映射服务] 当前映射记录: ${currentMappingResults.first}');
+      }
+
+      if (currentMappingResults.isEmpty) {
+        debugPrint('[映射服务] ❌ 未找到当前剧集的映射记录');
+        return null;
+      }
+
+      final currentMapping = currentMappingResults.first;
+      final currentJellyfinIndexNumber = currentMapping['jellyfin_index_number'] as int?;
+      final seriesId = currentMapping['jellyfin_series_id'] as String?;
+      final seasonId = currentMapping['jellyfin_season_id'] as String?;
+      final mappingId = currentMapping['mapping_id'] as int;
+
+      debugPrint('[映射服务] 第2步: 解析当前映射信息');
+      debugPrint('[映射服务] - 当前集号: $currentJellyfinIndexNumber');
+      debugPrint('[映射服务] - 系列ID: $seriesId');
+      debugPrint('[映射服务] - 季节ID: $seasonId'); 
+      debugPrint('[映射服务] - 映射ID: $mappingId');
+
+      if (currentJellyfinIndexNumber == null || seriesId == null) {
+        debugPrint('[映射服务] ❌ 当前剧集映射缺少必要信息');
+        return null;
+      }
+
+      // 2. 查找下一集的Jellyfin索引号
+      final nextJellyfinIndexNumber = currentJellyfinIndexNumber + 1;
+      debugPrint('[映射服务] 第3步: 计算下一集号 = $nextJellyfinIndexNumber');
+      
+      // 3. 检查是否已有下一集的映射
+      debugPrint('[映射服务] 第4步: 查找下一集的现有映射');
+      final nextMappingResults = await _database!.rawQuery('''
+        SELECT jem.*, jdm.dandanplay_anime_id, jdm.dandanplay_anime_title, jdm.jellyfin_series_id, jdm.jellyfin_season_id
+        FROM jellyfin_episode_mapping jem
+        INNER JOIN jellyfin_dandanplay_mapping jdm ON jem.mapping_id = jdm.id
+        WHERE jem.mapping_id = ? AND jem.jellyfin_index_number = ?
+      ''', [mappingId, nextJellyfinIndexNumber]);
+
+      debugPrint('[映射服务] 下一集现有映射查询结果数量: ${nextMappingResults.length}');
+
+      if (nextMappingResults.isNotEmpty) {
+        final nextMapping = nextMappingResults.first;
+        debugPrint('[映射服务] ✅ 找到下一集的现有映射: ${nextMapping}');
+        debugPrint('[映射服务] - 下一集集号: ${nextMapping['jellyfin_index_number']}');
+        debugPrint('[映射服务] - 下一集弹幕ID: ${nextMapping['dandanplay_episode_id']}');
+        return Map<String, dynamic>.from(nextMapping);
+      }
+
+      // 4. 如果没有现有映射，尝试基于已有映射推算下一集
+      debugPrint('[映射服务] 第5步: 没有现有映射，开始基于已有映射推算下一集');
+      debugPrint('[映射服务] - 目标集号: $nextJellyfinIndexNumber');
+      
+      // 查找同一个映射中已有的剧集映射记录，用于推算规律
+      final existingMappings = await _database!.query(
+        'jellyfin_episode_mapping',
+        where: 'mapping_id = ?',
+        whereArgs: [mappingId],
+        orderBy: 'jellyfin_index_number ASC',
+      );
+      
+      debugPrint('[映射服务] 找到 ${existingMappings.length} 个已有映射记录');
+      
+      if (existingMappings.isNotEmpty) {
+        // 使用已有的映射推算下一集ID
+        final referenceMapping = existingMappings.first;
+        final referenceJellyfinIndex = referenceMapping['jellyfin_index_number'] as int;
+        final referenceDandanplayEpisodeId = referenceMapping['dandanplay_episode_id'] as int;
+        
+        // 计算偏移量并推算目标剧集ID
+        final offset = nextJellyfinIndexNumber - referenceJellyfinIndex;
+        final predictedEpisodeId = referenceDandanplayEpisodeId + offset;
+        
+        debugPrint('[映射服务] 基于已有映射推算下一集:');
+        debugPrint('[映射服务] - 参考: 第${referenceJellyfinIndex}集 -> DandanPlay ID: ${referenceDandanplayEpisodeId}');
+        debugPrint('[映射服务] - 偏移量: $offset');
+        debugPrint('[映射服务] - 预测: 第${nextJellyfinIndexNumber}集 -> DandanPlay ID: ${predictedEpisodeId}');
+        
+        // 返回预测的映射信息
+        final predictedMapping = {
+          'jellyfin_index_number': nextJellyfinIndexNumber,
+          'dandanplay_episode_id': predictedEpisodeId,
+          'dandanplay_anime_id': currentAnimeId,
+          'jellyfin_series_id': seriesId,
+          'jellyfin_season_id': seasonId,
+          'mapping_id': mappingId,
+          'confirmed': 0, // 标记为预测映射
+        };
+        debugPrint('[映射服务] ✅ 返回推算的映射: $predictedMapping');
+        return predictedMapping;
+      } else {
+        debugPrint('[映射服务] ❌ 没有已有映射记录，无法推算');
+      }
+
+      debugPrint('[映射服务] ❌ 未找到下一集的有效映射');
+      debugPrint('[映射服务] ========== 查找下一集映射结束 ==========');
+      return null;
+    } catch (e) {
+      debugPrint('[映射服务] 查找下一集映射时出错：$e');
+      return null;
+    }
+  }
+
+  /// 根据弹幕ID获取上一集的映射
+  Future<Map<String, dynamic>?> getPreviousEpisodeMappingByDanmakuIds({
+    required int currentAnimeId,
+    required int currentEpisodeId,
+  }) async {
+    await initialize();
+
+    debugPrint('[映射服务] 查找上一集: animeId=$currentAnimeId, episodeId=$currentEpisodeId');
+
+    try {
+      // 1. 首先根据当前弹幕ID找到对应的Jellyfin剧集映射
+      final currentMappingResults = await _database!.rawQuery('''
+        SELECT jem.*, jdm.jellyfin_series_id, jdm.jellyfin_season_id, jdm.dandanplay_anime_id
+        FROM jellyfin_episode_mapping jem
+        INNER JOIN jellyfin_dandanplay_mapping jdm ON jem.mapping_id = jdm.id
+        WHERE jem.dandanplay_episode_id = ? AND jdm.dandanplay_anime_id = ?
+      ''', [currentEpisodeId, currentAnimeId]);
+
+      if (currentMappingResults.isEmpty) {
+        debugPrint('[映射服务] 未找到当前剧集的映射记录');
+        return null;
+      }
+
+      final currentMapping = currentMappingResults.first;
+      final currentJellyfinIndexNumber = currentMapping['jellyfin_index_number'] as int?;
+      final seriesId = currentMapping['jellyfin_series_id'] as String?;
+      final seasonId = currentMapping['jellyfin_season_id'] as String?;
+      final mappingId = currentMapping['mapping_id'] as int;
+
+      if (currentJellyfinIndexNumber == null || currentJellyfinIndexNumber <= 1 || seriesId == null) {
+        debugPrint('[映射服务] 当前剧集映射缺少必要信息或已是第一集');
+        return null;
+      }
+
+      // 2. 查找上一集的Jellyfin索引号
+      final previousJellyfinIndexNumber = currentJellyfinIndexNumber - 1;
+      
+      // 3. 检查是否已有上一集的映射
+      final previousMappingResults = await _database!.rawQuery('''
+        SELECT jem.*, jdm.dandanplay_anime_id, jdm.dandanplay_anime_title, jdm.jellyfin_series_id, jdm.jellyfin_season_id
+        FROM jellyfin_episode_mapping jem
+        INNER JOIN jellyfin_dandanplay_mapping jdm ON jem.mapping_id = jdm.id
+        WHERE jem.mapping_id = ? AND jem.jellyfin_index_number = ?
+      ''', [mappingId, previousJellyfinIndexNumber]);
+
+      if (previousMappingResults.isNotEmpty) {
+        final previousMapping = previousMappingResults.first;
+        debugPrint('[映射服务] 找到上一集的现有映射: 第${previousMapping['jellyfin_index_number']}集');
+        return Map<String, dynamic>.from(previousMapping);
+      }
+
+      // 4. 如果没有现有映射，尝试基于已有映射推算上一集
+      debugPrint('[映射服务] 尝试基于已有映射推算上一集: 第$previousJellyfinIndexNumber集');
+      
+      // 查找同一个映射中已有的剧集映射记录，用于推算规律
+      final existingMappings = await _database!.query(
+        'jellyfin_episode_mapping',
+        where: 'mapping_id = ?',
+        whereArgs: [mappingId],
+        orderBy: 'jellyfin_index_number ASC',
+      );
+      
+      if (existingMappings.isNotEmpty) {
+        // 使用已有的映射推算上一集ID
+        final referenceMapping = existingMappings.first;
+        final referenceJellyfinIndex = referenceMapping['jellyfin_index_number'] as int;
+        final referenceDandanplayEpisodeId = referenceMapping['dandanplay_episode_id'] as int;
+        
+        // 计算偏移量并推算目标剧集ID
+        final offset = previousJellyfinIndexNumber - referenceJellyfinIndex;
+        final predictedEpisodeId = referenceDandanplayEpisodeId + offset;
+        
+        debugPrint('[映射服务] 基于已有映射推算上一集: 参考第${referenceJellyfinIndex}集(ID=${referenceDandanplayEpisodeId}) -> 预测第${previousJellyfinIndexNumber}集(ID=${predictedEpisodeId})');
+        
+        // 返回预测的映射信息
+        return {
+          'jellyfin_index_number': previousJellyfinIndexNumber,
+          'dandanplay_episode_id': predictedEpisodeId,
+          'dandanplay_anime_id': currentAnimeId,
+          'jellyfin_series_id': seriesId,
+          'jellyfin_season_id': seasonId,
+          'mapping_id': mappingId,
+          'confirmed': 0, // 标记为预测映射
+        };
+      }
+
+      debugPrint('[映射服务] 未找到上一集的有效映射');
+      return null;
+    } catch (e) {
+      debugPrint('[映射服务] 查找上一集映射时出错：$e');
+      return null;
+    }
+  }
+
+  /// 清除所有映射数据
+  Future<void> clearAllMappings() async {
+    await initialize();
+
+    debugPrint('[映射服务] 清除所有映射数据');
+
+    try {
+      // 先删除所有剧集映射
+      await _database!.delete('jellyfin_episode_mapping');
+      
+      // 再删除所有动画映射
+      await _database!.delete('jellyfin_dandanplay_mapping');
+      
+      // 清理缓存
+      _animeMappingCache.clear();
+      _episodePredictionCache.clear();
+      
+      debugPrint('[映射服务] 所有映射数据清除完成');
+    } catch (e) {
+      debugPrint('[映射服务] 清除映射数据失败: $e');
+      rethrow;
+    }
+  }
+
+  /// 批量记录剧集映射
+  Future<void> batchRecordEpisodeMappings(List<Map<String, dynamic>> mappings) async {
+    await initialize();
+
+    debugPrint('[映射服务] 批量记录${mappings.length}个剧集映射');
+
+    final batch = _database!.batch();
+    
+    for (final mapping in mappings) {
+      batch.insert(
+        'jellyfin_episode_mapping',
+        {
+          'jellyfin_episode_id': mapping['jellyfinEpisodeId'],
+          'jellyfin_index_number': mapping['jellyfinIndexNumber'],
+          'dandanplay_episode_id': mapping['dandanplayEpisodeId'],
+          'mapping_id': mapping['mappingId'],
+          'confirmed': mapping['confirmed'] == true ? 1 : 0,
+        },
+        conflictAlgorithm: ConflictAlgorithm.replace,
+      );
+    }
+
+    await batch.commit(noResult: true);
+    
+    // 清理相关缓存
+    _episodePredictionCache.clear();
+    
+    debugPrint('[映射服务] 批量记录完成');
+  }
+
+  /// 清理指定系列的缓存
+  void _clearSeriesCache(String jellyfinSeriesId, String? seasonId) {
+    final cacheKey = '${jellyfinSeriesId}_${seasonId ?? 'null'}';
+    _animeMappingCache.remove(cacheKey);
+    
+    // 清理相关的剧集预测缓存
+    final keysToRemove = _episodePredictionCache.keys
+        .where((key) => key.startsWith(jellyfinSeriesId))
+        .toList();
+    
+    for (final key in keysToRemove) {
+      _episodePredictionCache.remove(key);
+    }
+  }
+
+  /// 清除指定系列的映射（用于重新配置）
+  Future<void> clearSeriesMapping(String jellyfinSeriesId, {String? seasonId}) async {
+    await initialize();
+
+    debugPrint('[映射服务] 清除系列映射: $jellyfinSeriesId');
+
+    // 先删除剧集映射
+    await _database!.rawDelete('''
+      DELETE FROM jellyfin_episode_mapping 
+      WHERE mapping_id IN (
+        SELECT id FROM jellyfin_dandanplay_mapping 
+        WHERE jellyfin_series_id = ? AND (jellyfin_season_id = ? OR ? IS NULL)
+      )
+    ''', [jellyfinSeriesId, seasonId, seasonId]);
+
+    // 再删除动画映射
+    await _database!.delete(
+      'jellyfin_dandanplay_mapping',
+      where: 'jellyfin_series_id = ? AND (jellyfin_season_id = ? OR ? IS NULL)',
+      whereArgs: [jellyfinSeriesId, seasonId, seasonId],
+    );
+
+    // 清理相关缓存
+    _clearSeriesCache(jellyfinSeriesId, seasonId);
+
+    debugPrint('[映射服务] 映射清除完成');
+  }
+
+  /// 获取映射统计信息（增强版本）
+  Future<Map<String, dynamic>> getMappingStats() async {
+    await initialize();
+
+    // 基础统计
+    final animeMappingCount = await _database!.rawQuery('SELECT COUNT(*) as count FROM jellyfin_dandanplay_mapping');
+    final episodeMappingCount = await _database!.rawQuery('SELECT COUNT(*) as count FROM jellyfin_episode_mapping');
+    final confirmedMappingCount = await _database!.rawQuery('SELECT COUNT(*) as count FROM jellyfin_episode_mapping WHERE confirmed = 1');
+    final predictedMappingCount = await _database!.rawQuery('SELECT COUNT(*) as count FROM jellyfin_episode_mapping WHERE confirmed = 0');
+
+    // 最近映射活动
+    final recentMappings = await _database!.rawQuery('''
+      SELECT jdm.jellyfin_series_name, jdm.dandanplay_anime_title, jdm.updated_at
+      FROM jellyfin_dandanplay_mapping jdm
+      ORDER BY jdm.updated_at DESC
+      LIMIT 5
+    ''');
+
+    // 映射准确性统计（简化版本，去掉偏移量字段）
+    final accuracyStats = await _database!.rawQuery('''
+      SELECT 
+        jdm.jellyfin_series_name,
+        COUNT(jem.id) as total_episodes,
+        SUM(CASE WHEN jem.confirmed = 1 THEN 1 ELSE 0 END) as confirmed_episodes
+      FROM jellyfin_dandanplay_mapping jdm
+      LEFT JOIN jellyfin_episode_mapping jem ON jdm.id = jem.mapping_id
+      GROUP BY jdm.id
+      HAVING total_episodes > 0
+    ''');
+
+    return {
+      'animeCount': (animeMappingCount.first['count'] as int?) ?? 0,
+      'episodeCount': (episodeMappingCount.first['count'] as int?) ?? 0,
+      'confirmedCount': (confirmedMappingCount.first['count'] as int?) ?? 0,
+      'predictedCount': (predictedMappingCount.first['count'] as int?) ?? 0,
+      'recentMappings': recentMappings,
+      'accuracyStats': accuracyStats,
+    };
+  }
+
+  /// 获取单个剧集的映射信息
+  Future<Map<String, dynamic>?> getEpisodeMapping(String jellyfinEpisodeId) async {
+    await initialize();
+
+    final results = await _database!.query(
+      'jellyfin_episode_mapping',
+      where: 'jellyfin_episode_id = ?',
+      whereArgs: [jellyfinEpisodeId],
+    );
+
+    if (results.isNotEmpty) {
+      return results.first;
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
## 概述

本次更新为NipaPlay-Reload应用的剧集导航功能和播放列表功能添加了完整的Jellyfin媒体服务器支持。现在用户可以在Jellyfin流媒体环境中享受与本地文件相同的无缝剧集切换体验，包括上一话/下一话导航和播放列表剧集选择。

##  主要功能

### 1. Jellyfin剧集导航支持
- **上一话/下一话功能**：完全支持Jellyfin流媒体的剧集导航
- **智能路径识别**：自动检测`jellyfin://`协议URL并使用专用的Jellyfin导航逻辑
- **流媒体URL处理**：正确处理Jellyfin协议URL到HTTP流媒体URL的转换

### 2. 播放列表Jellyfin集成
- **完整剧集列表**：播放列表现在支持显示Jellyfin同季所有剧集
- **智能剧集排序**：按集数正确排序并显示剧集名称
- **点击播放支持**：支持从播放列表直接选择任意Jellyfin剧集播放

### 3. 弹幕映射系统增强
- **智能映射预测**：基于已有映射自动预测新剧集的弹幕ID
- **完整映射流程**：包含映射获取、偏移量计算、数据库保存等完整逻辑
- **DandanPlay API集成**：获取准确的动画和剧集标题信息

##  技术实现

### 核心服务增强

#### `EpisodeNavigationService`
- 新增 `_getPreviousEpisodeFromJellyfin()` 和 `_getNextEpisodeFromJellyfin()` 方法
- 实现Jellyfin URL解析逻辑 (`_parseJellyfinUrl()`)
- 集成 `JellyfinEpisodeMappingService` 进行智能映射预测
- 添加 `_createJellyfinHistoryItem()` 创建包含弹幕信息的历史项

#### `PlaylistMenu`
- 新增 `_loadJellyfinEpisodes()` 方法加载同季剧集列表
- 实现Jellyfin剧集信息缓存机制
- 添加完整的弹幕映射预测逻辑 (`_createJellyfinHistoryItem()`)
- 支持Jellyfin协议URL到流媒体URL的转换

#### `JellyfinEpisodeMappingService`
- 实现 `getNextEpisodeMappingByDanmakuIds()` 和 `getPreviousEpisodeMappingByDanmakuIds()` 方法
- 添加基于偏移量的智能映射预测算法
- 提供 `predictEpisodeMapping()` 自动推算功能

### 播放器状态管理

#### `VideoPlayerState`
- 增强 `playPreviousEpisode()` 和 `playNextEpisode()` 方法以支持Jellyfin流媒体URL处理逻辑

##  具体更改

### 文件级更改

1. **剧集导航服务** (episode_navigation_service.dart)
   - 新增Jellyfin专用导航方法
   - 实现URL解析和剧集信息获取
   - 集成映射服务进行弹幕ID预测

2. **播放列表组件** (playlist_menu.dart)
   - 添加Jellyfin剧集加载和显示逻辑
   - 实现完整的映射预测流程
   - 支持Jellyfin剧集播放功能

3. **映射服务增强** (jellyfin_episode_mapping_service.dart)
   - 新增基于弹幕ID的映射查询方法
   - 实现偏移量计算和预测算法
   - 添加映射数据库操作功能

4. **播放器状态** (video_player_state.dart)
   - 增强剧集导航方法支持Jellyfin
