### PR TITLE
更新libmpv依赖为libmpv2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -618,7 +618,7 @@ jobs:
           export LD_LIBRARY_PATH="${APPDIR}/lib:${LD_LIBRARY_PATH}"
           chmod +x "${APPDIR}/${APP_NAME}"
           
-          ./linuxdeployqt "${APPDIR}/${APP_NAME}" -appimage -bundle-non-qt-libs
+          ./linuxdeployqt "${APPDIR}/${APP_NAME}" -unsupported-allow-new-glibc -appimage -bundle-non-qt-libs
           
           echo "Listing *.AppImage files in current directory after linuxdeployqt:"
           ls -la *.AppImage || echo "No AppImage found in current directory."

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
             artifact_path: build/windows/*
             arch: x64
           - target: Linux
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             arch: amd64
             artifact_name: release-Linux-amd64
             artifact_path: build/linux/

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.4.16
+version: 1.4.15
 
 environment:
   sdk: ^3.5.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.4.15
+version: 1.4.16
 
 environment:
   sdk: ^3.5.3


### PR DESCRIPTION
1. 将Linux编译平台更新为`Ubuntu 24.04`
2. 为生成appimage时使用的`linuxdeployqt`添加了`-unsupported-allow-new-glibc`参数