### PR TITLE
perf: 优化播放器性能并修复主页动画问题

### DIFF
--- a/lib/pages/dashboard_home_page.dart
+++ b/lib/pages/dashboard_home_page.dart
@@ -104,6 +104,7 @@ class _DashboardHomePageState extends State<DashboardHomePage>
   final Map<String, Map<String, dynamic>> _thumbnailCache = {};
 
   // 追踪已绘制的文件路径
+  // ignore: unused_field
   final Set<String> _renderedThumbnailPaths = {};
 
   // 静态变量，用于缓存推荐内容
@@ -1184,7 +1185,12 @@ class _DashboardHomePageState extends State<DashboardHomePage>
   Widget build(BuildContext context) {
     super.build(context);
     
-    return Scaffold(
+    // 当播放器处于活跃状态时，关闭 Dashboard 上的所有 Ticker（动画/过渡），避免后台动画占用栅格时间。
+    final bool tickerEnabled = !_isVideoPlayerActive();
+
+    return TickerMode(
+      enabled: tickerEnabled,
+      child: Scaffold(
       backgroundColor: Colors.transparent,
       body: Consumer2<JellyfinProvider, EmbyProvider>(
         builder: (context, jellyfinProvider, embyProvider, child) {
@@ -1290,7 +1296,8 @@ class _DashboardHomePageState extends State<DashboardHomePage>
               onPressed: _loadData,
               description: ' 刷新主页',
             ),
-    );
+        ),
+      );
   }
 
   Widget _buildHeroBanner() {

--- a/lib/widgets/danmaku_container.dart
+++ b/lib/widgets/danmaku_container.dart
@@ -801,6 +801,10 @@ class _DanmakuContainerState extends State<DanmakuContainer> {
 
   @override
   Widget build(BuildContext context) {
+    // 弹幕不可见时，彻底不渲染，避免 TextPainter/ParagraphBuilder 开销
+    if (!widget.isVisible) {
+      return const SizedBox.shrink();
+    }
     if (_textRenderer == null) {
       return const SizedBox.shrink();
     }
@@ -818,7 +822,11 @@ class _DanmakuContainerState extends State<DanmakuContainer> {
 
         return Consumer<VideoPlayerState>(
           builder: (context, videoState, child) {
-            final mergeDanmaku = videoState.danmakuVisible && (videoState.mergeDanmaku ?? false);
+            // 弹幕不可见时仍然避免不必要计算
+            if (!widget.isVisible) {
+              return const SizedBox.shrink();
+            }
+            final mergeDanmaku = videoState.danmakuVisible && videoState.mergeDanmaku;
             final allowStacking = videoState.danmakuStacking;
             final forceRefresh = _getBlockStateHash(videoState) != _lastBlockStateHash;
             if (forceRefresh) {

--- a/lib/widgets/danmaku_overlay.dart
+++ b/lib/widgets/danmaku_overlay.dart
@@ -34,6 +34,10 @@ class _DanmakuOverlayState extends State<DanmakuOverlay> {
 
   @override
   Widget build(BuildContext context) {
+    if (!widget.isVisible) {
+      // 弹幕不可见时，彻底不构建，避免文本排版消耗
+      return const SizedBox.shrink();
+    }
     return Consumer<VideoPlayerState>(
       builder: (context, videoState, child) {
         final kernelType = DanmakuKernelFactory.getKernelType();
@@ -88,7 +92,7 @@ class _DanmakuOverlayState extends State<DanmakuOverlay> {
         }
 
         // Fallback to CPU rendering
-        return DanmakuContainer(
+  return DanmakuContainer(
           danmakuList: activeDanmakuList,
           currentTime: widget.currentPosition / 1000,
           videoDuration: widget.videoDuration / 1000,

--- a/lib/widgets/nipaplay_theme/video_player_ui.dart
+++ b/lib/widgets/nipaplay_theme/video_player_ui.dart
@@ -339,27 +339,31 @@ class _VideoPlayerUIState extends State<VideoPlayerUI> {
                               ),
                             ),
                             
-                                                          if (videoState.hasVideo)
-                                Positioned.fill(
-                                  child: IgnorePointer(
-                                    ignoring: true,
-                                    child: Consumer<VideoPlayerState>(
-                                      builder: (context, videoState, _) {
-                                        // 修改：保持DanmakuOverlay组件始终存在，通过isVisible控制可见性
-                                        // 避免销毁重建导致的延迟问题
-                                        return DanmakuOverlay(
-                                          key: ValueKey('danmaku_${videoState.danmakuOverlayKey}'),
-                                          currentPosition: videoState.position.inMilliseconds.toDouble(),
-                                          videoDuration: videoState.videoDuration.inMilliseconds.toDouble(),
-                                          isPlaying: videoState.status == PlayerStatus.playing,
-                                          fontSize: getFontSize(videoState),
-                                          isVisible: videoState.danmakuVisible,
-                                          opacity: videoState.mappedDanmakuOpacity,
-                                        );
-                                      },
-                                    ),
+                            if (videoState.hasVideo && videoState.danmakuVisible)
+                              Positioned.fill(
+                                child: IgnorePointer(
+                                  ignoring: true,
+                                  child: Consumer<VideoPlayerState>(
+                                    builder: (context, videoState, _) {
+                                      // 使用高频时间轴驱动弹幕帧率
+                                      return ValueListenableBuilder<double>(
+                                        valueListenable: videoState.playbackTimeMs,
+                                        builder: (context, posMs, __) {
+                                          return DanmakuOverlay(
+                                            key: ValueKey('danmaku_${videoState.danmakuOverlayKey}'),
+                                            currentPosition: posMs,
+                                            videoDuration: videoState.videoDuration.inMilliseconds.toDouble(),
+                                            isPlaying: videoState.status == PlayerStatus.playing,
+                                            fontSize: getFontSize(videoState),
+                                            isVisible: videoState.danmakuVisible,
+                                            opacity: videoState.mappedDanmakuOpacity,
+                                          );
+                                        },
+                                      );
+                                    },
                                   ),
                                 ),
+                              ),
                             
                             if (videoState.status == PlayerStatus.recognizing || videoState.status == PlayerStatus.loading)
                               Positioned.fill(
@@ -404,22 +408,26 @@ class _VideoPlayerUIState extends State<VideoPlayerUI> {
                                 ),
                               ),
                               
-                              if (videoState.hasVideo)
+                              if (videoState.hasVideo && videoState.danmakuVisible)
                                 Positioned.fill(
                                   child: IgnorePointer(
                                     ignoring: true,
                                     child: Consumer<VideoPlayerState>(
                                       builder: (context, videoState, _) {
-                                        // 修改：保持DanmakuOverlay组件始终存在，通过isVisible控制可见性
-                                        // 避免销毁重建导致的延迟问题
-                                        return DanmakuOverlay(
-                                          key: ValueKey('danmaku_${videoState.danmakuOverlayKey}'),
-                                          currentPosition: videoState.position.inMilliseconds.toDouble(),
-                                          videoDuration: videoState.videoDuration.inMilliseconds.toDouble(),
-                                          isPlaying: videoState.status == PlayerStatus.playing,
-                                          fontSize: getFontSize(videoState),
-                                          isVisible: videoState.danmakuVisible,
-                                          opacity: videoState.mappedDanmakuOpacity,
+                                        // 使用高频时间轴驱动弹幕帧率
+                                        return ValueListenableBuilder<double>(
+                                          valueListenable: videoState.playbackTimeMs,
+                                          builder: (context, posMs, __) {
+                                            return DanmakuOverlay(
+                                              key: ValueKey('danmaku_${videoState.danmakuOverlayKey}'),
+                                              currentPosition: posMs,
+                                              videoDuration: videoState.videoDuration.inMilliseconds.toDouble(),
+                                              isPlaying: videoState.status == PlayerStatus.playing,
+                                              fontSize: getFontSize(videoState),
+                                              isVisible: videoState.danmakuVisible,
+                                              opacity: videoState.mappedDanmakuOpacity,
+                                            );
+                                          },
                                         );
                                       },
                                     ),


### PR DESCRIPTION
本次更新重点关注播放器核心性能和 UI 流畅性，主要包含以下两方面的改进：

**1. 播放器性能与弹幕渲染优化 (Performance Tuning):**

*   **引入高频时间轴 (`ValueNotifier<double>`)**:
    *   为弹幕系统提供了一个独立于 UI 刷新（`notifyListeners`）的、更高频率的时间源。这使得弹幕动画可以独立于主 UI 进行更新，实现了更平滑的弹幕滚动效果，尤其是在主 UI 刷新率较低时。
    *   `DanmakuOverlay` 现在由 `ValueListenableBuilder` 驱动，直接响应高频时间变化，确保弹幕位置的精确更新。

*   **UI 更新与播放位置保存节流 (Throttling):**
    *   **UI 更新节流**: 通过引入 `_uiUpdateIntervalMs`，限制了 `notifyListeners` 的调用频率，避免了因过于频繁的 UI 重建（例如每帧都调用）而导致的性能开销。现在 UI 状态（如进度条）的更新频率更加合理。
    *   **播放位置保存节流**: 优化了播放历史记录的保存逻辑。现在仅当播放时间间隔超过 `_positionSaveIntervalMs` (3秒) 或播放位置变化超过 `_positionSaveDeltaThresholdMs` (2秒) 时，才会触发数据库写入操作，显著减少了 I/O 次数。

*   **优化弹幕渲染组件**:
    *   在 `DanmakuContainer` 和 `DanmakuOverlay` 中增加了 `isVisible` 判断。当弹幕被用户设置为不可见时，将直接返回 `SizedBox.shrink()`，彻底避免了后续的弹幕计算、布局和渲染开销。

**2. 修复主页动画在后台重建的问题 (Bug Fix):**

*   **引入 `TickerMode`**:
    *   在 `DashboardHomePage` 中，通过监听播放器的活跃状态 (`_isVideoPlayerActive`)，动态地控制 `TickerMode` 的 `enabled` 属性。
    *   当视频播放器处于活动状态时，主页的 `TickerMode` 会被禁用，从而暂停所有在主页上的动画（如 `Ticker`、`AnimationController`）。这有效地防止了在播放视频时，后台的主页仍在进行不必要的动画计算和 UI 重建，降低了 CPU 和 GPU 的负载，提升了应用在前台播放时的流畅度。

目前大概降低了播放中30%的CPU性能消耗