### PR TITLE
将Linux .desktop文件中的执行路径改为绝对路径

### DIFF
--- a/assets/linux/io.github.MCDFsteve.NipaPlay-Reload.desktop
+++ b/assets/linux/io.github.MCDFsteve.NipaPlay-Reload.desktop
@@ -2,7 +2,7 @@
 Name=NipaPlay
 Comment=A cross platform danmaku video player.
 Comment[zh_CN]=一款跨平台本地弹幕视频播放器。
-Exec=nipaplay %f
+Exec=/opt/nipaplay/NipaPlay %f
 Icon=io.github.MCDFsteve.NipaPlay-Reload
 Terminal=false
 Type=Application


### PR DESCRIPTION
NipaPlay Linux版本的deb包和rpm包都是将软件安装在`/opt`目录下，可执行文件路径为`/opt/nipaplay/NipaPlay`。将`Exec=`路径修改为可执行文件的绝对路径的原因是，`/opt`目录以及目录下的文件夹并不在Linux默认的PATH里，并且一般也不将其放入PATH。
所以如果为相对路径的话会报错，提示“找不到可执行文件”，无法启动；修改为绝对路径后能才能正常使用。