### PR TITLE
fix: 修复右侧悬浮菜单的 Widget 生命周期错误

### DIFF
--- a/lib/widgets/right_edge_hover_menu.dart
+++ b/lib/widgets/right_edge_hover_menu.dart
@@ -19,7 +19,7 @@ class _RightEdgeHoverMenuState extends State<RightEdgeHoverMenu> {
 
   @override
   void dispose() {
-    _hideSettingsMenu();
+    _hideSettingsMenuWithoutSetState();
     super.dispose();
   }
 
@@ -30,25 +30,37 @@ class _RightEdgeHoverMenuState extends State<RightEdgeHoverMenu> {
       builder: (context) => HoverSettingsMenuWrapper(
         onClose: _hideSettingsMenu,
         onHover: (isHovered) {
-          setState(() {
-            _isMenuVisible = isHovered;
-          });
+          if (mounted) {
+            setState(() {
+              _isMenuVisible = isHovered;
+            });
+          }
         },
       ),
     );
 
     Overlay.of(context).insert(_settingsMenuOverlay!);
-    setState(() {
-      _isMenuVisible = true;
-    });
+    if (mounted) {
+      setState(() {
+        _isMenuVisible = true;
+      });
+    }
   }
 
   void _hideSettingsMenu() {
     _settingsMenuOverlay?.remove();
     _settingsMenuOverlay = null;
-    setState(() {
-      _isMenuVisible = false;
-    });
+    if (mounted) {
+      setState(() {
+        _isMenuVisible = false;
+      });
+    }
+  }
+
+  void _hideSettingsMenuWithoutSetState() {
+    _settingsMenuOverlay?.remove();
+    _settingsMenuOverlay = null;
+    _isMenuVisible = false;
   }
 
   @override


### PR DESCRIPTION
## 问题
用户快速退出视频播放时出现崩溃：
```
'_lifecycleState != _ElementLifecycle.defunct': is not true
```

**原因**：用户悬停触发设置菜单后快速点击返回，导致 Widget 在 dispose 过程中调用 setState()。

## 修复
在 `RightEdgeHoverMenu` 中添加生命周期保护：

1. **所有 setState 前添加 mounted 检查**
2. **dispose 时使用无状态清理方法**
3. **延迟回调中添加 mounted 保护**

## 主要更改
```dart
// dispose 时安全清理
@override
void dispose() {
  _hideSettingsMenuWithoutSetState(); // 不调用 setState
  super.dispose();
}

// 添加 mounted 检查
if (mounted) {
  setState(() {
    _isMenuVisible = isHovered;
  });
}
```


**文件**：right_edge_hover_menu.dart