### PR TITLE
Implements robust multi-address server connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,9 @@ doc/api/
 /MCDFsteve/
 /assets/web
 docs/error.txt
+
+# 忽略 Mac 的隐藏文件
+.DS_Store
+
+# 忽略 VSCode 的设置文件
+.vscode/settings.json

--- a/lib/models/server_profile_model.dart
+++ b/lib/models/server_profile_model.dart
@@ -7,6 +7,7 @@ class ServerProfile {
   final String serverType; // 服务器类型: emby, jellyfin
   final List<ServerAddress> addresses; // 多个地址列表
   final String username; // 用户名
+  final String? serverId; // 远程服务器ID（Emby/Jellyfin服务器的唯一标识）
   String? accessToken; // 访问令牌
   String? userId; // 用户ID
   String? lastSuccessfulAddressId; // 最近成功连接的地址ID
@@ -18,6 +19,7 @@ class ServerProfile {
     required this.serverType,
     required this.addresses,
     required this.username,
+    this.serverId,
     this.accessToken,
     this.userId,
     this.lastSuccessfulAddressId,
@@ -111,6 +113,7 @@ class ServerProfile {
     String? serverType,
     List<ServerAddress>? addresses,
     String? username,
+    String? serverId,
     String? accessToken,
     String? userId,
     String? lastSuccessfulAddressId,
@@ -122,6 +125,7 @@ class ServerProfile {
       serverType: serverType ?? this.serverType,
       addresses: addresses ?? this.addresses,
       username: username ?? this.username,
+      serverId: serverId ?? this.serverId,
       accessToken: accessToken ?? this.accessToken,
       userId: userId ?? this.userId,
       lastSuccessfulAddressId: lastSuccessfulAddressId ?? this.lastSuccessfulAddressId,
@@ -136,6 +140,7 @@ class ServerProfile {
       'serverType': serverType,
       'addresses': addresses.map((addr) => addr.toJson()).toList(),
       'username': username,
+      'serverId': serverId,
       'accessToken': accessToken,
       'userId': userId,
       'lastSuccessfulAddressId': lastSuccessfulAddressId,
@@ -152,6 +157,7 @@ class ServerProfile {
           .map((addr) => ServerAddress.fromJson(addr))
           .toList(),
       username: json['username'],
+      serverId: json['serverId'],
       accessToken: json['accessToken'],
       userId: json['userId'],
       lastSuccessfulAddressId: json['lastSuccessfulAddressId'],

--- a/lib/models/server_profile_model.dart
+++ b/lib/models/server_profile_model.dart
@@ -1,0 +1,268 @@
+
+
+/// 服务器配置文件模型，支持多地址管理
+class ServerProfile {
+  final String id; // 服务器唯一标识
+  final String serverName; // 服务器名称
+  final String serverType; // 服务器类型: emby, jellyfin
+  final List<ServerAddress> addresses; // 多个地址列表
+  final String username; // 用户名
+  String? accessToken; // 访问令牌
+  String? userId; // 用户ID
+  String? lastSuccessfulAddressId; // 最近成功连接的地址ID
+  DateTime? lastConnectionTime; // 最后连接时间
+  
+  ServerProfile({
+    required this.id,
+    required this.serverName,
+    required this.serverType,
+    required this.addresses,
+    required this.username,
+    this.accessToken,
+    this.userId,
+    this.lastSuccessfulAddressId,
+    this.lastConnectionTime,
+  });
+
+  /// 获取当前应该使用的地址（优先使用最近成功的地址）
+  ServerAddress? get currentAddress {
+    if (addresses.isEmpty) return null;
+    
+    // 优先使用最近成功连接的地址
+    if (lastSuccessfulAddressId != null) {
+      final lastAddress = addresses.firstWhere(
+        (addr) => addr.id == lastSuccessfulAddressId,
+        orElse: () => addresses.first,
+      );
+      if (lastAddress.isEnabled) return lastAddress;
+    }
+    
+    // 返回第一个启用的地址
+    return addresses.firstWhere(
+      (addr) => addr.isEnabled,
+      orElse: () => addresses.first,
+    );
+  }
+
+  /// 获取所有启用的地址列表（按优先级排序）
+  List<ServerAddress> get enabledAddresses {
+    final List<ServerAddress> enabled = addresses.where((addr) => addr.isEnabled).toList();
+    
+    // 按优先级和最近成功时间排序
+    enabled.sort((a, b) {
+      // 最近成功的地址优先
+      if (a.id == lastSuccessfulAddressId) return -1;
+      if (b.id == lastSuccessfulAddressId) return 1;
+      
+      // 按优先级排序
+      final priorityCompare = a.priority.compareTo(b.priority);
+      if (priorityCompare != 0) return priorityCompare;
+      
+      // 按最后成功时间排序
+      if (a.lastSuccessTime != null && b.lastSuccessTime != null) {
+        return b.lastSuccessTime!.compareTo(a.lastSuccessTime!);
+      }
+      if (a.lastSuccessTime != null) return -1;
+      if (b.lastSuccessTime != null) return 1;
+      
+      return 0;
+    });
+    
+    return enabled;
+  }
+
+  /// 标记某个地址为成功连接
+  ServerProfile markAddressSuccess(String addressId) {
+    final updatedAddresses = addresses.map((addr) {
+      if (addr.id == addressId) {
+        return addr.copyWith(
+          lastSuccessTime: DateTime.now(),
+          failureCount: 0,
+        );
+      }
+      return addr;
+    }).toList();
+    
+    return copyWith(
+      addresses: updatedAddresses,
+      lastSuccessfulAddressId: addressId,
+      lastConnectionTime: DateTime.now(),
+    );
+  }
+
+  /// 标记某个地址连接失败
+  ServerProfile markAddressFailed(String addressId) {
+    final updatedAddresses = addresses.map((addr) {
+      if (addr.id == addressId) {
+        return addr.copyWith(
+          lastFailureTime: DateTime.now(),
+          failureCount: addr.failureCount + 1,
+        );
+      }
+      return addr;
+    }).toList();
+    
+    return copyWith(addresses: updatedAddresses);
+  }
+
+  ServerProfile copyWith({
+    String? id,
+    String? serverName,
+    String? serverType,
+    List<ServerAddress>? addresses,
+    String? username,
+    String? accessToken,
+    String? userId,
+    String? lastSuccessfulAddressId,
+    DateTime? lastConnectionTime,
+  }) {
+    return ServerProfile(
+      id: id ?? this.id,
+      serverName: serverName ?? this.serverName,
+      serverType: serverType ?? this.serverType,
+      addresses: addresses ?? this.addresses,
+      username: username ?? this.username,
+      accessToken: accessToken ?? this.accessToken,
+      userId: userId ?? this.userId,
+      lastSuccessfulAddressId: lastSuccessfulAddressId ?? this.lastSuccessfulAddressId,
+      lastConnectionTime: lastConnectionTime ?? this.lastConnectionTime,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'serverName': serverName,
+      'serverType': serverType,
+      'addresses': addresses.map((addr) => addr.toJson()).toList(),
+      'username': username,
+      'accessToken': accessToken,
+      'userId': userId,
+      'lastSuccessfulAddressId': lastSuccessfulAddressId,
+      'lastConnectionTime': lastConnectionTime?.toIso8601String(),
+    };
+  }
+
+  factory ServerProfile.fromJson(Map<String, dynamic> json) {
+    return ServerProfile(
+      id: json['id'],
+      serverName: json['serverName'],
+      serverType: json['serverType'],
+      addresses: (json['addresses'] as List)
+          .map((addr) => ServerAddress.fromJson(addr))
+          .toList(),
+      username: json['username'],
+      accessToken: json['accessToken'],
+      userId: json['userId'],
+      lastSuccessfulAddressId: json['lastSuccessfulAddressId'],
+      lastConnectionTime: json['lastConnectionTime'] != null
+          ? DateTime.parse(json['lastConnectionTime'])
+          : null,
+    );
+  }
+}
+
+/// 服务器地址模型
+class ServerAddress {
+  final String id; // 地址唯一标识
+  final String url; // 服务器URL
+  final String name; // 地址名称（如：家庭网络、公网访问等）
+  final int priority; // 优先级（数字越小优先级越高）
+  final bool isEnabled; // 是否启用
+  final DateTime? lastSuccessTime; // 最后成功连接时间
+  final DateTime? lastFailureTime; // 最后失败时间
+  final int failureCount; // 连续失败次数
+  final Map<String, dynamic>? metadata; // 额外元数据
+
+  ServerAddress({
+    required this.id,
+    required this.url,
+    required this.name,
+    this.priority = 0,
+    this.isEnabled = true,
+    this.lastSuccessTime,
+    this.lastFailureTime,
+    this.failureCount = 0,
+    this.metadata,
+  });
+
+  /// 规范化URL（确保URL格式正确）
+  String get normalizedUrl {
+    String normalized = url.trim();
+    if (!normalized.startsWith('http://') && !normalized.startsWith('https://')) {
+      normalized = 'http://$normalized';
+    }
+    if (normalized.endsWith('/')) {
+      normalized = normalized.substring(0, normalized.length - 1);
+    }
+    return normalized;
+  }
+
+  /// 是否应该重试（基于失败次数和时间）
+  bool shouldRetry({int maxFailures = 3, Duration cooldownPeriod = const Duration(minutes: 5)}) {
+    if (failureCount < maxFailures) return true;
+    
+    if (lastFailureTime != null) {
+      final timeSinceFailure = DateTime.now().difference(lastFailureTime!);
+      return timeSinceFailure > cooldownPeriod;
+    }
+    
+    return true;
+  }
+
+  ServerAddress copyWith({
+    String? id,
+    String? url,
+    String? name,
+    int? priority,
+    bool? isEnabled,
+    DateTime? lastSuccessTime,
+    DateTime? lastFailureTime,
+    int? failureCount,
+    Map<String, dynamic>? metadata,
+  }) {
+    return ServerAddress(
+      id: id ?? this.id,
+      url: url ?? this.url,
+      name: name ?? this.name,
+      priority: priority ?? this.priority,
+      isEnabled: isEnabled ?? this.isEnabled,
+      lastSuccessTime: lastSuccessTime ?? this.lastSuccessTime,
+      lastFailureTime: lastFailureTime ?? this.lastFailureTime,
+      failureCount: failureCount ?? this.failureCount,
+      metadata: metadata ?? this.metadata,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'url': url,
+      'name': name,
+      'priority': priority,
+      'isEnabled': isEnabled,
+      'lastSuccessTime': lastSuccessTime?.toIso8601String(),
+      'lastFailureTime': lastFailureTime?.toIso8601String(),
+      'failureCount': failureCount,
+      'metadata': metadata,
+    };
+  }
+
+  factory ServerAddress.fromJson(Map<String, dynamic> json) {
+    return ServerAddress(
+      id: json['id'],
+      url: json['url'],
+      name: json['name'],
+      priority: json['priority'] ?? 0,
+      isEnabled: json['isEnabled'] ?? true,
+      lastSuccessTime: json['lastSuccessTime'] != null
+          ? DateTime.parse(json['lastSuccessTime'])
+          : null,
+      lastFailureTime: json['lastFailureTime'] != null
+          ? DateTime.parse(json['lastFailureTime'])
+          : null,
+      failureCount: json['failureCount'] ?? 0,
+      metadata: json['metadata'],
+    );
+  }
+}

--- a/lib/pages/anime_page.dart
+++ b/lib/pages/anime_page.dart
@@ -293,6 +293,7 @@ class _MediaLibraryTabsState extends State<_MediaLibraryTabs> with TickerProvide
     final embyProvider = Provider.of<EmbyProvider>(context, listen: false);
     _isJellyfinConnected = jellyfinProvider.isConnected;
     _isEmbyConnected = embyProvider.isConnected;
+    print('_MediaLibraryTabs: 连接状态检查 - Jellyfin: $_isJellyfinConnected, Emby: $_isEmbyConnected');
   }
 
   TabChangeNotifier? _tabChangeNotifierRef;
@@ -397,6 +398,7 @@ class _MediaLibraryTabsState extends State<_MediaLibraryTabs> with TickerProvide
         // 检查连接状态是否改变
         if (_isJellyfinConnected != currentJellyfinConnectionState || 
             _isEmbyConnected != currentEmbyConnectionState) {
+          print('_MediaLibraryTabs: 连接状态发生变化 - Jellyfin: $_isJellyfinConnected -> $currentJellyfinConnectionState, Emby: $_isEmbyConnected -> $currentEmbyConnectionState');
           WidgetsBinding.instance.addPostFrameCallback((_) {
             if (mounted) {
               _updateTabController(currentJellyfinConnectionState, currentEmbyConnectionState);

--- a/lib/providers/emby_provider.dart
+++ b/lib/providers/emby_provider.dart
@@ -119,14 +119,17 @@ class EmbyProvider extends ChangeNotifier {
   /// 连接状态变化回调
   void _onConnectionStateChanged(bool isConnected) {
     print('EmbyProvider: 连接状态变化 - isConnected: $isConnected');
+    
+    // 连接状态变化需要立即通知UI，不能延迟
+    // 这样可以确保媒体库标签页能及时显示/隐藏
+    notifyListeners();
+    
     if (isConnected) {
       print('EmbyProvider: Emby已连接，开始加载媒体项目...');
       // 异步加载媒体项目，不阻塞UI
       loadMediaItems();
       loadMovieItems();
     }
-    // 连接状态变化可能伴随后续的媒体加载通知，这里合并通知，避免短时间多次刷新
-    _notifyCoalesced();
   }
   
   // 加载Emby媒体项

--- a/lib/providers/emby_provider.dart
+++ b/lib/providers/emby_provider.dart
@@ -172,14 +172,14 @@ class EmbyProvider extends ChangeNotifier {
   }
   
   // 连接到Emby服务器
-  Future<bool> connectToServer(String serverUrl, String username, String password) async {
+  Future<bool> connectToServer(String serverUrl, String username, String password, {String? addressName}) async {
     _isLoading = true;
     _hasError = false;
     _errorMessage = null;
     _notifyCoalesced();
     
     try {
-      final success = await _embyService.connect(serverUrl, username, password);
+      final success = await _embyService.connect(serverUrl, username, password, addressName: addressName);
       
       if (success) {
         await loadMediaItems();

--- a/lib/providers/jellyfin_provider.dart
+++ b/lib/providers/jellyfin_provider.dart
@@ -145,14 +145,17 @@ class JellyfinProvider extends ChangeNotifier {
   /// 连接状态变化回调
   void _onConnectionStateChanged(bool isConnected) {
     print('JellyfinProvider: 连接状态变化 - isConnected: $isConnected');
+    
+    // 连接状态变化需要立即通知UI，不能延迟
+    // 这样可以确保媒体库标签页能及时显示/隐藏
+    notifyListeners();
+    
     if (isConnected) {
       print('JellyfinProvider: Jellyfin已连接，开始加载媒体项目...');
       // 异步加载媒体项目，不阻塞UI
       loadMediaItems();
       loadMovieItems();
     }
-  // 连接状态变化可能伴随后续的媒体加载通知，这里合并通知，避免短时间多次刷新
-  _notifyCoalesced();
   }
   
   // 加载Jellyfin媒体项

--- a/lib/providers/jellyfin_provider.dart
+++ b/lib/providers/jellyfin_provider.dart
@@ -197,14 +197,14 @@ class JellyfinProvider extends ChangeNotifier {
   }
   
   // 连接到Jellyfin服务器
-  Future<bool> connectToServer(String serverUrl, String username, String password) async {
+  Future<bool> connectToServer(String serverUrl, String username, String password, {String? addressName}) async {
     _isLoading = true;
     _hasError = false;
     _errorMessage = null;
     _notifyCoalesced();
     
     try {
-      final success = await _jellyfinService.connect(serverUrl, username, password);
+      final success = await _jellyfinService.connect(serverUrl, username, password, addressName: addressName);
       
       if (success) {
         await loadMediaItems();

--- a/lib/services/emby_episode_mapping_service.dart
+++ b/lib/services/emby_episode_mapping_service.dart
@@ -895,4 +895,28 @@ class EmbyEpisodeMappingService {
 
     debugPrint('[Emby映射服务] 导入完成: ${animeMappings.length}个动画映射, ${episodeMappings.length}个剧集映射');
   }
+
+  /// 清除所有映射数据
+  Future<void> clearAllMappings() async {
+    await initialize();
+
+    debugPrint('[Emby映射服务] 清除所有映射数据');
+
+    try {
+      // 先删除所有剧集映射
+      await _database!.delete('emby_episode_mapping');
+      
+      // 再删除所有动画映射
+      await _database!.delete('emby_dandanplay_mapping');
+      
+      // 清理缓存
+      _animeMappingCache.clear();
+      _episodePredictionCache.clear();
+      
+      debugPrint('[Emby映射服务] 所有映射数据清除完成');
+    } catch (e) {
+      debugPrint('[Emby映射服务] 清除映射数据失败: $e');
+      rethrow;
+    }
+  }
 } 

--- a/lib/services/emby_service.dart
+++ b/lib/services/emby_service.dart
@@ -252,10 +252,12 @@ class EmbyService {
         _currentAddressId = connectionResult.successfulAddressId;
         _username = username;
         _password = password;
-        _isConnected = true;
         
         // 执行完整的认证流程
         await _performAuthentication(_serverUrl!, username, password);
+        
+        // 只有在认证成功后才设置连接状态为true
+        _isConnected = true;
         
         // 更新配置中的认证信息
         _currentProfile = _currentProfile!.copyWith(

--- a/lib/services/emby_service.dart
+++ b/lib/services/emby_service.dart
@@ -4,9 +4,12 @@ import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:nipaplay/models/emby_model.dart';
+import 'package:nipaplay/models/server_profile_model.dart';
+import 'package:nipaplay/services/multi_address_server_service.dart';
 import 'package:path_provider/path_provider.dart' if (dart.library.html) 'package:nipaplay/utils/mock_path_provider.dart';
 import 'dart:io' if (dart.library.io) 'dart:io';
 import 'package:package_info_plus/package_info_plus.dart';
+import 'debug_log_service.dart';
 
 class EmbyService {
   static final EmbyService instance = EmbyService._internal();
@@ -21,6 +24,11 @@ class EmbyService {
   bool _isConnected = false;
   List<EmbyLibrary> _availableLibraries = [];
   List<String> _selectedLibraryIds = [];
+  
+  // 多地址支持
+  ServerProfile? _currentProfile;
+  String? _currentAddressId;
+  final MultiAddressServerService _multiAddressService = MultiAddressServerService.instance;
 
   // Client information cache
   String? _cachedClientInfo;
@@ -70,12 +78,42 @@ class EmbyService {
       _isConnected = false;
       return;
     }
+    
+    // 初始化多地址服务
+    await _multiAddressService.initialize();
+    
     final prefs = await SharedPreferences.getInstance();
     
-    _serverUrl = prefs.getString('emby_server_url');
-    _username = prefs.getString('emby_username');
-    _accessToken = prefs.getString('emby_access_token');
-    _userId = prefs.getString('emby_user_id');
+    // 尝试加载当前配置
+    final profileId = prefs.getString('emby_current_profile_id');
+    if (profileId != null) {
+      try {
+        _currentProfile = _multiAddressService.getProfileById(profileId);
+        if (_currentProfile != null) {
+          _username = _currentProfile!.username;
+          _accessToken = _currentProfile!.accessToken;
+          _userId = _currentProfile!.userId;
+          
+          // 使用当前地址
+          final currentAddress = _currentProfile!.currentAddress;
+          if (currentAddress != null) {
+            _serverUrl = currentAddress.normalizedUrl;
+            _currentAddressId = currentAddress.id;
+          }
+        }
+      } catch (e) {
+        DebugLogService().addLog('Emby: 加载配置失败: $e');
+      }
+    }
+    
+    // 兼容旧版本存储
+    if (_currentProfile == null) {
+      _serverUrl = prefs.getString('emby_server_url');
+      _username = prefs.getString('emby_username');
+      _accessToken = prefs.getString('emby_access_token');
+      _userId = prefs.getString('emby_user_id');
+    }
+    
     _selectedLibraryIds = prefs.getStringList('emby_selected_libraries') ?? [];
     
     print('Emby loadSavedSettings: serverUrl=$_serverUrl, username=$_username, hasToken=${_accessToken != null}, userId=$_userId');
@@ -141,62 +179,88 @@ class EmbyService {
   }
   
   Future<bool> connect(String serverUrl, String username, String password) async {
-    // 确保URL格式正确
-    if (!serverUrl.startsWith('http://') && !serverUrl.startsWith('https://')) {
-      serverUrl = 'http://$serverUrl';
-    }
+    // 初始化多地址服务
+    await _multiAddressService.initialize();
     
-    // 移除末尾的斜杠
-    if (serverUrl.endsWith('/')) {
-      serverUrl = serverUrl.substring(0, serverUrl.length - 1);
-    }
-    
-    _serverUrl = serverUrl;
-    _username = username;
-    _password = password;
+    // 规范化URL
+    final normalizedUrl = _normalizeUrl(serverUrl);
     
     try {
-      // 获取客户端配置
-      final configResponse = await http.get(
-        Uri.parse('$_serverUrl/emby/System/Info/Public'),
+      // 先识别服务器
+      final identifyResult = await _multiAddressService.identifyServer(
+        url: normalizedUrl,
+        serverType: 'emby',
+        getServerId: _getEmbyServerId,
       );
       
-      if (configResponse.statusCode != 200) {
-        throw Exception('服务器返回错误: ${configResponse.statusCode} ${configResponse.reasonPhrase ?? ''}\n${configResponse.body}');
+      ServerProfile? profile;
+      
+      if (identifyResult.success && identifyResult.existingProfile != null) {
+        // 服务器已存在，添加新地址或使用现有地址
+        profile = identifyResult.existingProfile!;
+        
+        // 检查是否需要添加新地址
+        final hasAddress = profile.addresses.any(
+          (addr) => addr.normalizedUrl == normalizedUrl,
+        );
+        
+        if (!hasAddress) {
+          profile = await _multiAddressService.addAddressToProfile(
+            profileId: profile.id,
+            url: normalizedUrl,
+            name: _generateAddressName(normalizedUrl),
+          );
+        }
+      } else {
+        // 创建新配置
+        profile = await _multiAddressService.addProfile(
+          serverName: await _getServerName(normalizedUrl) ?? 'Emby服务器',
+          serverType: 'emby',
+          url: normalizedUrl,
+          username: username,
+          addressName: _generateAddressName(normalizedUrl),
+        );
       }
       
-      // 认证用户
-      final clientInfo = await _getClientInfo();
-      final authResponse = await http.post(
-        Uri.parse('$_serverUrl/emby/Users/AuthenticateByName'),
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Emby-Authorization': clientInfo,
-        },
-        body: json.encode({
-          'Username': username,
-          'Pw': password,
-        }),
+      if (profile == null) {
+        throw Exception('无法创建服务器配置');
+      }
+      
+      // 使用多地址尝试连接
+      final connectionResult = await _multiAddressService.tryConnect(
+        profile: profile,
+        testConnection: (url) => _testEmbyConnection(url, username, password),
       );
       
-      if (authResponse.statusCode != 200) {
-        throw Exception('服务器返回错误: ${authResponse.statusCode} ${authResponse.reasonPhrase ?? ''}\n${authResponse.body}');
+      if (connectionResult.success && connectionResult.profile != null) {
+        _currentProfile = connectionResult.profile;
+        _serverUrl = connectionResult.successfulUrl;
+        _currentAddressId = connectionResult.successfulAddressId;
+        _username = username;
+        _password = password;
+        _isConnected = true;
+        
+        // 执行完整的认证流程
+        await _performAuthentication(_serverUrl!, username, password);
+        
+        // 更新配置中的认证信息
+        _currentProfile = _currentProfile!.copyWith(
+          accessToken: _accessToken,
+          userId: _userId,
+        );
+        await _multiAddressService.updateProfile(_currentProfile!);
+        
+        // 保存连接信息
+        await _saveConnectionInfo();
+        print('Emby: 连接信息已保存到SharedPreferences');
+        
+        // 加载可用媒体库
+        await loadAvailableLibraries();
+        
+        return true;
+      } else {
+        throw Exception(connectionResult.error ?? '连接失败');
       }
-      
-      final authData = json.decode(authResponse.body);
-      _accessToken = authData['AccessToken'];
-      _userId = authData['User']['Id'];
-      
-      _isConnected = true;
-      
-      // 保存连接信息
-      await _saveConnectionInfo();
-      print('Emby: 连接信息已保存到SharedPreferences');
-      
-      // 加载可用媒体库
-      await loadAvailableLibraries();
-      
-      return true;
     } catch (e) {
       print('Emby 连接失败: $e');
       _isConnected = false;
@@ -204,8 +268,110 @@ class EmbyService {
     }
   }
   
+  /// 测试Emby连接
+  Future<bool> _testEmbyConnection(String url, String username, String password) async {
+    try {
+      // 获取服务器信息
+      final configResponse = await http.get(
+        Uri.parse('$url/emby/System/Info/Public'),
+      ).timeout(const Duration(seconds: 5));
+      
+      return configResponse.statusCode == 200;
+    } catch (e) {
+      return false;
+    }
+  }
+  
+  /// 执行完整的认证流程
+  Future<void> _performAuthentication(String serverUrl, String username, String password) async {
+    final clientInfo = await _getClientInfo();
+    final authResponse = await http.post(
+      Uri.parse('$serverUrl/emby/Users/AuthenticateByName'),
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Emby-Authorization': clientInfo,
+      },
+      body: json.encode({
+        'Username': username,
+        'Pw': password,
+      }),
+    );
+    
+    if (authResponse.statusCode != 200) {
+      throw Exception('认证失败: ${authResponse.statusCode}');
+    }
+    
+    final authData = json.decode(authResponse.body);
+    _accessToken = authData['AccessToken'];
+    _userId = authData['User']['Id'];
+  }
+  
+  /// 获取Emby服务器ID
+  Future<String?> _getEmbyServerId(String url) async {
+    try {
+      final response = await http.get(
+        Uri.parse('$url/emby/System/Info/Public'),
+      ).timeout(const Duration(seconds: 5));
+      
+      if (response.statusCode == 200) {
+        final data = json.decode(response.body);
+        return data['Id'] ?? data['ServerId'];
+      }
+    } catch (e) {
+      DebugLogService().addLog('获取Emby服务器ID失败: $e');
+    }
+    return null;
+  }
+  
+  /// 获取服务器名称
+  Future<String?> _getServerName(String url) async {
+    try {
+      final response = await http.get(
+        Uri.parse('$url/emby/System/Info/Public'),
+      ).timeout(const Duration(seconds: 5));
+      
+      if (response.statusCode == 200) {
+        final data = json.decode(response.body);
+        return data['ServerName'];
+      }
+    } catch (e) {
+      DebugLogService().addLog('获取Emby服务器名称失败: $e');
+    }
+    return null;
+  }
+  
+  /// 根据URL生成地址名称
+  String _generateAddressName(String url) {
+    if (url.contains('192.168') || url.contains('10.') || url.contains('172.')) {
+      return '局域网';
+    } else if (url.contains('localhost') || url.contains('127.0.0.1')) {
+      return '本地';
+    } else {
+      return '公网';
+    }
+  }
+  
+  /// 规范化URL
+  String _normalizeUrl(String url) {
+    String normalized = url.trim();
+    if (!normalized.startsWith('http://') && !normalized.startsWith('https://')) {
+      normalized = 'http://$normalized';
+    }
+    if (normalized.endsWith('/')) {
+      normalized = normalized.substring(0, normalized.length - 1);
+    }
+    return normalized;
+  }
+  
   Future<void> _saveConnectionInfo() async {
     final prefs = await SharedPreferences.getInstance();
+    
+    // 保存当前配置ID
+    if (_currentProfile != null) {
+      await prefs.setString('emby_current_profile_id', _currentProfile!.id);
+    }
+    
+    // 兼容旧版本，同时保存单地址信息
     await prefs.setString('emby_server_url', _serverUrl!);
     await prefs.setString('emby_username', _username!);
     await prefs.setString('emby_access_token', _accessToken!);
@@ -216,12 +382,15 @@ class EmbyService {
   
   Future<void> disconnect() async {
     final prefs = await SharedPreferences.getInstance();
+    await prefs.remove('emby_current_profile_id');
     await prefs.remove('emby_server_url');
     await prefs.remove('emby_username');
     await prefs.remove('emby_access_token');
     await prefs.remove('emby_user_id');
     await prefs.remove('emby_selected_libraries');
     
+    _currentProfile = null;
+    _currentAddressId = null;
     _serverUrl = null;
     _username = null;
     _password = null;
@@ -237,6 +406,12 @@ class EmbyService {
       throw Exception('未连接到 Emby 服务器');
     }
     
+    // 如果有多地址配置，尝试使用多地址重试机制
+    if (_currentProfile != null) {
+      return await _makeAuthenticatedRequestWithRetry(path, method: method, body: body, timeout: timeout);
+    }
+    
+    // 单地址模式（兼容旧版本）
     final uri = Uri.parse('$_serverUrl$path');
     final clientInfo = await _getClientInfo();
     final authHeader = clientInfo + ', Token="$_accessToken"';
@@ -278,14 +453,80 @@ class EmbyService {
     return response;
   }
   
-  // 专门用于需要验证连接状态的请求方法
-  Future<http.Response> _makeVerifiedAuthenticatedRequest(String path, {String method = 'GET', Map<String, dynamic>? body}) async {
-    if (!_isConnected || _accessToken == null) {
+  /// 带重试的认证请求（多地址支持）
+  Future<http.Response> _makeAuthenticatedRequestWithRetry(String path, {String method = 'GET', Map<String, dynamic>? body, Duration? timeout}) async {
+    if (_currentProfile == null || _accessToken == null) {
       throw Exception('未连接到 Emby 服务器');
     }
     
-    return _makeAuthenticatedRequest(path, method: method, body: body);
+    final addresses = _currentProfile!.enabledAddresses;
+    if (addresses.isEmpty) {
+      throw Exception('没有可用的服务器地址');
+    }
+    
+    final clientInfo = await _getClientInfo();
+    final authHeader = clientInfo + ', Token="$_accessToken"';
+    final headers = {
+      'Content-Type': 'application/json',
+      'X-Emby-Authorization': authHeader,
+    };
+    
+    final requestTimeout = timeout ?? const Duration(seconds: 10);
+    
+    Exception? lastError;
+    
+    // 尝试每个地址
+    for (final address in addresses) {
+      if (!address.shouldRetry()) continue;
+      
+      final uri = Uri.parse('${address.normalizedUrl}$path');
+      
+      try {
+        http.Response response;
+        switch (method.toUpperCase()) {
+          case 'GET':
+            response = await http.get(uri, headers: headers).timeout(requestTimeout);
+            break;
+          case 'POST':
+            response = await http.post(uri, headers: headers, body: body != null ? json.encode(body) : null).timeout(requestTimeout);
+            break;
+          case 'PUT':
+            response = await http.put(uri, headers: headers, body: body != null ? json.encode(body) : null).timeout(requestTimeout);
+            break;
+          case 'DELETE':
+            response = await http.delete(uri, headers: headers).timeout(requestTimeout);
+            break;
+          default:
+            throw Exception('不支持的 HTTP 方法: $method');
+        }
+        
+        if (response.statusCode < 400) {
+          // 成功，更新当前使用的地址
+          if (_currentAddressId != address.id) {
+            _serverUrl = address.normalizedUrl;
+            _currentAddressId = address.id;
+            _currentProfile = _currentProfile!.markAddressSuccess(address.id);
+            await _multiAddressService.updateProfile(_currentProfile!);
+          }
+          return response;
+        } else {
+          lastError = Exception('服务器返回错误: ${response.statusCode}');
+        }
+      } on TimeoutException catch (e) {
+        lastError = Exception('请求超时: ${e.message}');
+        _currentProfile = _currentProfile!.markAddressFailed(address.id);
+      } catch (e) {
+        lastError = Exception('请求失败: $e');
+        _currentProfile = _currentProfile!.markAddressFailed(address.id);
+      }
+    }
+    
+    // 更新失败信息
+    await _multiAddressService.updateProfile(_currentProfile!);
+    
+    throw lastError ?? Exception('所有地址连接失败');
   }
+
   
   Future<void> loadAvailableLibraries() async {
     if (kIsWeb || !_isConnected || _userId == null) return;
@@ -984,6 +1225,104 @@ class EmbyService {
       print('Stack trace: $stackTrace');
       return [];
     }
+  }
+
+  /// 获取当前服务器的所有地址
+  List<ServerAddress> getServerAddresses() {
+    if (_currentProfile != null) {
+      return _currentProfile!.addresses;
+    }
+    return [];
+  }
+  
+  /// 添加新地址到当前服务器
+  Future<bool> addServerAddress(String url, String name) async {
+    if (_currentProfile == null) return false;
+    
+    try {
+      final updatedProfile = await _multiAddressService.addAddressToProfile(
+        profileId: _currentProfile!.id,
+        url: url,
+        name: name,
+      );
+      
+      if (updatedProfile != null) {
+        _currentProfile = updatedProfile;
+        return true;
+      }
+    } catch (e) {
+      DebugLogService().addLog('添加服务器地址失败: $e');
+    }
+    return false;
+  }
+  
+  /// 删除服务器地址
+  Future<bool> removeServerAddress(String addressId) async {
+    if (_currentProfile == null) return false;
+    
+    try {
+      final updatedProfile = await _multiAddressService.deleteAddressFromProfile(
+        profileId: _currentProfile!.id,
+        addressId: addressId,
+      );
+      
+      if (updatedProfile != null) {
+        _currentProfile = updatedProfile;
+        return true;
+      }
+    } catch (e) {
+      DebugLogService().addLog('删除服务器地址失败: $e');
+    }
+    return false;
+  }
+  
+  /// 切换服务器地址
+  Future<bool> switchToAddress(String addressId) async {
+    if (_currentProfile == null) return false;
+    
+    final address = _currentProfile!.addresses.firstWhere(
+      (addr) => addr.id == addressId,
+      orElse: () => throw Exception('地址不存在'),
+    );
+    
+    // 测试连接
+    final success = await _testEmbyConnection(
+      address.normalizedUrl,
+      _username ?? '',
+      _password ?? '',
+    );
+    
+    if (success) {
+      _serverUrl = address.normalizedUrl;
+      _currentAddressId = address.id;
+      _currentProfile = _currentProfile!.markAddressSuccess(address.id);
+      await _multiAddressService.updateProfile(_currentProfile!);
+      return true;
+    }
+    
+    return false;
+  }
+
+  /// 更新服务器地址优先级
+  Future<bool> updateServerPriority(String addressId, int priority) async {
+    if (_currentProfile == null) return false;
+    
+    try {
+      final updatedProfile = await _multiAddressService.updateAddressPriority(
+        profileId: _currentProfile!.id,
+        addressId: addressId,
+        priority: priority,
+      );
+      
+      if (updatedProfile != null) {
+        _currentProfile = updatedProfile;
+        return true;
+      }
+    } catch (e) {
+      DebugLogService().addLog('EmbyService: 更新地址优先级失败: $e');
+    }
+    
+    return false;
   }
 
   /// 下载Emby外挂字幕文件

--- a/lib/services/jellyfin_service.dart
+++ b/lib/services/jellyfin_service.dart
@@ -250,10 +250,12 @@ class JellyfinService {
         _currentAddressId = connectionResult.successfulAddressId;
         _username = username;
         _password = password;
-        _isConnected = true;
         
         // 执行完整的认证流程
         await _performAuthentication(_serverUrl!, username, password);
+        
+        // 只有在认证成功后才设置连接状态为true
+        _isConnected = true;
         
         // 更新配置中的认证信息
         _currentProfile = _currentProfile!.copyWith(

--- a/lib/services/jellyfin_service.dart
+++ b/lib/services/jellyfin_service.dart
@@ -208,16 +208,28 @@ class JellyfinService {
             url: normalizedUrl,
             name: _generateAddressName(normalizedUrl),
           );
+        } else {
+          print('JellyfinService: 地址已存在，使用现有配置');
         }
-      } else {
-        // 创建新配置
+      } else if (identifyResult.isConflict) {
+        // 检测到冲突：URL相同但serverId不同
+        print('JellyfinService: 检测到冲突，抛出异常: ${identifyResult.error}');
+        throw Exception(identifyResult.error ?? '服务器冲突');
+      } else if (identifyResult.success) {
+        // 服务器识别成功但没有现有配置，创建新配置
+        print('JellyfinService: 创建新的服务器配置');
         profile = await _multiAddressService.addProfile(
           serverName: await _getServerName(normalizedUrl) ?? 'Jellyfin服务器',
           serverType: 'jellyfin',
           url: normalizedUrl,
           username: username,
+          serverId: identifyResult.serverId,
           addressName: _generateAddressName(normalizedUrl),
         );
+      } else {
+        // 服务器识别失败
+        print('JellyfinService: 服务器识别失败: ${identifyResult.error}');
+        throw Exception(identifyResult.error ?? '无法识别Jellyfin服务器');
       }
       
       if (profile == null) {
@@ -261,7 +273,14 @@ class JellyfinService {
         throw Exception(connectionResult.error ?? '连接失败');
       }
     } catch (e) {
+      print('JellyfinService: 连接过程中发生异常: $e');
       _isConnected = false;
+      
+      // 如果是服务器冲突错误，直接传递原始错误信息
+      if (e.toString().contains('已被另一个') || e.toString().contains('已被占用')) {
+        throw Exception(e.toString());
+      }
+      
       throw Exception('连接Jellyfin服务器失败: $e');
     }
   }
@@ -1254,19 +1273,45 @@ class JellyfinService {
   Future<bool> addServerAddress(String url, String name) async {
     if (_currentProfile == null) return false;
     
+    final normalizedUrl = _normalizeUrl(url);
+    
     try {
+      // 先验证这是否为同一台服务器
+      final identifyResult = await _multiAddressService.identifyServer(
+        url: normalizedUrl,
+        serverType: 'jellyfin',
+        getServerId: _getJellyfinServerId,
+      );
+      
+      if (!identifyResult.success) {
+        DebugLogService().addLog('添加地址失败: ${identifyResult.error}');
+        throw Exception(identifyResult.error ?? '无法验证服务器身份');
+      }
+      
+      if (identifyResult.isConflict) {
+        DebugLogService().addLog('添加地址失败: ${identifyResult.error}');
+        throw Exception(identifyResult.error ?? '服务器冲突');
+      }
+      
+      // 验证serverId是否匹配
+      if (identifyResult.serverId != _currentProfile!.serverId) {
+        throw Exception('该地址属于不同的Jellyfin服务器（服务器ID: ${identifyResult.serverId}），无法添加到当前配置');
+      }
+      
       final updatedProfile = await _multiAddressService.addAddressToProfile(
         profileId: _currentProfile!.id,
-        url: url,
+        url: normalizedUrl,
         name: name,
       );
       
       if (updatedProfile != null) {
         _currentProfile = updatedProfile;
+        DebugLogService().addLog('成功添加新地址: $normalizedUrl');
         return true;
       }
     } catch (e) {
       DebugLogService().addLog('添加服务器地址失败: $e');
+      rethrow; // 重新抛出异常以便UI处理
     }
     return false;
   }

--- a/lib/services/jellyfin_service.dart
+++ b/lib/services/jellyfin_service.dart
@@ -5,9 +5,12 @@ import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:nipaplay/models/jellyfin_model.dart';
+import 'package:nipaplay/models/server_profile_model.dart';
+import 'package:nipaplay/services/multi_address_server_service.dart';
 import 'package:path_provider/path_provider.dart' if (dart.library.html) 'package:nipaplay/utils/mock_path_provider.dart';
 import 'dart:io' if (dart.library.io) 'dart:io';
 import 'package:package_info_plus/package_info_plus.dart';
+import 'debug_log_service.dart';
 
 class JellyfinService {
   static final JellyfinService instance = JellyfinService._internal();
@@ -22,6 +25,11 @@ class JellyfinService {
   bool _isConnected = false;
   List<JellyfinLibrary> _availableLibraries = [];
   List<String> _selectedLibraryIds = [];
+  
+  // 多地址支持
+  ServerProfile? _currentProfile;
+  String? _currentAddressId;
+  final MultiAddressServerService _multiAddressService = MultiAddressServerService.instance;
 
   // Client information cache
   String? _cachedClientInfo;
@@ -71,12 +79,42 @@ class JellyfinService {
       _isConnected = false;
       return;
     }
+    
+    // 初始化多地址服务
+    await _multiAddressService.initialize();
+    
     final prefs = await SharedPreferences.getInstance();
     
-    _serverUrl = prefs.getString('jellyfin_server_url');
-    _username = prefs.getString('jellyfin_username');
-    _accessToken = prefs.getString('jellyfin_access_token');
-    _userId = prefs.getString('jellyfin_user_id');
+    // 尝试加载当前配置
+    final profileId = prefs.getString('jellyfin_current_profile_id');
+    if (profileId != null) {
+      try {
+        _currentProfile = _multiAddressService.getProfileById(profileId);
+        if (_currentProfile != null) {
+          _username = _currentProfile!.username;
+          _accessToken = _currentProfile!.accessToken;
+          _userId = _currentProfile!.userId;
+          
+          // 使用当前地址
+          final currentAddress = _currentProfile!.currentAddress;
+          if (currentAddress != null) {
+            _serverUrl = currentAddress.normalizedUrl;
+            _currentAddressId = currentAddress.id;
+          }
+        }
+      } catch (e) {
+        DebugLogService().addLog('Jellyfin: 加载配置失败: $e');
+      }
+    }
+    
+    // 兼容旧版本存储
+    if (_currentProfile == null) {
+      _serverUrl = prefs.getString('jellyfin_server_url');
+      _username = prefs.getString('jellyfin_username');
+      _accessToken = prefs.getString('jellyfin_access_token');
+      _userId = prefs.getString('jellyfin_user_id');
+    }
+    
     _selectedLibraryIds = prefs.getStringList('jellyfin_selected_libraries') ?? [];
     
     if (_serverUrl != null && _accessToken != null && _userId != null) {
@@ -139,76 +177,210 @@ class JellyfinService {
   }
   
   Future<bool> connect(String serverUrl, String username, String password) async {
-    // 确保URL格式正确
-    if (!serverUrl.startsWith('http://') && !serverUrl.startsWith('https://')) {
-      serverUrl = 'http://$serverUrl';
-    }
+    // 初始化多地址服务
+    await _multiAddressService.initialize();
     
-    // 移除末尾的斜杠
-    if (serverUrl.endsWith('/')) {
-      serverUrl = serverUrl.substring(0, serverUrl.length - 1);
-    }
-    
-    _serverUrl = serverUrl;
-    _username = username;
-    _password = password;
+    // 规范化URL
+    final normalizedUrl = _normalizeUrl(serverUrl);
     
     try {
-      // 获取客户端配置
-      final configResponse = await http.get(
-        Uri.parse('$_serverUrl/System/Info/Public'),
+      // 先识别服务器
+      final identifyResult = await _multiAddressService.identifyServer(
+        url: normalizedUrl,
+        serverType: 'jellyfin',
+        getServerId: _getJellyfinServerId,
       );
       
-      if (configResponse.statusCode != 200) {
-        throw Exception('服务器返回错误: ${configResponse.statusCode} ${configResponse.reasonPhrase ?? ''}\n${configResponse.body}');
+      ServerProfile? profile;
+      
+      if (identifyResult.success && identifyResult.existingProfile != null) {
+        // 服务器已存在，添加新地址或使用现有地址
+        profile = identifyResult.existingProfile!;
+        
+        // 检查是否需要添加新地址
+        final hasAddress = profile.addresses.any(
+          (addr) => addr.normalizedUrl == normalizedUrl,
+        );
+        
+        if (!hasAddress) {
+          profile = await _multiAddressService.addAddressToProfile(
+            profileId: profile.id,
+            url: normalizedUrl,
+            name: _generateAddressName(normalizedUrl),
+          );
+        }
+      } else {
+        // 创建新配置
+        profile = await _multiAddressService.addProfile(
+          serverName: await _getServerName(normalizedUrl) ?? 'Jellyfin服务器',
+          serverType: 'jellyfin',
+          url: normalizedUrl,
+          username: username,
+          addressName: _generateAddressName(normalizedUrl),
+        );
       }
       
-      // 认证用户
-      final clientInfo = await _getClientInfo();
-      final authResponse = await http.post(
-        Uri.parse('$_serverUrl/Users/AuthenticateByName'),
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Emby-Authorization': clientInfo,
-        },
-        body: json.encode({
-          'Username': username,
-          'Pw': password,
-        }),
+      if (profile == null) {
+        throw Exception('无法创建服务器配置');
+      }
+      
+      // 使用多地址尝试连接
+      final connectionResult = await _multiAddressService.tryConnect(
+        profile: profile,
+        testConnection: (url) => _testJellyfinConnection(url, username, password),
       );
       
-      if (authResponse.statusCode != 200) {
-        throw Exception('服务器返回错误: ${authResponse.statusCode} ${authResponse.reasonPhrase ?? ''}\n${authResponse.body}');
+      if (connectionResult.success && connectionResult.profile != null) {
+        _currentProfile = connectionResult.profile;
+        _serverUrl = connectionResult.successfulUrl;
+        _currentAddressId = connectionResult.successfulAddressId;
+        _username = username;
+        _password = password;
+        _isConnected = true;
+        
+        // 执行完整的认证流程
+        await _performAuthentication(_serverUrl!, username, password);
+        
+        // 更新配置中的认证信息
+        _currentProfile = _currentProfile!.copyWith(
+          accessToken: _accessToken,
+          userId: _userId,
+        );
+        await _multiAddressService.updateProfile(_currentProfile!);
+        
+        // 保存连接信息
+        await _saveConnectionInfo();
+        
+        // 获取可用的媒体库列表
+        if (!kIsWeb) {
+          await loadAvailableLibraries();
+        }
+        
+        return true;
+      } else {
+        throw Exception(connectionResult.error ?? '连接失败');
       }
-      
-      final authData = json.decode(authResponse.body);
-      _accessToken = authData['AccessToken'];
-      _userId = authData['User']['Id'];
-      
-      // 保存设置到SharedPreferences
-      final prefs = await SharedPreferences.getInstance();
-      await prefs.setString('jellyfin_server_url', _serverUrl!);
-      await prefs.setString('jellyfin_username', _username!);
-      await prefs.setString('jellyfin_access_token', _accessToken!);
-      await prefs.setString('jellyfin_user_id', _userId!);
-      
-      _isConnected = true;
-      
-      // 获取可用的媒体库列表
-      if (!kIsWeb) {
-        await loadAvailableLibraries();
-      }
-      
-      return true;
     } catch (e) {
       _isConnected = false;
-      // 直接抛出异常，Provider会捕获并展示message
       throw Exception('连接Jellyfin服务器失败: $e');
     }
   }
   
+  /// 测试Jellyfin连接
+  Future<bool> _testJellyfinConnection(String url, String username, String password) async {
+    try {
+      // 获取服务器信息
+      final configResponse = await http.get(
+        Uri.parse('$url/System/Info/Public'),
+      ).timeout(const Duration(seconds: 5));
+      
+      return configResponse.statusCode == 200;
+    } catch (e) {
+      return false;
+    }
+  }
+  
+  /// 执行完整的认证流程
+  Future<void> _performAuthentication(String serverUrl, String username, String password) async {
+    final clientInfo = await _getClientInfo();
+    final authResponse = await http.post(
+      Uri.parse('$serverUrl/Users/AuthenticateByName'),
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Emby-Authorization': clientInfo,
+      },
+      body: json.encode({
+        'Username': username,
+        'Pw': password,
+      }),
+    );
+    
+    if (authResponse.statusCode != 200) {
+      throw Exception('认证失败: ${authResponse.statusCode}');
+    }
+    
+    final authData = json.decode(authResponse.body);
+    _accessToken = authData['AccessToken'];
+    _userId = authData['User']['Id'];
+  }
+  
+  /// 获取Jellyfin服务器ID
+  Future<String?> _getJellyfinServerId(String url) async {
+    try {
+      final response = await http.get(
+        Uri.parse('$url/System/Info/Public'),
+      ).timeout(const Duration(seconds: 5));
+      
+      if (response.statusCode == 200) {
+        final data = json.decode(response.body);
+        return data['Id'] ?? data['ServerId'];
+      }
+    } catch (e) {
+      DebugLogService().addLog('获取Jellyfin服务器ID失败: $e');
+    }
+    return null;
+  }
+  
+  /// 获取服务器名称
+  Future<String?> _getServerName(String url) async {
+    try {
+      final response = await http.get(
+        Uri.parse('$url/System/Info/Public'),
+      ).timeout(const Duration(seconds: 5));
+      
+      if (response.statusCode == 200) {
+        final data = json.decode(response.body);
+        return data['ServerName'];
+      }
+    } catch (e) {
+      DebugLogService().addLog('获取Jellyfin服务器名称失败: $e');
+    }
+    return null;
+  }
+  
+  /// 根据URL生成地址名称
+  String _generateAddressName(String url) {
+    if (url.contains('192.168') || url.contains('10.') || url.contains('172.')) {
+      return '局域网';
+    } else if (url.contains('localhost') || url.contains('127.0.0.1')) {
+      return '本地';
+    } else {
+      return '公网';
+    }
+  }
+  
+  /// 规范化URL
+  String _normalizeUrl(String url) {
+    String normalized = url.trim();
+    if (!normalized.startsWith('http://') && !normalized.startsWith('https://')) {
+      normalized = 'http://$normalized';
+    }
+    if (normalized.endsWith('/')) {
+      normalized = normalized.substring(0, normalized.length - 1);
+    }
+    return normalized;
+  }
+  
+  /// 保存连接信息
+  Future<void> _saveConnectionInfo() async {
+    final prefs = await SharedPreferences.getInstance();
+    
+    // 保存当前配置ID
+    if (_currentProfile != null) {
+      await prefs.setString('jellyfin_current_profile_id', _currentProfile!.id);
+    }
+    
+    // 兼容旧版本，同时保存单地址信息
+    await prefs.setString('jellyfin_server_url', _serverUrl!);
+    await prefs.setString('jellyfin_username', _username!);
+    await prefs.setString('jellyfin_access_token', _accessToken!);
+    await prefs.setString('jellyfin_user_id', _userId!);
+  }
+  
   Future<void> disconnect() async {
     _isConnected = false;
+    _currentProfile = null;
+    _currentAddressId = null;
     _serverUrl = null;
     _username = null;
     _password = null;
@@ -219,6 +391,7 @@ class JellyfinService {
     
     // 清除保存的设置
     final prefs = await SharedPreferences.getInstance();
+    await prefs.remove('jellyfin_current_profile_id');
     await prefs.remove('jellyfin_server_url');
     await prefs.remove('jellyfin_username');
     await prefs.remove('jellyfin_access_token');
@@ -933,7 +1106,17 @@ class JellyfinService {
   
   // 辅助方法：发送经过身份验证的HTTP请求
   Future<http.Response> _makeAuthenticatedRequest(String endpoint, {String method = 'GET', Map<String, dynamic>? body, Duration? timeout}) async {
-    if (_serverUrl == null || _accessToken == null) {
+    if (_accessToken == null) {
+      throw Exception('未连接到Jellyfin服务器');
+    }
+    
+    // 如果有多地址配置，尝试使用多地址重试机制
+    if (_currentProfile != null) {
+      return await _makeAuthenticatedRequestWithRetry(endpoint, method: method, body: body, timeout: timeout);
+    }
+    
+    // 单地址模式（兼容旧版本）
+    if (_serverUrl == null) {
       throw Exception('未连接到Jellyfin服务器');
     }
     
@@ -980,5 +1163,180 @@ class JellyfinService {
       throw Exception('服务器返回错误: ${response.statusCode} ${response.reasonPhrase ?? ''}\n${response.body}');
     }
     return response;
+  }
+  
+  /// 带重试的认证请求（多地址支持）
+  Future<http.Response> _makeAuthenticatedRequestWithRetry(String endpoint, {String method = 'GET', Map<String, dynamic>? body, Duration? timeout}) async {
+    if (_currentProfile == null || _accessToken == null) {
+      throw Exception('未连接到 Jellyfin 服务器');
+    }
+    
+    final addresses = _currentProfile!.enabledAddresses;
+    if (addresses.isEmpty) {
+      throw Exception('没有可用的服务器地址');
+    }
+    
+    final clientInfo = await _getClientInfo();
+    final authHeader = clientInfo + ', Token="$_accessToken"';
+    final Map<String, String> headers = {
+      'X-Emby-Authorization': authHeader,
+    };
+    
+    if (body != null) {
+      headers['Content-Type'] = 'application/json';
+    }
+    
+    final requestTimeout = timeout ?? const Duration(seconds: 10);
+    
+    Exception? lastError;
+    
+    // 尝试每个地址
+    for (final address in addresses) {
+      if (!address.shouldRetry()) continue;
+      
+      final Uri uri = Uri.parse('${address.normalizedUrl}$endpoint');
+      
+      try {
+        http.Response response;
+        switch (method.toUpperCase()) {
+          case 'GET':
+            response = await http.get(uri, headers: headers).timeout(requestTimeout);
+            break;
+          case 'POST':
+            response = await http.post(uri, headers: headers, body: body != null ? json.encode(body) : null).timeout(requestTimeout);
+            break;
+          case 'PUT':
+            response = await http.put(uri, headers: headers, body: body != null ? json.encode(body) : null).timeout(requestTimeout);
+            break;
+          case 'DELETE':
+            response = await http.delete(uri, headers: headers).timeout(requestTimeout);
+            break;
+          default:
+            throw Exception('不支持的 HTTP 方法: $method');
+        }
+        
+        if (response.statusCode < 400) {
+          // 成功，更新当前使用的地址
+          if (_currentAddressId != address.id) {
+            _serverUrl = address.normalizedUrl;
+            _currentAddressId = address.id;
+            _currentProfile = _currentProfile!.markAddressSuccess(address.id);
+            await _multiAddressService.updateProfile(_currentProfile!);
+          }
+          return response;
+        } else {
+          lastError = Exception('服务器返回错误: ${response.statusCode}');
+        }
+      } on TimeoutException catch (e) {
+        lastError = Exception('请求超时: ${e.message}');
+        _currentProfile = _currentProfile!.markAddressFailed(address.id);
+      } catch (e) {
+        lastError = Exception('请求失败: $e');
+        _currentProfile = _currentProfile!.markAddressFailed(address.id);
+      }
+    }
+    
+    // 更新失败信息
+    await _multiAddressService.updateProfile(_currentProfile!);
+    
+    throw lastError ?? Exception('所有地址连接失败');
+  }
+  
+  /// 获取当前服务器的所有地址
+  List<ServerAddress> getServerAddresses() {
+    if (_currentProfile != null) {
+      return _currentProfile!.addresses;
+    }
+    return [];
+  }
+  
+  /// 添加新地址到当前服务器
+  Future<bool> addServerAddress(String url, String name) async {
+    if (_currentProfile == null) return false;
+    
+    try {
+      final updatedProfile = await _multiAddressService.addAddressToProfile(
+        profileId: _currentProfile!.id,
+        url: url,
+        name: name,
+      );
+      
+      if (updatedProfile != null) {
+        _currentProfile = updatedProfile;
+        return true;
+      }
+    } catch (e) {
+      DebugLogService().addLog('添加服务器地址失败: $e');
+    }
+    return false;
+  }
+  
+  /// 删除服务器地址
+  Future<bool> removeServerAddress(String addressId) async {
+    if (_currentProfile == null) return false;
+    
+    try {
+      final updatedProfile = await _multiAddressService.deleteAddressFromProfile(
+        profileId: _currentProfile!.id,
+        addressId: addressId,
+      );
+      
+      if (updatedProfile != null) {
+        _currentProfile = updatedProfile;
+        return true;
+      }
+    } catch (e) {
+      DebugLogService().addLog('删除服务器地址失败: $e');
+    }
+    return false;
+  }
+  
+  /// 切换服务器地址
+  Future<bool> switchToAddress(String addressId) async {
+    if (_currentProfile == null) return false;
+    
+    final address = _currentProfile!.addresses.firstWhere(
+      (addr) => addr.id == addressId,
+      orElse: () => throw Exception('地址不存在'),
+    );
+    
+    // 测试连接
+    final success = await _testJellyfinConnection(
+      address.normalizedUrl,
+      _username ?? '',
+      _password ?? '',
+    );
+    
+    if (success) {
+      _serverUrl = address.normalizedUrl;
+      _currentAddressId = address.id;
+      _currentProfile = _currentProfile!.markAddressSuccess(address.id);
+      await _multiAddressService.updateProfile(_currentProfile!);
+      return true;
+    }
+    
+    return false;
+  }
+
+  /// 更新服务器地址优先级
+  Future<bool> updateServerPriority(String addressId, int priority) async {
+    if (_currentProfile == null) return false;
+    
+    try {
+      final updatedProfile = await _multiAddressService.updateAddressPriority(
+        profileId: _currentProfile!.id,
+        addressId: addressId,
+        priority: priority,
+      );
+      
+      if (updatedProfile != null) {
+        _currentProfile = updatedProfile;
+        return true;
+      }
+    } catch (e) {
+      DebugLogService().addLog('JellyfinService: 更新地址优先级失败: $e');
+    }
+    
+    return false;
   }
 }

--- a/lib/services/jellyfin_service.dart
+++ b/lib/services/jellyfin_service.dart
@@ -11,7 +11,7 @@ import 'package:path_provider/path_provider.dart' if (dart.library.html) 'packag
 import 'dart:io' if (dart.library.io) 'dart:io';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'debug_log_service.dart';
-import 'jellyfin_episode_mapping_service.dart';
+
 import 'package:nipaplay/utils/url_name_generator.dart';
 
 class JellyfinService {
@@ -423,14 +423,7 @@ class JellyfinService {
       }
     }
     
-    // 清除映射服务中的数据
-    try {
-      final jellyfinEpisodeMappingService = JellyfinEpisodeMappingService();
-      await jellyfinEpisodeMappingService.clearAllMappings();
-      DebugLogService().addLog('JellyfinService: 已清除所有Jellyfin映射数据');
-    } catch (e) {
-      DebugLogService().addLog('JellyfinService: 清除映射数据失败: $e');
-    }
+
     
     // TODO: 清除播放同步服务中的数据（待实现）
     // 当前 JellyfinPlaybackSyncService 没有清除所有数据的方法
@@ -1263,7 +1256,21 @@ class JellyfinService {
           }
           return response;
         } else {
-          lastError = Exception('服务器返回错误: ${response.statusCode}');
+          // 提供更详细的错误信息
+          String errorMessage;
+          if (response.statusCode == 401) {
+            errorMessage = '认证失败: 访问令牌无效或已过期 (HTTP 401)';
+          } else if (response.statusCode == 403) {
+            errorMessage = '访问被拒绝: 用户权限不足 (HTTP 403)';
+          } else if (response.statusCode == 404) {
+            errorMessage = '请求的资源未找到 (HTTP 404)';
+          } else if (response.statusCode >= 500) {
+            errorMessage = 'Jellyfin服务器内部错误 (HTTP ${response.statusCode})';
+          } else {
+            errorMessage = '服务器返回错误: HTTP ${response.statusCode} ${response.reasonPhrase ?? ''}';
+          }
+          lastError = Exception(errorMessage);
+          DebugLogService().addLog('JellyfinService: 请求失败 ${address.normalizedUrl}: $errorMessage');
         }
       } on TimeoutException catch (e) {
         lastError = Exception('请求超时: ${e.message}');
@@ -1372,11 +1379,33 @@ class JellyfinService {
     );
     
     if (success) {
-      _serverUrl = address.normalizedUrl;
-      _currentAddressId = address.id;
-      _currentProfile = _currentProfile!.markAddressSuccess(address.id);
-      await _multiAddressService.updateProfile(_currentProfile!);
-      return true;
+      // 验证当前用户token在新地址上的有效性
+      try {
+        final originalUrl = _serverUrl;
+        _serverUrl = address.normalizedUrl;
+        
+        // 进行轻量级认证验证
+        final authResponse = await _makeAuthenticatedRequest('/System/Info')
+            .timeout(const Duration(seconds: 5));
+        
+        if (authResponse.statusCode == 200) {
+          _currentAddressId = address.id;
+          _currentProfile = _currentProfile!.markAddressSuccess(address.id);
+          await _multiAddressService.updateProfile(_currentProfile!);
+          DebugLogService().addLog('JellyfinService: 成功切换到地址: ${address.normalizedUrl}');
+          return true;
+        } else {
+          // 认证失败，恢复原地址
+          _serverUrl = originalUrl;
+          DebugLogService().addLog('JellyfinService: 地址切换失败，token在新地址上无效: HTTP ${authResponse.statusCode}');
+          return false;
+        }
+      } catch (e) {
+        // 认证失败，恢复原地址
+        _serverUrl = _currentProfile!.currentAddress?.normalizedUrl;
+        DebugLogService().addLog('JellyfinService: 地址切换失败，认证验证异常: $e');
+        return false;
+      }
     }
     
     return false;

--- a/lib/services/multi_address_server_service.dart
+++ b/lib/services/multi_address_server_service.dart
@@ -1,0 +1,448 @@
+import 'dart:async';
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter/foundation.dart';
+import '../models/server_profile_model.dart';
+import 'debug_log_service.dart';
+
+/// 多地址服务器管理服务
+class MultiAddressServerService {
+  static const String _profilesKey = 'server_profiles';
+  static const Duration _connectionTimeout = Duration(seconds: 5);
+  
+  // 服务器配置列表
+  List<ServerProfile> _profiles = [];
+  
+  // 单例模式
+  static final MultiAddressServerService _instance = MultiAddressServerService._internal();
+  factory MultiAddressServerService() => _instance;
+  MultiAddressServerService._internal();
+  
+  static MultiAddressServerService get instance => _instance;
+  
+  List<ServerProfile> get profiles => List.unmodifiable(_profiles);
+  
+  /// 初始化服务，加载保存的配置
+  Future<void> initialize() async {
+    await loadProfiles();
+  }
+  
+  /// 从存储加载服务器配置
+  Future<void> loadProfiles() async {
+    if (kIsWeb) {
+      _profiles = [];
+      return;
+    }
+    
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final profilesJson = prefs.getString(_profilesKey);
+      
+      if (profilesJson != null) {
+        final List<dynamic> profilesList = json.decode(profilesJson);
+        _profiles = profilesList
+            .map((p) => ServerProfile.fromJson(p as Map<String, dynamic>))
+            .toList();
+        
+        DebugLogService().addLog('MultiAddressServer: 加载了 ${_profiles.length} 个服务器配置');
+      }
+    } catch (e) {
+      DebugLogService().addLog('MultiAddressServer: 加载配置失败: $e');
+      _profiles = [];
+    }
+  }
+  
+  /// 保存服务器配置到存储
+  Future<void> saveProfiles() async {
+    if (kIsWeb) return;
+    
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final profilesJson = json.encode(_profiles.map((p) => p.toJson()).toList());
+      await prefs.setString(_profilesKey, profilesJson);
+      
+      DebugLogService().addLog('MultiAddressServer: 保存了 ${_profiles.length} 个服务器配置');
+    } catch (e) {
+      DebugLogService().addLog('MultiAddressServer: 保存配置失败: $e');
+    }
+  }
+  
+  /// 添加新的服务器配置
+  Future<ServerProfile?> addProfile({
+    required String serverName,
+    required String serverType,
+    required String url,
+    required String username,
+    String? addressName,
+  }) async {
+    // 规范化URL
+    final normalizedUrl = _normalizeUrl(url);
+    
+    // 创建新地址 (第一个地址优先级为0)
+    final address = ServerAddress(
+      id: DateTime.now().millisecondsSinceEpoch.toString(),
+      url: normalizedUrl,
+      name: addressName ?? '默认地址',
+      priority: 0,
+    );
+    
+    // 创建新配置
+    final profile = ServerProfile(
+      id: DateTime.now().millisecondsSinceEpoch.toString(),
+      serverName: serverName,
+      serverType: serverType,
+      addresses: [address],
+      username: username,
+    );
+    
+    _profiles.add(profile);
+    await saveProfiles();
+    
+    return profile;
+  }
+  
+  /// 通过服务器ID获取配置
+  ServerProfile? getProfileById(String id) {
+    return _profiles.firstWhere(
+      (p) => p.id == id,
+      orElse: () => throw Exception('未找到服务器配置'),
+    );
+  }
+  
+  /// 通过服务器类型和用户名查找配置
+  ServerProfile? findProfile({
+    required String serverType,
+    required String username,
+    String? serverUrl,
+  }) {
+    for (final profile in _profiles) {
+      if (profile.serverType == serverType && profile.username == username) {
+        // 如果提供了URL，检查是否有匹配的地址
+        if (serverUrl != null) {
+          final normalizedUrl = _normalizeUrl(serverUrl);
+          final hasMatchingAddress = profile.addresses.any(
+            (addr) => addr.normalizedUrl == normalizedUrl,
+          );
+          if (hasMatchingAddress) return profile;
+        } else {
+          return profile;
+        }
+      }
+    }
+    return null;
+  }
+  
+  /// 向现有配置添加新地址
+  Future<ServerProfile?> addAddressToProfile({
+    required String profileId,
+    required String url,
+    required String name,
+    int? priority,
+  }) async {
+    final profileIndex = _profiles.indexWhere((p) => p.id == profileId);
+    if (profileIndex == -1) return null;
+    
+    final profile = _profiles[profileIndex];
+    final normalizedUrl = _normalizeUrl(url);
+    
+    // 检查地址是否已存在
+    final existingAddress = profile.addresses.firstWhere(
+      (addr) => addr.normalizedUrl == normalizedUrl,
+      orElse: () => ServerAddress(id: '', url: '', name: ''),
+    );
+    
+    if (existingAddress.id.isNotEmpty) {
+      DebugLogService().addLog('MultiAddressServer: 地址已存在: $normalizedUrl');
+      return profile;
+    }
+    
+    // 如果没有指定优先级，设置为比现有最大优先级+1
+    int finalPriority = priority ?? 0;
+    if (priority == null && profile.addresses.isNotEmpty) {
+      final maxPriority = profile.addresses.map((a) => a.priority).reduce((a, b) => a > b ? a : b);
+      finalPriority = maxPriority + 1;
+    }
+    
+    // 添加新地址
+    final newAddress = ServerAddress(
+      id: DateTime.now().millisecondsSinceEpoch.toString(),
+      url: normalizedUrl,
+      name: name,
+      priority: finalPriority,
+    );
+    
+    final updatedProfile = profile.copyWith(
+      addresses: [...profile.addresses, newAddress],
+    );
+    
+    _profiles[profileIndex] = updatedProfile;
+    await saveProfiles();
+    
+    return updatedProfile;
+  }
+  
+  /// 更新服务器配置
+  Future<void> updateProfile(ServerProfile profile) async {
+    final index = _profiles.indexWhere((p) => p.id == profile.id);
+    if (index != -1) {
+      _profiles[index] = profile;
+      await saveProfiles();
+    }
+  }
+  
+  /// 删除服务器配置
+  Future<void> deleteProfile(String profileId) async {
+    _profiles.removeWhere((p) => p.id == profileId);
+    await saveProfiles();
+  }
+  
+  /// 删除配置中的某个地址
+  Future<ServerProfile?> deleteAddressFromProfile({
+    required String profileId,
+    required String addressId,
+  }) async {
+    final profileIndex = _profiles.indexWhere((p) => p.id == profileId);
+    if (profileIndex == -1) return null;
+    
+    final profile = _profiles[profileIndex];
+    
+    // 不能删除最后一个地址
+    if (profile.addresses.length <= 1) {
+      throw Exception('不能删除最后一个地址');
+    }
+    
+    final updatedAddresses = profile.addresses
+        .where((addr) => addr.id != addressId)
+        .toList();
+    
+    final updatedProfile = profile.copyWith(addresses: updatedAddresses);
+    _profiles[profileIndex] = updatedProfile;
+    await saveProfiles();
+    
+    return updatedProfile;
+  }
+  
+  /// 更新地址的启用状态
+  Future<ServerProfile?> toggleAddressEnabled({
+    required String profileId,
+    required String addressId,
+    required bool enabled,
+  }) async {
+    final profileIndex = _profiles.indexWhere((p) => p.id == profileId);
+    if (profileIndex == -1) return null;
+    
+    final profile = _profiles[profileIndex];
+    final updatedAddresses = profile.addresses.map((addr) {
+      if (addr.id == addressId) {
+        return addr.copyWith(isEnabled: enabled);
+      }
+      return addr;
+    }).toList();
+    
+    final updatedProfile = profile.copyWith(addresses: updatedAddresses);
+    _profiles[profileIndex] = updatedProfile;
+    await saveProfiles();
+    
+    return updatedProfile;
+  }
+
+  /// 更新地址的优先级
+  Future<ServerProfile?> updateAddressPriority({
+    required String profileId,
+    required String addressId,
+    required int priority,
+  }) async {
+    final profileIndex = _profiles.indexWhere((p) => p.id == profileId);
+    if (profileIndex == -1) return null;
+    
+    final profile = _profiles[profileIndex];
+    final updatedAddresses = profile.addresses.map((addr) {
+      if (addr.id == addressId) {
+        return addr.copyWith(priority: priority);
+      }
+      return addr;
+    }).toList();
+    
+    final updatedProfile = profile.copyWith(addresses: updatedAddresses);
+    _profiles[profileIndex] = updatedProfile;
+    await saveProfiles();
+    
+    return updatedProfile;
+  }
+  
+  /// 尝试连接到服务器（使用多个地址）
+  Future<ConnectionResult> tryConnect({
+    required ServerProfile profile,
+    required Future<bool> Function(String url) testConnection,
+  }) async {
+    final addresses = profile.enabledAddresses;
+    
+    if (addresses.isEmpty) {
+      return ConnectionResult(
+        success: false,
+        error: '没有可用的服务器地址',
+      );
+    }
+    
+    String? lastError;
+    ServerProfile updatedProfile = profile;
+    
+    // 按优先级尝试每个地址
+    for (final address in addresses) {
+      if (!address.shouldRetry()) {
+        DebugLogService().addLog(
+          'MultiAddressServer: 跳过地址 ${address.name} (${address.url}) - 失败次数过多'
+        );
+        continue;
+      }
+      
+      DebugLogService().addLog(
+        'MultiAddressServer: 尝试连接 ${address.name} (${address.url})'
+      );
+      
+      try {
+        final success = await testConnection(address.normalizedUrl)
+            .timeout(_connectionTimeout);
+        
+        if (success) {
+          // 标记成功
+          updatedProfile = updatedProfile.markAddressSuccess(address.id);
+          await updateProfile(updatedProfile);
+          
+          DebugLogService().addLog(
+            'MultiAddressServer: 成功连接到 ${address.name} (${address.url})'
+          );
+          
+          return ConnectionResult(
+            success: true,
+            successfulUrl: address.normalizedUrl,
+            successfulAddressId: address.id,
+            profile: updatedProfile,
+          );
+        } else {
+          lastError = '服务器验证失败';
+          updatedProfile = updatedProfile.markAddressFailed(address.id);
+        }
+      } on TimeoutException {
+        lastError = '连接超时';
+        updatedProfile = updatedProfile.markAddressFailed(address.id);
+        DebugLogService().addLog(
+          'MultiAddressServer: 地址 ${address.name} 连接超时'
+        );
+      } catch (e) {
+        lastError = e.toString();
+        updatedProfile = updatedProfile.markAddressFailed(address.id);
+        DebugLogService().addLog(
+          'MultiAddressServer: 地址 ${address.name} 连接失败: $e'
+        );
+      }
+    }
+    
+    // 更新失败信息
+    await updateProfile(updatedProfile);
+    
+    return ConnectionResult(
+      success: false,
+      error: lastError ?? '所有地址连接失败',
+    );
+  }
+  
+  /// 检查服务器是否可达（通过服务器ID和特定URL识别）
+  Future<ServerIdentifyResult> identifyServer({
+    required String url,
+    required String serverType,
+    required Future<String?> Function(String url) getServerId,
+  }) async {
+    final normalizedUrl = _normalizeUrl(url);
+    
+    try {
+      final serverId = await getServerId(normalizedUrl)
+          .timeout(_connectionTimeout);
+      
+      if (serverId == null) {
+        return ServerIdentifyResult(
+          success: false,
+          error: '无法获取服务器ID',
+        );
+      }
+      
+      // 查找是否有相同ID的服务器配置
+      ServerProfile? existingProfile;
+      for (final profile in _profiles) {
+        if (profile.serverType == serverType) {
+          // 这里可以通过serverId匹配，但需要在profile中存储serverId
+          // 暂时通过serverName匹配
+          for (final addr in profile.addresses) {
+            if (addr.normalizedUrl == normalizedUrl) {
+              existingProfile = profile;
+              break;
+            }
+          }
+        }
+      }
+      
+      return ServerIdentifyResult(
+        success: true,
+        serverId: serverId,
+        existingProfile: existingProfile,
+        url: normalizedUrl,
+      );
+    } on TimeoutException {
+      return ServerIdentifyResult(
+        success: false,
+        error: '连接超时',
+      );
+    } catch (e) {
+      return ServerIdentifyResult(
+        success: false,
+        error: e.toString(),
+      );
+    }
+  }
+  
+  /// 规范化URL
+  String _normalizeUrl(String url) {
+    String normalized = url.trim();
+    if (!normalized.startsWith('http://') && !normalized.startsWith('https://')) {
+      normalized = 'http://$normalized';
+    }
+    if (normalized.endsWith('/')) {
+      normalized = normalized.substring(0, normalized.length - 1);
+    }
+    return normalized;
+  }
+}
+
+/// 连接结果
+class ConnectionResult {
+  final bool success;
+  final String? successfulUrl;
+  final String? successfulAddressId;
+  final String? error;
+  final ServerProfile? profile;
+  
+  ConnectionResult({
+    required this.success,
+    this.successfulUrl,
+    this.successfulAddressId,
+    this.error,
+    this.profile,
+  });
+}
+
+/// 服务器识别结果
+class ServerIdentifyResult {
+  final bool success;
+  final String? serverId;
+  final String? url;
+  final ServerProfile? existingProfile;
+  final String? error;
+  
+  ServerIdentifyResult({
+    required this.success,
+    this.serverId,
+    this.url,
+    this.existingProfile,
+    this.error,
+  });
+}

--- a/lib/utils/url_name_generator.dart
+++ b/lib/utils/url_name_generator.dart
@@ -1,0 +1,51 @@
+/// URL名称生成工具类
+class UrlNameGenerator {
+  /// 根据URL生成地址名称
+  /// 如果提供了自定义名称，则使用自定义名称；否则根据URL特征自动生成
+  static String generateAddressName(String url, {String? customName}) {
+    // 如果提供了自定义名称且不为空，直接使用
+    if (customName != null && customName.trim().isNotEmpty) {
+      return customName.trim();
+    }
+    
+    // 根据URL自动生成名称
+    return _generateNameFromUrl(url);
+  }
+  
+  /// 根据URL特征自动生成名称
+  static String _generateNameFromUrl(String url) {
+    final lowercaseUrl = url.toLowerCase();
+    
+    // 本地地址
+    if (lowercaseUrl.contains('localhost') || lowercaseUrl.contains('127.0.0.1')) {
+      return '本地';
+    }
+    
+    // 局域网地址
+    if (lowercaseUrl.contains('192.168') || 
+        lowercaseUrl.contains('10.') || 
+        (lowercaseUrl.contains('172.') && _isPrivateIPRange172(url))) {
+      return '局域网';
+    }
+    
+    // 其他情况默认为公网
+    return '公网';
+  }
+  
+  /// 检查是否为172.16.0.0到172.31.255.255的私有IP范围
+  static bool _isPrivateIPRange172(String url) {
+    final regex = RegExp(r'172\.(\d+)\.');
+    final match = regex.firstMatch(url);
+    if (match != null) {
+      final secondOctet = int.tryParse(match.group(1) ?? '');
+      return secondOctet != null && secondOctet >= 16 && secondOctet <= 31;
+    }
+    return false;
+  }
+  
+  /// 为首次连接生成服务器名称建议
+  static String generateServerNameSuggestion(String url, String serverType) {
+    final baseName = _generateNameFromUrl(url);
+    return '$serverType服务器 - $baseName';
+  }
+}

--- a/lib/widgets/nipaplay_theme/multi_address_manager_widget.dart
+++ b/lib/widgets/nipaplay_theme/multi_address_manager_widget.dart
@@ -1,0 +1,540 @@
+import 'package:flutter/material.dart';
+import 'dart:ui';
+import 'package:nipaplay/models/server_profile_model.dart';
+import 'package:nipaplay/widgets/nipaplay_theme/blur_snackbar.dart';
+
+/// 多地址管理组件
+class MultiAddressManagerWidget extends StatefulWidget {
+  final List<ServerAddress> addresses;
+  final String? currentAddressId;
+  final Function(String url, String name) onAddAddress;
+  final Function(String addressId) onRemoveAddress;
+  final Function(String addressId) onSwitchAddress;
+  final Function(String addressId, int priority)? onUpdatePriority;
+  
+  const MultiAddressManagerWidget({
+    super.key,
+    required this.addresses,
+    this.currentAddressId,
+    required this.onAddAddress,
+    required this.onRemoveAddress,
+    required this.onSwitchAddress,
+    this.onUpdatePriority,
+  });
+
+  @override
+  State<MultiAddressManagerWidget> createState() => _MultiAddressManagerWidgetState();
+}
+
+class _MultiAddressManagerWidgetState extends State<MultiAddressManagerWidget> {
+  final TextEditingController _urlController = TextEditingController();
+  final TextEditingController _nameController = TextEditingController();
+  
+  @override
+  void dispose() {
+    _urlController.dispose();
+    _nameController.dispose();
+    super.dispose();
+  }
+  
+  Future<void> _showAddAddressDialog() async {
+    _urlController.clear();
+    _nameController.clear();
+    
+    final result = await showDialog<Map<String, String>>(
+      context: context,
+      barrierDismissible: false,
+      builder: (dialogContext) => AlertDialog(
+        backgroundColor: Colors.black.withOpacity(0.8),
+        title: const Text('添加服务器地址', style: TextStyle(color: Colors.white)),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              '为同一服务器添加多个访问地址，系统会自动选择可用的地址连接。',
+              style: TextStyle(color: Colors.white70, fontSize: 14),
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: _urlController,
+              style: const TextStyle(color: Colors.white),
+              decoration: InputDecoration(
+                labelText: '服务器地址',
+                hintText: '例如：http://192.168.1.100:8096',
+                labelStyle: const TextStyle(color: Colors.white70),
+                hintStyle: TextStyle(color: Colors.white.withOpacity(0.3)),
+                enabledBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(8),
+                  borderSide: BorderSide(color: Colors.white.withOpacity(0.3)),
+                ),
+                focusedBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(8),
+                  borderSide: const BorderSide(color: Colors.blue),
+                ),
+              ),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _nameController,
+              style: const TextStyle(color: Colors.white),
+              decoration: InputDecoration(
+                labelText: '地址名称',
+                hintText: '例如：家庭网络、公网访问',
+                labelStyle: const TextStyle(color: Colors.white70),
+                hintStyle: TextStyle(color: Colors.white.withOpacity(0.3)),
+                enabledBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(8),
+                  borderSide: BorderSide(color: Colors.white.withOpacity(0.3)),
+                ),
+                focusedBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(8),
+                  borderSide: const BorderSide(color: Colors.blue),
+                ),
+              ),
+            ),
+          ],
+        ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('取消', style: TextStyle(color: Colors.white70)),
+        ),
+        TextButton(
+          onPressed: () {
+            if (_urlController.text.isNotEmpty && _nameController.text.isNotEmpty) {
+              Navigator.of(context).pop({
+                'url': _urlController.text,
+                'name': _nameController.text,
+              });
+            } else {
+              BlurSnackBar.show(context, '请填写所有字段');
+            }
+          },
+          child: const Text('添加', style: TextStyle(color: Colors.blue)),
+        ),
+      ],
+      ),
+    );
+    
+    if (result != null) {
+      widget.onAddAddress(result['url']!, result['name']!);
+    }
+  }
+  
+  Future<void> _confirmRemoveAddress(ServerAddress address) async {
+    if (widget.addresses.length <= 1) {
+      BlurSnackBar.show(context, '至少需要保留一个地址');
+      return;
+    }
+    
+    final confirm = await showDialog<bool>(
+      context: context,
+      barrierDismissible: false,
+      builder: (dialogContext) => AlertDialog(
+        backgroundColor: Colors.black.withOpacity(0.8),
+        title: const Text('删除地址', style: TextStyle(color: Colors.white)),
+        content: Text(
+          '确定要删除地址 "${address.name}" 吗？\n${address.url}',
+          style: const TextStyle(color: Colors.white70),
+        ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(false),
+          child: const Text('取消', style: TextStyle(color: Colors.white70)),
+        ),
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(true),
+          child: const Text('删除', style: TextStyle(color: Colors.red)),
+        ),
+      ],
+      ),
+    );
+    
+    if (confirm == true) {
+      widget.onRemoveAddress(address.id);
+    }
+  }
+
+  Future<void> _showPriorityDialog(ServerAddress address) async {
+    if (widget.onUpdatePriority == null) return;
+
+    final TextEditingController priorityController = TextEditingController();
+    priorityController.text = address.priority.toString();
+    
+    final result = await showDialog<int>(
+      context: context,
+      barrierDismissible: false,
+      builder: (dialogContext) => AlertDialog(
+        backgroundColor: Colors.black.withOpacity(0.8),
+        title: const Text('设置优先级', style: TextStyle(color: Colors.white)),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '地址: ${address.name}',
+              style: const TextStyle(color: Colors.white70, fontSize: 14),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'URL: ${address.url}',
+              style: const TextStyle(color: Colors.white70, fontSize: 14),
+            ),
+            const SizedBox(height: 16),
+            const Text(
+              '优先级（数字越小优先级越高）:',
+              style: TextStyle(color: Colors.white, fontSize: 16),
+            ),
+            const SizedBox(height: 12),
+            // 优先级输入框
+            TextField(
+              controller: priorityController,
+              style: const TextStyle(color: Colors.white),
+              keyboardType: TextInputType.number,
+              decoration: InputDecoration(
+                hintText: '输入0-99的数字，0为最高优先级',
+                hintStyle: TextStyle(color: Colors.white.withOpacity(0.5)),
+                enabledBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(8),
+                  borderSide: BorderSide(color: Colors.white.withOpacity(0.3)),
+                ),
+                focusedBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(8),
+                  borderSide: const BorderSide(color: Colors.blue),
+                ),
+                errorBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(8),
+                  borderSide: const BorderSide(color: Colors.red),
+                ),
+                focusedErrorBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(8),
+                  borderSide: const BorderSide(color: Colors.red),
+                ),
+              ),
+            ),
+            const SizedBox(height: 12),
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: Colors.blue.withOpacity(0.1),
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(color: Colors.blue.withOpacity(0.2)),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '优先级说明:',
+                    style: TextStyle(color: Colors.blue.withOpacity(0.9), fontWeight: FontWeight.w600),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    '• 0: 最高优先级（优先）\n• 1-3: 高优先级\n• 4-9: 中等优先级\n• 10+: 低优先级',
+                    style: TextStyle(color: Colors.white.withOpacity(0.7), fontSize: 12),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () {
+              priorityController.dispose();
+              Navigator.of(context).pop();
+            },
+            child: const Text('取消', style: TextStyle(color: Colors.white70)),
+          ),
+          TextButton(
+            onPressed: () {
+              final priorityText = priorityController.text.trim();
+              final priority = int.tryParse(priorityText);
+              
+              if (priority == null) {
+                BlurSnackBar.show(context, '请输入有效的数字');
+                return;
+              }
+              
+              if (priority < 0 || priority > 99) {
+                BlurSnackBar.show(context, '优先级必须在0-99之间');
+                return;
+              }
+              
+              priorityController.dispose();
+              Navigator.of(context).pop(priority);
+            },
+            child: const Text('确定', style: TextStyle(color: Colors.blue)),
+          ),
+        ],
+      ),
+    );
+    
+    if (result != null && result != address.priority) {
+      widget.onUpdatePriority!(address.id, result);
+    }
+  }
+  
+  Widget _buildAddressStatus(ServerAddress address) {
+    // 当前使用中的地址
+    if (address.id == widget.currentAddressId) {
+      return Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        decoration: BoxDecoration(
+          color: Colors.green.withOpacity(0.2),
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: Colors.green.withOpacity(0.3)),
+        ),
+        child: const Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.check_circle, color: Colors.green, size: 14),
+            SizedBox(width: 4),
+            Text('当前使用', style: TextStyle(color: Colors.green, fontSize: 12)),
+          ],
+        ),
+      );
+    }
+    
+    // 最近成功连接
+    if (address.lastSuccessTime != null) {
+      final timeDiff = DateTime.now().difference(address.lastSuccessTime!);
+      String timeText;
+      if (timeDiff.inMinutes < 1) {
+        timeText = '刚刚';
+      } else if (timeDiff.inHours < 1) {
+        timeText = '${timeDiff.inMinutes}分钟前';
+      } else if (timeDiff.inDays < 1) {
+        timeText = '${timeDiff.inHours}小时前';
+      } else {
+        timeText = '${timeDiff.inDays}天前';
+      }
+      
+      return Text(
+        '上次成功: $timeText',
+        style: TextStyle(color: Colors.white.withOpacity(0.5), fontSize: 12),
+      );
+    }
+    
+    // 连续失败
+    if (address.failureCount > 0) {
+      return Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        decoration: BoxDecoration(
+          color: Colors.orange.withOpacity(0.2),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Text(
+          '失败 ${address.failureCount} 次',
+          style: const TextStyle(color: Colors.orange, fontSize: 12),
+        ),
+      );
+    }
+    
+    // 未启用
+    if (!address.isEnabled) {
+      return Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        decoration: BoxDecoration(
+          color: Colors.grey.withOpacity(0.2),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: const Text(
+          '已禁用',
+          style: TextStyle(color: Colors.grey, fontSize: 12),
+        ),
+      );
+    }
+    
+    return const SizedBox.shrink();
+  }
+
+  Widget _buildPriorityBadge(ServerAddress address) {
+    final lowestPriority = widget.addresses.map((a) => a.priority).reduce((a, b) => a < b ? a : b);
+    final isHighestPriority = address.priority == lowestPriority;
+    
+    // 只有最高优先级（数字最小）的地址显示优先标记
+    if (isHighestPriority && widget.addresses.length > 1) {
+      return Container(
+        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+        decoration: BoxDecoration(
+          color: Colors.blue.withOpacity(0.2),
+          borderRadius: BorderRadius.circular(4),
+        ),
+        child: const Text(
+          '优先',
+          style: TextStyle(color: Colors.blue, fontSize: 10),
+        ),
+      );
+    }
+    
+    // 显示优先级数字（如果不是0且有多个地址）
+    if (address.priority > 0 && widget.addresses.length > 1) {
+      return Container(
+        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+        decoration: BoxDecoration(
+          color: Colors.grey.withOpacity(0.2),
+          borderRadius: BorderRadius.circular(4),
+        ),
+        child: Text(
+          'P${address.priority}',
+          style: TextStyle(color: Colors.white.withOpacity(0.6), fontSize: 10),
+        ),
+      );
+    }
+    
+    return const SizedBox.shrink();
+  }
+  
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // 标题栏
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            const Text(
+              '服务器地址管理',
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            TextButton.icon(
+              onPressed: _showAddAddressDialog,
+              icon: const Icon(Icons.add, color: Colors.blue, size: 16),
+              label: const Text('添加地址', style: TextStyle(color: Colors.blue)),
+              style: TextButton.styleFrom(
+                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                backgroundColor: Colors.blue.withOpacity(0.1),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8),
+                ),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        
+        // 地址列表
+        Container(
+          decoration: BoxDecoration(
+            color: Colors.white.withOpacity(0.05),
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(color: Colors.white.withOpacity(0.1)),
+          ),
+          child: Builder(
+            builder: (context) {
+              // 按优先级排序地址列表
+              final sortedAddresses = List<ServerAddress>.from(widget.addresses);
+              sortedAddresses.sort((a, b) {
+                // 当前使用的地址优先显示
+                if (a.id == widget.currentAddressId && b.id != widget.currentAddressId) return -1;
+                if (b.id == widget.currentAddressId && a.id != widget.currentAddressId) return 1;
+                
+                // 按优先级排序（数字越小优先级越高）
+                return a.priority.compareTo(b.priority);
+              });
+              
+              return ListView.separated(
+                shrinkWrap: true,
+                physics: const NeverScrollableScrollPhysics(),
+                itemCount: sortedAddresses.length,
+                separatorBuilder: (context, index) => Divider(
+                  color: Colors.white.withOpacity(0.1),
+                  height: 1,
+                ),
+                itemBuilder: (context, index) {
+                  final address = sortedAddresses[index];
+                  final isCurrent = address.id == widget.currentAddressId;
+              
+                  return ListTile(
+                contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                title: Row(
+                  children: [
+                    // 优先级标记
+                    _buildPriorityBadge(address),
+                    if (widget.addresses.length > 1) const SizedBox(width: 8),
+                    Text(
+                      address.name,
+                      style: TextStyle(
+                        color: isCurrent ? Colors.green : Colors.white,
+                        fontWeight: isCurrent ? FontWeight.w600 : FontWeight.normal,
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    _buildAddressStatus(address),
+                  ],
+                ),
+                subtitle: Padding(
+                  padding: const EdgeInsets.only(top: 4),
+                  child: Text(
+                    address.url,
+                    style: TextStyle(
+                      color: Colors.white.withOpacity(0.5),
+                      fontSize: 13,
+                    ),
+                  ),
+                ),
+                trailing: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    // 优先级设置按钮
+                    if (widget.onUpdatePriority != null && widget.addresses.length > 1)
+                      IconButton(
+                        icon: const Icon(Icons.tune, color: Colors.white70),
+                        tooltip: '设置优先级',
+                        onPressed: () => _showPriorityDialog(address),
+                      ),
+                    // 切换按钮
+                    if (!isCurrent && address.isEnabled)
+                      IconButton(
+                        icon: const Icon(Icons.swap_horiz, color: Colors.white70),
+                        tooltip: '切换到此地址',
+                        onPressed: () => widget.onSwitchAddress(address.id),
+                      ),
+                    // 删除按钮
+                    if (widget.addresses.length > 1)
+                      IconButton(
+                        icon: Icon(Icons.delete_outline, color: Colors.red.withOpacity(0.7)),
+                        tooltip: '删除地址',
+                        onPressed: () => _confirmRemoveAddress(address),
+                      ),
+                  ],
+                ),
+                  );
+                },
+              );
+            },
+          ),
+        ),
+        
+        // 提示信息
+        const SizedBox(height: 12),
+        Container(
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: Colors.blue.withOpacity(0.1),
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(color: Colors.blue.withOpacity(0.2)),
+          ),
+          child: Row(
+            children: [
+              Icon(Icons.info_outline, color: Colors.blue.withOpacity(0.7), size: 16),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  '系统会自动选择最优地址连接。当一个地址无法连接时，会自动尝试其他地址。',
+                  style: TextStyle(color: Colors.white.withOpacity(0.7), fontSize: 12),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/nipaplay_theme/multi_address_manager_widget.dart
+++ b/lib/widgets/nipaplay_theme/multi_address_manager_widget.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'dart:ui';
 import 'package:nipaplay/models/server_profile_model.dart';
 import 'package:nipaplay/widgets/nipaplay_theme/blur_snackbar.dart';
+import 'package:nipaplay/utils/url_name_generator.dart';
 
 /// 多地址管理组件
 class MultiAddressManagerWidget extends StatefulWidget {
@@ -79,8 +80,8 @@ class _MultiAddressManagerWidgetState extends State<MultiAddressManagerWidget> {
               controller: _nameController,
               style: const TextStyle(color: Colors.white),
               decoration: InputDecoration(
-                labelText: '地址名称',
-                hintText: '例如：家庭网络、公网访问',
+                labelText: '地址名称（可留空自动生成）',
+                hintText: '例如：家庭网络、公网访问，或留空自动生成',
                 labelStyle: const TextStyle(color: Colors.white70),
                 hintStyle: TextStyle(color: Colors.white.withOpacity(0.3)),
                 enabledBorder: OutlineInputBorder(
@@ -102,13 +103,16 @@ class _MultiAddressManagerWidgetState extends State<MultiAddressManagerWidget> {
         ),
         TextButton(
           onPressed: () {
-            if (_urlController.text.isNotEmpty && _nameController.text.isNotEmpty) {
+            if (_urlController.text.trim().isNotEmpty) {
+              final url = _urlController.text.trim();
+              final name = UrlNameGenerator.generateAddressName(url, customName: _nameController.text.trim());
+              
               Navigator.of(context).pop({
-                'url': _urlController.text,
-                'name': _nameController.text,
+                'url': url,
+                'name': name,
               });
             } else {
-              BlurSnackBar.show(context, '请填写所有字段');
+              BlurSnackBar.show(context, '请填写服务器地址');
             }
           },
           child: const Text('添加', style: TextStyle(color: Colors.blue)),

--- a/lib/widgets/nipaplay_theme/network_media_server_dialog.dart
+++ b/lib/widgets/nipaplay_theme/network_media_server_dialog.dart
@@ -256,10 +256,18 @@ class _NetworkMediaServerDialogState extends State<NetworkMediaServerDialog> {
         if (mounted) {
           BlurSnackBar.show(context, '地址添加成功');
         }
+      } else {
+        if (mounted) {
+          BlurSnackBar.show(context, '添加地址失败：未知原因');
+        }
       }
     } catch (e) {
       if (mounted) {
-        BlurSnackBar.show(context, '添加地址失败: $e');
+        String errorMsg = e.toString();
+        if (errorMsg.startsWith('Exception: ')) {
+          errorMsg = errorMsg.substring(11);
+        }
+        BlurSnackBar.show(context, '添加地址失败：$errorMsg');
       }
     }
   }
@@ -452,7 +460,6 @@ class _NetworkMediaServerDialogState extends State<NetworkMediaServerDialog> {
                       const SizedBox(height: 20),
                       _buildServerInfo(),
                       const SizedBox(height: 20),
-                      // 添加多地址管理组件
                       if (_serverAddresses.isNotEmpty) ...[
                         MultiAddressManagerWidget(
                           addresses: _serverAddresses,
@@ -609,7 +616,7 @@ class _NetworkMediaServerDialogState extends State<NetworkMediaServerDialog> {
         ),
         const SizedBox(height: 12),
         Container(
-          height: 300, // 给一个固定高度
+          height: 300,
           decoration: BoxDecoration(
             color: Colors.white.withOpacity(0.03),
             borderRadius: BorderRadius.circular(12),


### PR DESCRIPTION
Introduces multi-address support for Jellyfin and Emby services, enabling the application to automatically retry connections across multiple configured server URLs. This significantly enhances connection reliability and resilience to network changes or server address failures.

Enhances the remote media library settings page with:
- Clear initialization loading indicators for a better user experience.
- Prominent display of connection errors for both services, providing immediate feedback.
- Improved robustness for media library selection, gracefully handling cases where a previously selected library might no longer be available.
- A new UI component to manage multiple server addresses, allowing users to add, remove, switch, and reorder them.

Closes #110 