### PR TITLE
fix: 卡顿及日志刷屏问题

### DIFF
--- a/lib/pages/dashboard_home_page.dart
+++ b/lib/pages/dashboard_home_page.dart
@@ -42,6 +42,12 @@ class DashboardHomePage extends StatefulWidget {
 
 class _DashboardHomePageState extends State<DashboardHomePage>
     with AutomaticKeepAliveClientMixin {
+  // 持有Provider实例引用，确保在dispose中能正确移除监听器
+  JellyfinProvider? _jellyfinProviderRef;
+  EmbyProvider? _embyProviderRef;
+  WatchHistoryProvider? _watchHistoryProviderRef;
+  ScanService? _scanServiceRef;
+  VideoPlayerState? _videoPlayerStateRef;
   
   @override
   bool get wantKeepAlive => true;
@@ -188,40 +194,40 @@ class _DashboardHomePageState extends State<DashboardHomePage>
   void _setupProviderListeners() {
     // 监听Jellyfin连接状态变化
     try {
-      final jellyfinProvider = Provider.of<JellyfinProvider>(context, listen: false);
-      jellyfinProvider.addListener(_onJellyfinStateChanged);
+  _jellyfinProviderRef = Provider.of<JellyfinProvider>(context, listen: false);
+  _jellyfinProviderRef!.addListener(_onJellyfinStateChanged);
     } catch (e) {
       debugPrint('DashboardHomePage: 添加JellyfinProvider监听器失败: $e');
     }
     
     // 监听Emby连接状态变化
     try {
-      final embyProvider = Provider.of<EmbyProvider>(context, listen: false);
-      embyProvider.addListener(_onEmbyStateChanged);
+  _embyProviderRef = Provider.of<EmbyProvider>(context, listen: false);
+  _embyProviderRef!.addListener(_onEmbyStateChanged);
     } catch (e) {
       debugPrint('DashboardHomePage: 添加EmbyProvider监听器失败: $e');
     }
     
     // 监听WatchHistoryProvider的加载状态变化
     try {
-      final watchHistoryProvider = Provider.of<WatchHistoryProvider>(context, listen: false);
-      watchHistoryProvider.addListener(_onWatchHistoryStateChanged);
+  _watchHistoryProviderRef = Provider.of<WatchHistoryProvider>(context, listen: false);
+  _watchHistoryProviderRef!.addListener(_onWatchHistoryStateChanged);
     } catch (e) {
       debugPrint('DashboardHomePage: 添加WatchHistoryProvider监听器失败: $e');
     }
     
     // 监听ScanService的扫描完成状态变化
     try {
-      final scanService = Provider.of<ScanService>(context, listen: false);
-      scanService.addListener(_onScanServiceStateChanged);
+  _scanServiceRef = Provider.of<ScanService>(context, listen: false);
+  _scanServiceRef!.addListener(_onScanServiceStateChanged);
     } catch (e) {
       debugPrint('DashboardHomePage: 添加ScanService监听器失败: $e');
     }
     
     // 监听VideoPlayerState的状态变化，用于检测播放器状态
     try {
-      final videoPlayerState = Provider.of<VideoPlayerState>(context, listen: false);
-      videoPlayerState.addListener(_onVideoPlayerStateChanged);
+  _videoPlayerStateRef = Provider.of<VideoPlayerState>(context, listen: false);
+  _videoPlayerStateRef!.addListener(_onVideoPlayerStateChanged);
     } catch (e) {
       debugPrint('DashboardHomePage: 添加VideoPlayerState监听器失败: $e');
     }
@@ -365,7 +371,6 @@ class _DashboardHomePageState extends State<DashboardHomePage>
   void _onWatchHistoryStateChanged() {
     // 检查Widget是否仍然处于活动状态
     if (!mounted) {
-      debugPrint('DashboardHomePage: Widget已销毁，跳过WatchHistory状态变化处理');
       return;
     }
     
@@ -456,53 +461,38 @@ class _DashboardHomePageState extends State<DashboardHomePage>
     
     _heroBannerIndexNotifier.dispose();
     
-    // 移除监听器 - 使用更安全的方式
+    // 移除监听器 - 使用初始化时保存的实例引用，避免在dispose中再次查找context
     try {
-      if (mounted) {
-        final jellyfinProvider = Provider.of<JellyfinProvider>(context, listen: false);
-        jellyfinProvider.removeListener(_onJellyfinStateChanged);
-        debugPrint('DashboardHomePage: JellyfinProvider监听器已移除');
-      }
+      _jellyfinProviderRef?.removeListener(_onJellyfinStateChanged);
+      debugPrint('DashboardHomePage: JellyfinProvider监听器已移除');
     } catch (e) {
       debugPrint('DashboardHomePage: 移除JellyfinProvider监听器失败: $e');
     }
     
     try {
-      if (mounted) {
-        final embyProvider = Provider.of<EmbyProvider>(context, listen: false);
-        embyProvider.removeListener(_onEmbyStateChanged);
-        debugPrint('DashboardHomePage: EmbyProvider监听器已移除');
-      }
+      _embyProviderRef?.removeListener(_onEmbyStateChanged);
+      debugPrint('DashboardHomePage: EmbyProvider监听器已移除');
     } catch (e) {
       debugPrint('DashboardHomePage: 移除EmbyProvider监听器失败: $e');
     }
     
     try {
-      if (mounted) {
-        final watchHistoryProvider = Provider.of<WatchHistoryProvider>(context, listen: false);
-        watchHistoryProvider.removeListener(_onWatchHistoryStateChanged);
-        debugPrint('DashboardHomePage: WatchHistoryProvider监听器已移除');
-      }
+      _watchHistoryProviderRef?.removeListener(_onWatchHistoryStateChanged);
+      debugPrint('DashboardHomePage: WatchHistoryProvider监听器已移除');
     } catch (e) {
       debugPrint('DashboardHomePage: 移除WatchHistoryProvider监听器失败: $e');
     }
     
     try {
-      if (mounted) {
-        final scanService = Provider.of<ScanService>(context, listen: false);
-        scanService.removeListener(_onScanServiceStateChanged);
-        debugPrint('DashboardHomePage: ScanService监听器已移除');
-      }
+      _scanServiceRef?.removeListener(_onScanServiceStateChanged);
+      debugPrint('DashboardHomePage: ScanService监听器已移除');
     } catch (e) {
       debugPrint('DashboardHomePage: 移除ScanService监听器失败: $e');
     }
     
     try {
-      if (mounted) {
-        final videoPlayerState = Provider.of<VideoPlayerState>(context, listen: false);
-        videoPlayerState.removeListener(_onVideoPlayerStateChanged);
-        debugPrint('DashboardHomePage: VideoPlayerState监听器已移除');
-      }
+      _videoPlayerStateRef?.removeListener(_onVideoPlayerStateChanged);
+      debugPrint('DashboardHomePage: VideoPlayerState监听器已移除');
     } catch (e) {
       debugPrint('DashboardHomePage: 移除VideoPlayerState监听器失败: $e');
     }

--- a/lib/utils/video_player_state.dart
+++ b/lib/utils/video_player_state.dart
@@ -83,6 +83,9 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
   String? _currentVideoPath;
   String _danmakuOverlayKey = 'idle'; // 弹幕覆盖层的稳定key
   Timer? _uiUpdateTimer; // UI更新定时器（包含位置保存和数据持久化功能）
+  // 观看记录节流：记录上一次更新所处的10秒分桶，避免同一时间窗内重复写DB与通知Provider
+  int _lastHistoryUpdateBucket = -1;
+  // （保留占位，若未来要做更细粒度同步节流可再启用）
   // 🔥 新增：Ticker相关字段
   Ticker? _uiUpdateTicker;
   int _lastTickTime = 0;
@@ -1361,7 +1364,8 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
         }
         
         if (_context != null && _context!.mounted) {
-          _context!.read<WatchHistoryProvider>().refresh();
+          // 仅通知变更的那条记录，避免全量刷新导致的监听风暴
+          await _context!.read<WatchHistoryProvider>().addOrUpdateHistory(updatedHistory);
         }
         return;
       }
@@ -4787,8 +4791,10 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
             // 保存播放位置（原来在10秒定时器中）
             _saveVideoPosition(_currentVideoPath!, _position.inMilliseconds);
 
-            // 每10秒更新一次观看记录（减少数据库写入频率）
-            if (_position.inMilliseconds % 10000 < 500) { 
+            // 每10秒更新一次观看记录（使用分桶去抖，避免在窗口内重复调用）
+            final int currentBucket = _position.inMilliseconds ~/ 10000;
+            if (currentBucket != _lastHistoryUpdateBucket) {
+              _lastHistoryUpdateBucket = currentBucket;
               _updateWatchHistory();
             }
 


### PR DESCRIPTION
dashboard_home_page.dart
保存 Provider 实例引用并用它们移除监听
在 init 时把 Jellyfin/Emby/WatchHistory/ScanService/VideoPlayerState 的 provider 引用保存到私有字段。
在 dispose 里直接用这些引用移除监听，不再在 dispose 中通过 context 查找 Provider（避免失败后遗留监听）。
降噪：当不 mounted 时，直接 return，不再打印“Widget已销毁…”这类日志。

video_player_state.dart
给观看记录更新做“10 秒分桶去抖”
播放时的 UI Ticker 原先每帧都会检查 position，并用“取模<500ms”策略触发更新；这会在 500ms 的窗口内多次触发，仍然很频繁。
改为用 position ~/ 10000 的分桶策略，相同 10 秒桶只更新一次，大幅减少 DB 写入与 Provider 通知。
避免全量 refresh
在已有记录更新的分支中，替换 _context.read<WatchHistoryProvider>().refresh() 为 addOrUpdateHistory(updatedHistory)，只更新变更项，避免刷新完整列表和连锁通知。