### PR TITLE
perf: 消除空闲帧与泄漏；默认启用 GPU 弹幕；资源监视按需刷新；仅播放时启停 UI Ticker

### DIFF
--- a/lib/danmaku_abstraction/danmaku_kernel_factory.dart
+++ b/lib/danmaku_abstraction/danmaku_kernel_factory.dart
@@ -13,7 +13,8 @@ enum DanmakuRenderEngine {
 /// 负责读写弹幕渲染引擎设置的工厂类
 class DanmakuKernelFactory {
   static const String _danmakuRenderEngineKey = 'danmaku_render_engine';
-  static DanmakuRenderEngine _cachedEngine = DanmakuRenderEngine.cpu;
+  // Default to GPU if no user setting exists
+  static DanmakuRenderEngine _cachedEngine = DanmakuRenderEngine.gpu;
   static bool _initialized = false;
 
   // 添加StreamController用于广播内核切换事件
@@ -36,10 +37,10 @@ class DanmakuKernelFactory {
       if (engineIndex != null && engineIndex >= 0 && engineIndex < DanmakuRenderEngine.values.length) {
         _cachedEngine = DanmakuRenderEngine.values[engineIndex];
       } else {
-        _cachedEngine = DanmakuRenderEngine.cpu; // 默认使用 CPU
+        _cachedEngine = DanmakuRenderEngine.gpu; // 默认使用 GPU
       }
     } catch (e) {
-      _cachedEngine = DanmakuRenderEngine.cpu;
+      _cachedEngine = DanmakuRenderEngine.gpu;
     }
     
     _initialized = true;

--- a/lib/danmaku_abstraction/danmaku_text_renderer_factory.dart
+++ b/lib/danmaku_abstraction/danmaku_text_renderer_factory.dart
@@ -2,14 +2,12 @@ import 'package:nipaplay/danmaku_abstraction/danmaku_text_renderer.dart';
 import 'package:nipaplay/danmaku_gpu/lib/dynamic_font_atlas.dart';
 import 'package:nipaplay/danmaku_gpu/lib/gpu_danmaku_config.dart';
 import 'package:nipaplay/danmaku_gpu/lib/gpu_danmaku_text_renderer.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'danmaku_kernel_factory.dart';
 
 class DanmakuTextRendererFactory {
   static Future<DanmakuTextRenderer> create() async {
-    final prefs = await SharedPreferences.getInstance();
-    final engineIndex = prefs.getInt('danmaku_render_engine') ?? 0;
-    final engine = DanmakuRenderEngine.values[engineIndex];
+  // Use centralized kernel factory which already caches & defaults to GPU
+  final engine = DanmakuKernelFactory.getKernelType();
 
     if (engine == DanmakuRenderEngine.gpu) {
       // For GPU, we need to create its dependencies
@@ -19,9 +17,8 @@ class DanmakuTextRendererFactory {
       final config = GPUDanmakuConfig(); // Default config
       
       return GpuDanmakuTextRenderer(fontAtlas: fontAtlas, config: config);
-    } else {
-      // Default to CPU renderer
-      return const CpuDanmakuTextRenderer();
-    }
+  }
+  // Default to CPU renderer
+  return const CpuDanmakuTextRenderer();
   }
 } 

--- a/lib/widgets/nipaplay_theme/switchable_view.dart
+++ b/lib/widgets/nipaplay_theme/switchable_view.dart
@@ -72,7 +72,13 @@ class _SwitchableViewState extends State<SwitchableView> {
         return IndexedStack(
           index: _currentIndex,
           sizing: StackFit.expand,
-          children: widget.children,
+          children: List.generate(
+            widget.children.length,
+            (i) => TickerMode(
+              enabled: i == _currentIndex,
+              child: widget.children[i],
+            ),
+          ),
         );
       }
       
@@ -99,7 +105,13 @@ class _SwitchableViewState extends State<SwitchableView> {
       return IndexedStack(
         index: _currentIndex,
         sizing: StackFit.expand,
-        children: widget.children,
+        children: List.generate(
+          widget.children.length,
+          (i) => TickerMode(
+            enabled: i == _currentIndex,
+            child: widget.children[i],
+          ),
+        ),
       );
     }
   }


### PR DESCRIPTION
## 概述
- 目标：在不改变功能语义的前提下，去掉“空闲/后台”持续产帧，降低 CPU/GPU 占用；并将默认弹幕引擎切到 GPU 以提升渲染性能。
- 结果：暂停/非播放器页时基本不再产帧；DevTools 实测空闲 CPU/GPU ≈ 1.5%。播放流程与交互保持不变。

## 变更类型
- 性能优化
- 修复资源释放问题（Overlay 动画控制器泄漏）
- 默认配置调整（弹幕渲染引擎默认改为 GPU）

## 变更详情
- 导航/渲染
  - `switchable_view.dart`：IndexedStack 子项外包 `TickerMode`，仅当前标签允许动画/计时器；后台页停止 tick。
- Overlay 生命周期
  - `blur_snackbar.dart`、`countdown_snackbar.dart`：统一 `AnimationController` 生命周期，`reverse → remove → dispose`，消除“幽灵控制器”。
- 系统资源监视按需刷新
  - system_resource_monitor.dart：引入消费者计数，只有有消费者时才启动 FPS Ticker/资源定时器；无消费者立刻停止。
  - `system_resource_display.dart`：显示时注册消费者并启动 500ms 刷新；隐藏/销毁时注销并停止。
- 播放器 UI Ticker 收紧
  - video_player_state.dart：`_uiUpdateTicker` 仅在 `PlayerStatus.playing` 启动；`pause/stop` 立即停止；初始化不再常开，避免空闲持续要帧。
- 弹幕默认 GPU 与统一读取入口
  - danmaku_kernel_factory.dart：默认从 CPU→GPU；偏好未设置或异常时回落 GPU；保持 `onKernelChanged` 广播。
  - danmaku_text_renderer_factory.dart：不再直接读偏好，统一通过 `DanmakuKernelFactory.getKernelType()` 获取，保证默认与缓存一致。

## 受影响模块/文件
- switchable_view.dart
- blur_snackbar.dart
- countdown_snackbar.dart
- system_resource_monitor.dart
- system_resource_display.dart
- video_player_state.dart
- danmaku_kernel_factory.dart
- danmaku_text_renderer_factory.dart

## 性能影响
- 空闲/非播放器页：Timeline 不再出现连续 Vsync 帧；CPU/GPU 从持续占用降至 ≈1.5%（以本地测量为准）。
- 播放过程：维持原性能或更好（GPU 弹幕）。
