### PR TITLE
perf: 仪表盘加载与监听优化：新增后端 ready 机制、防抖

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -30,8 +30,6 @@ import 'package:nipaplay/providers/watch_history_provider.dart';
 import 'package:nipaplay/services/scan_service.dart';
 import 'package:nipaplay/providers/developer_options_provider.dart';
 import 'package:nipaplay/providers/appearance_settings_provider.dart';
-import 'package:nipaplay/providers/jellyfin_provider.dart';
-import 'package:nipaplay/providers/emby_provider.dart';
 import 'package:nipaplay/providers/ui_theme_provider.dart';
 import 'package:nipaplay/pages/fluent_main_page.dart';
 import 'package:fluent_ui/fluent_ui.dart' as fluent;
@@ -450,22 +448,15 @@ void main(List<String> args) async {
             ),
           ),
           ChangeNotifierProvider(create: (_) => TabChangeNotifier()),
-          ChangeNotifierProvider(create: (_) => WatchHistoryProvider()),
+          // 统一使用 ServiceProvider 中的全局实例，避免重复初始化与事件风暴
+          ChangeNotifierProvider.value(value: ServiceProvider.watchHistoryProvider),
           ChangeNotifierProvider(create: (_) => ScanService()),
           ChangeNotifierProvider(create: (_) => DeveloperOptionsProvider()),
           ChangeNotifierProvider(create: (_) => AppearanceSettingsProvider()),
           ChangeNotifierProvider(create: (_) => UIThemeProvider()),
           ChangeNotifierProvider.value(value: debugLogService),
-          ChangeNotifierProvider(create: (context) { // 修改 JellyfinProvider 的创建方式
-            final jellyfinProvider = JellyfinProvider();
-            jellyfinProvider.initialize(); // 在创建后立即调用 initialize
-            return jellyfinProvider;
-          }),
-          ChangeNotifierProvider(create: (context) { // 添加 EmbyProvider
-            final embyProvider = EmbyProvider();
-            embyProvider.initialize(); // 在创建后立即调用 initialize
-            return embyProvider;
-          }),
+          ChangeNotifierProvider.value(value: ServiceProvider.jellyfinProvider),
+          ChangeNotifierProvider.value(value: ServiceProvider.embyProvider),
         ],
         child: NipaPlayApp(launchFilePath: launchFilePath),
       ),


### PR DESCRIPTION
目的
- 降低仪表盘初始化与连接切换时的刷新风暴，避免与播放器活跃态竞争渲染资源，提升平滑度与稳定性。

主要改动
- Provider 注入
  - 通过 ServiceProvider 提供 Jellyfin/Emby/WatchHistory 全局实例，使用 ChangeNotifierProvider.value 注入，避免重复实例与事件风暴。
- Dashboard 行为优化
  - 仅在 Jellyfin/Emby Service “ready” 后启用 Provider 即时监听。
  - 新增 300ms 防抖与最近加载时间合并，抑制短时间内多次触发。
  - 服务断连时主动清空“最近添加”数据映射，防止脏数据残留。
  - 使用 addPostFrameCallback 避免在 build 期间 setState。
- 服务层能力
  - JellyfinService/EmbyService 新增 isReady 与 ready 回调（add/removeReadyListener, _notifyReady），在验证/连接/媒体库加载完成后发出就绪信号；断开时复位。
  - 为页面层的首刷与监听激活提供清晰的同步点。