### PR TITLE
feat:  统一技术信息面板与服务端转码支持

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSCameraUsageDescription</key>
+	<string>未来需要更新头像</string>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 	<key>CFBundleDevelopmentRegion</key>
@@ -152,8 +154,6 @@
 	</array>
 	<key>UISupportsDocumentBrowser</key>
 	<true/>
-	
-	<!-- 文档类型配置 -->
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>
@@ -229,8 +229,6 @@
 			</array>
 		</dict>
 	</array>
-	
-	<!-- 导入的内容类型 -->
 	<key>UTImportedTypeDeclarations</key>
 	<array>
 		<dict>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,6 +32,7 @@ import 'package:nipaplay/providers/developer_options_provider.dart';
 import 'package:nipaplay/providers/appearance_settings_provider.dart';
 import 'package:nipaplay/providers/ui_theme_provider.dart';
 import 'package:nipaplay/providers/jellyfin_transcode_provider.dart';
+import 'package:nipaplay/providers/emby_transcode_provider.dart';
 import 'package:nipaplay/pages/fluent_main_page.dart';
 import 'package:fluent_ui/fluent_ui.dart' as fluent;
 import 'dart:async';
@@ -456,6 +457,7 @@ void main(List<String> args) async {
           ChangeNotifierProvider(create: (_) => AppearanceSettingsProvider()),
           ChangeNotifierProvider(create: (_) => UIThemeProvider()),
           ChangeNotifierProvider(create: (_) => JellyfinTranscodeProvider()),
+          ChangeNotifierProvider(create: (_) => EmbyTranscodeProvider()),
           ChangeNotifierProvider.value(value: debugLogService),
           ChangeNotifierProvider.value(value: ServiceProvider.jellyfinProvider),
           ChangeNotifierProvider.value(value: ServiceProvider.embyProvider),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -31,6 +31,7 @@ import 'package:nipaplay/services/scan_service.dart';
 import 'package:nipaplay/providers/developer_options_provider.dart';
 import 'package:nipaplay/providers/appearance_settings_provider.dart';
 import 'package:nipaplay/providers/ui_theme_provider.dart';
+import 'package:nipaplay/providers/jellyfin_transcode_provider.dart';
 import 'package:nipaplay/pages/fluent_main_page.dart';
 import 'package:fluent_ui/fluent_ui.dart' as fluent;
 import 'dart:async';
@@ -454,6 +455,7 @@ void main(List<String> args) async {
           ChangeNotifierProvider(create: (_) => DeveloperOptionsProvider()),
           ChangeNotifierProvider(create: (_) => AppearanceSettingsProvider()),
           ChangeNotifierProvider(create: (_) => UIThemeProvider()),
+          ChangeNotifierProvider(create: (_) => JellyfinTranscodeProvider()),
           ChangeNotifierProvider.value(value: debugLogService),
           ChangeNotifierProvider.value(value: ServiceProvider.jellyfinProvider),
           ChangeNotifierProvider.value(value: ServiceProvider.embyProvider),

--- a/lib/models/jellyfin_transcode_settings.dart
+++ b/lib/models/jellyfin_transcode_settings.dart
@@ -1,0 +1,456 @@
+/// Jellyfin转码设置模型
+class JellyfinTranscodeSettings {
+  /// 是否启用转码
+  final bool enableTranscoding;
+  
+  /// 视频转码设置
+  final JellyfinVideoTranscodeSettings video;
+  
+  /// 音频转码设置
+  final JellyfinAudioTranscodeSettings audio;
+  
+  /// 字幕处理设置
+  final JellyfinSubtitleSettings subtitle;
+  
+  /// 网络自适应设置
+  final JellyfinAdaptiveSettings adaptive;
+
+  const JellyfinTranscodeSettings({
+    this.enableTranscoding = true,
+    this.video = const JellyfinVideoTranscodeSettings(),
+    this.audio = const JellyfinAudioTranscodeSettings(),
+    this.subtitle = const JellyfinSubtitleSettings(),
+    this.adaptive = const JellyfinAdaptiveSettings(),
+  });
+
+  JellyfinTranscodeSettings copyWith({
+    bool? enableTranscoding,
+    JellyfinVideoTranscodeSettings? video,
+    JellyfinAudioTranscodeSettings? audio,
+    JellyfinSubtitleSettings? subtitle,
+    JellyfinAdaptiveSettings? adaptive,
+  }) {
+    return JellyfinTranscodeSettings(
+      enableTranscoding: enableTranscoding ?? this.enableTranscoding,
+      video: video ?? this.video,
+      audio: audio ?? this.audio,
+      subtitle: subtitle ?? this.subtitle,
+      adaptive: adaptive ?? this.adaptive,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'enableTranscoding': enableTranscoding,
+      'video': video.toJson(),
+      'audio': audio.toJson(),
+      'subtitle': subtitle.toJson(),
+      'adaptive': adaptive.toJson(),
+    };
+  }
+
+  factory JellyfinTranscodeSettings.fromJson(Map<String, dynamic> json) {
+    return JellyfinTranscodeSettings(
+      enableTranscoding: json['enableTranscoding'] ?? true,
+      video: JellyfinVideoTranscodeSettings.fromJson(json['video'] ?? {}),
+      audio: JellyfinAudioTranscodeSettings.fromJson(json['audio'] ?? {}),
+      subtitle: JellyfinSubtitleSettings.fromJson(json['subtitle'] ?? {}),
+      adaptive: JellyfinAdaptiveSettings.fromJson(json['adaptive'] ?? {}),
+    );
+  }
+}
+
+/// 视频转码设置
+class JellyfinVideoTranscodeSettings {
+  /// 转码质量预设
+  final JellyfinVideoQuality quality;
+  
+  /// 自定义视频比特率 (Kbps)
+  final int? videoBitRate;
+  
+  /// 最大分辨率
+  final JellyfinResolution? maxResolution;
+  
+  /// 视频编解码器偏好
+  final List<String> preferredCodecs;
+  
+  /// 是否允许硬件加速
+  final bool enableHardwareAcceleration;
+  
+  /// 最大帧率
+  final double? maxFramerate;
+
+  const JellyfinVideoTranscodeSettings({
+    this.quality = JellyfinVideoQuality.auto,
+    this.videoBitRate,
+    this.maxResolution,
+    this.preferredCodecs = const ['h264', 'hevc', 'av1'],
+    this.enableHardwareAcceleration = true,
+    this.maxFramerate,
+  });
+
+  JellyfinVideoTranscodeSettings copyWith({
+    JellyfinVideoQuality? quality,
+    int? videoBitRate,
+    JellyfinResolution? maxResolution,
+    List<String>? preferredCodecs,
+    bool? enableHardwareAcceleration,
+    double? maxFramerate,
+  }) {
+    return JellyfinVideoTranscodeSettings(
+      quality: quality ?? this.quality,
+      videoBitRate: videoBitRate ?? this.videoBitRate,
+      maxResolution: maxResolution ?? this.maxResolution,
+      preferredCodecs: preferredCodecs ?? this.preferredCodecs,
+      enableHardwareAcceleration: enableHardwareAcceleration ?? this.enableHardwareAcceleration,
+      maxFramerate: maxFramerate ?? this.maxFramerate,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'quality': quality.index,
+      'videoBitRate': videoBitRate,
+      'maxResolution': maxResolution?.toJson(),
+      'preferredCodecs': preferredCodecs,
+      'enableHardwareAcceleration': enableHardwareAcceleration,
+      'maxFramerate': maxFramerate,
+    };
+  }
+
+  factory JellyfinVideoTranscodeSettings.fromJson(Map<String, dynamic> json) {
+    return JellyfinVideoTranscodeSettings(
+      quality: JellyfinVideoQuality.values[json['quality'] ?? 0],
+      videoBitRate: json['videoBitRate'],
+      maxResolution: json['maxResolution'] != null 
+          ? JellyfinResolution.fromJson(json['maxResolution'])
+          : null,
+      preferredCodecs: List<String>.from(json['preferredCodecs'] ?? ['h264', 'hevc', 'av1']),
+      enableHardwareAcceleration: json['enableHardwareAcceleration'] ?? true,
+      maxFramerate: json['maxFramerate']?.toDouble(),
+    );
+  }
+}
+
+/// 音频转码设置
+class JellyfinAudioTranscodeSettings {
+  /// 音频比特率 (Kbps)
+  final int? audioBitRate;
+  
+  /// 最大音频声道数
+  final int maxAudioChannels;
+  
+  /// 音频编解码器偏好
+  final List<String> preferredCodecs;
+  
+  /// 音频采样率
+  final int? audioSampleRate;
+
+  const JellyfinAudioTranscodeSettings({
+    this.audioBitRate,
+    this.maxAudioChannels = 2,
+    this.preferredCodecs = const ['aac', 'mp3', 'opus'],
+    this.audioSampleRate,
+  });
+
+  JellyfinAudioTranscodeSettings copyWith({
+    int? audioBitRate,
+    int? maxAudioChannels,
+    List<String>? preferredCodecs,
+    int? audioSampleRate,
+  }) {
+    return JellyfinAudioTranscodeSettings(
+      audioBitRate: audioBitRate ?? this.audioBitRate,
+      maxAudioChannels: maxAudioChannels ?? this.maxAudioChannels,
+      preferredCodecs: preferredCodecs ?? this.preferredCodecs,
+      audioSampleRate: audioSampleRate ?? this.audioSampleRate,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'audioBitRate': audioBitRate,
+      'maxAudioChannels': maxAudioChannels,
+      'preferredCodecs': preferredCodecs,
+      'audioSampleRate': audioSampleRate,
+    };
+  }
+
+  factory JellyfinAudioTranscodeSettings.fromJson(Map<String, dynamic> json) {
+    return JellyfinAudioTranscodeSettings(
+      audioBitRate: json['audioBitRate'],
+      maxAudioChannels: json['maxAudioChannels'] ?? 2,
+      preferredCodecs: List<String>.from(json['preferredCodecs'] ?? ['aac', 'mp3', 'opus']),
+      audioSampleRate: json['audioSampleRate'],
+    );
+  }
+}
+
+/// 字幕处理设置
+class JellyfinSubtitleSettings {
+  /// 字幕传输方法
+  final JellyfinSubtitleDeliveryMethod deliveryMethod;
+  
+  /// 是否启用字幕转码
+  final bool enableTranscoding;
+  
+  /// 首选字幕编解码器
+  final List<String> preferredCodecs;
+
+  const JellyfinSubtitleSettings({
+    this.deliveryMethod = JellyfinSubtitleDeliveryMethod.external,
+    this.enableTranscoding = true,
+    this.preferredCodecs = const ['srt', 'ass', 'vtt'],
+  });
+
+  JellyfinSubtitleSettings copyWith({
+    JellyfinSubtitleDeliveryMethod? deliveryMethod,
+    bool? enableTranscoding,
+    List<String>? preferredCodecs,
+  }) {
+    return JellyfinSubtitleSettings(
+      deliveryMethod: deliveryMethod ?? this.deliveryMethod,
+      enableTranscoding: enableTranscoding ?? this.enableTranscoding,
+      preferredCodecs: preferredCodecs ?? this.preferredCodecs,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'deliveryMethod': deliveryMethod.index,
+      'enableTranscoding': enableTranscoding,
+      'preferredCodecs': preferredCodecs,
+    };
+  }
+
+  factory JellyfinSubtitleSettings.fromJson(Map<String, dynamic> json) {
+    return JellyfinSubtitleSettings(
+      deliveryMethod: JellyfinSubtitleDeliveryMethod.values[json['deliveryMethod'] ?? 1],
+      enableTranscoding: json['enableTranscoding'] ?? true,
+      preferredCodecs: List<String>.from(json['preferredCodecs'] ?? ['srt', 'ass', 'vtt']),
+    );
+  }
+}
+
+/// 网络自适应设置
+class JellyfinAdaptiveSettings {
+  /// 是否启用自适应码率
+  final bool enableAdaptiveBitrate;
+  
+  /// 网络监测间隔（秒）
+  final int networkCheckInterval;
+  
+  /// 低网速阈值 (Mbps)
+  final double lowBandwidthThreshold;
+  
+  /// 高网速阈值 (Mbps)
+  final double highBandwidthThreshold;
+
+  const JellyfinAdaptiveSettings({
+    this.enableAdaptiveBitrate = true,
+    this.networkCheckInterval = 30,
+    this.lowBandwidthThreshold = 2.0,
+    this.highBandwidthThreshold = 10.0,
+  });
+
+  JellyfinAdaptiveSettings copyWith({
+    bool? enableAdaptiveBitrate,
+    int? networkCheckInterval,
+    double? lowBandwidthThreshold,
+    double? highBandwidthThreshold,
+  }) {
+    return JellyfinAdaptiveSettings(
+      enableAdaptiveBitrate: enableAdaptiveBitrate ?? this.enableAdaptiveBitrate,
+      networkCheckInterval: networkCheckInterval ?? this.networkCheckInterval,
+      lowBandwidthThreshold: lowBandwidthThreshold ?? this.lowBandwidthThreshold,
+      highBandwidthThreshold: highBandwidthThreshold ?? this.highBandwidthThreshold,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'enableAdaptiveBitrate': enableAdaptiveBitrate,
+      'networkCheckInterval': networkCheckInterval,
+      'lowBandwidthThreshold': lowBandwidthThreshold,
+      'highBandwidthThreshold': highBandwidthThreshold,
+    };
+  }
+
+  factory JellyfinAdaptiveSettings.fromJson(Map<String, dynamic> json) {
+    return JellyfinAdaptiveSettings(
+      enableAdaptiveBitrate: json['enableAdaptiveBitrate'] ?? true,
+      networkCheckInterval: json['networkCheckInterval'] ?? 30,
+      lowBandwidthThreshold: json['lowBandwidthThreshold']?.toDouble() ?? 2.0,
+      highBandwidthThreshold: json['highBandwidthThreshold']?.toDouble() ?? 10.0,
+    );
+  }
+}
+
+/// 视频质量预设（基于网络带宽）
+enum JellyfinVideoQuality {
+  auto,        // 自动选择（服务器决定）
+  bandwidth1m, // 1 Mbps (360p)
+  bandwidth2m, // 2 Mbps (480p)
+  bandwidth5m, // 5 Mbps (720p)
+  bandwidth10m,// 10 Mbps (1080p)
+  bandwidth20m,// 20 Mbps (1080p高质量)
+  bandwidth40m,// 40 Mbps (4K)
+  original,    // 原始质量（不转码，DirectPlay）
+}
+
+extension JellyfinVideoQualityExtension on JellyfinVideoQuality {
+  String get displayName {
+    switch (this) {
+      case JellyfinVideoQuality.auto:
+        return '自动选择';
+      case JellyfinVideoQuality.bandwidth1m:
+        return '省流量 (1 Mbps, 360p)';
+      case JellyfinVideoQuality.bandwidth2m:
+        return '标准 (2 Mbps, 480p)';
+      case JellyfinVideoQuality.bandwidth5m:
+        return '高清 (5 Mbps, 720p)';
+      case JellyfinVideoQuality.bandwidth10m:
+        return '全高清 (10 Mbps, 1080p)';
+      case JellyfinVideoQuality.bandwidth20m:
+        return '超清 (20 Mbps, 1080p)';
+      case JellyfinVideoQuality.bandwidth40m:
+        return '4K (40 Mbps, 2160p)';
+      case JellyfinVideoQuality.original:
+        return '原始质量';
+    }
+  }
+
+  /// 获取对应的比特率（Kbps）
+  int? get bitrate {
+    switch (this) {
+      case JellyfinVideoQuality.bandwidth1m:
+        return 1000;   // 1 Mbps
+      case JellyfinVideoQuality.bandwidth2m:
+        return 2000;   // 2 Mbps
+      case JellyfinVideoQuality.bandwidth5m:
+        return 5000;   // 5 Mbps
+      case JellyfinVideoQuality.bandwidth10m:
+        return 10000;  // 10 Mbps
+      case JellyfinVideoQuality.bandwidth20m:
+        return 20000;  // 20 Mbps
+      case JellyfinVideoQuality.bandwidth40m:
+        return 40000;  // 40 Mbps
+      default:
+        return null;   // auto 和 original 不限制
+    }
+  }
+
+  /// 获取推荐的最大分辨率
+  JellyfinResolution? get maxResolution {
+    switch (this) {
+      case JellyfinVideoQuality.bandwidth1m:
+        return const JellyfinResolution(width: 640, height: 360);
+      case JellyfinVideoQuality.bandwidth2m:
+        return const JellyfinResolution(width: 854, height: 480);
+      case JellyfinVideoQuality.bandwidth5m:
+        return const JellyfinResolution(width: 1280, height: 720);
+      case JellyfinVideoQuality.bandwidth10m:
+      case JellyfinVideoQuality.bandwidth20m:
+        return const JellyfinResolution(width: 1920, height: 1080);
+      case JellyfinVideoQuality.bandwidth40m:
+        return const JellyfinResolution(width: 3840, height: 2160);
+      default:
+        return null;   // auto 和 original 不限制分辨率
+    }
+  }
+  
+  /// 是否需要转码（原始质量不转码）
+  bool get requiresTranscoding {
+    return this != JellyfinVideoQuality.original;
+  }
+}
+
+/// 分辨率设置
+class JellyfinResolution {
+  final int width;
+  final int height;
+
+  const JellyfinResolution({
+    required this.width,
+    required this.height,
+  });
+
+  JellyfinResolution copyWith({
+    int? width,
+    int? height,
+  }) {
+    return JellyfinResolution(
+      width: width ?? this.width,
+      height: height ?? this.height,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'width': width,
+      'height': height,
+    };
+  }
+
+  factory JellyfinResolution.fromJson(Map<String, dynamic> json) {
+    return JellyfinResolution(
+      width: json['width'],
+      height: json['height'],
+    );
+  }
+
+  @override
+  String toString() => '${width}x$height';
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is JellyfinResolution &&
+          runtimeType == other.runtimeType &&
+          width == other.width &&
+          height == other.height;
+
+  @override
+  int get hashCode => width.hashCode ^ height.hashCode;
+}
+
+/// 字幕传输方法
+enum JellyfinSubtitleDeliveryMethod {
+  encode,   // 烧录到视频
+  embed,    // 嵌入流中
+  external, // 外部字幕文件
+  hls,      // HLS分段
+  drop,     // 不传输字幕
+}
+
+extension JellyfinSubtitleDeliveryMethodExtension on JellyfinSubtitleDeliveryMethod {
+  String get apiValue {
+    switch (this) {
+      case JellyfinSubtitleDeliveryMethod.encode:
+        return 'Encode';
+      case JellyfinSubtitleDeliveryMethod.embed:
+        return 'Embed';
+      case JellyfinSubtitleDeliveryMethod.external:
+        return 'External';
+      case JellyfinSubtitleDeliveryMethod.hls:
+        return 'Hls';
+      case JellyfinSubtitleDeliveryMethod.drop:
+        return 'Drop';
+    }
+  }
+
+  String get displayName {
+    switch (this) {
+      case JellyfinSubtitleDeliveryMethod.encode:
+        return '烧录字幕';
+      case JellyfinSubtitleDeliveryMethod.embed:
+        return '嵌入字幕';
+      case JellyfinSubtitleDeliveryMethod.external:
+        return '外挂字幕';
+      case JellyfinSubtitleDeliveryMethod.hls:
+        return 'HLS字幕';
+      case JellyfinSubtitleDeliveryMethod.drop:
+        return '不显示字幕';
+    }
+  }
+}

--- a/lib/pages/anime_page.dart
+++ b/lib/pages/anime_page.dart
@@ -129,7 +129,7 @@ class _AnimePageState extends State<AnimePage> with WidgetsBindingObserver {
           final embyId = item.filePath.replaceFirst('emby://', '');
           final embyService = EmbyService.instance;
           if (embyService.isConnected) {
-            actualPlayUrl = embyService.getStreamUrl(embyId);
+            actualPlayUrl = await embyService.getStreamUrl(embyId);
           } else {
             BlurSnackBar.show(context, '未连接到Emby服务器');
             return;

--- a/lib/pages/dashboard_home_page.dart
+++ b/lib/pages/dashboard_home_page.dart
@@ -2493,7 +2493,7 @@ class _DashboardHomePageState extends State<DashboardHomePage>
   // 已移除旧的创建本地动画项目的重量级方法，改为快速路径+后台补齐。
 
   void _navigateToJellyfinDetail(String jellyfinId) {
-    MediaServerDetailPage.showJellyfin(context, jellyfinId).then((result) {
+    MediaServerDetailPage.showJellyfin(context, jellyfinId).then((result) async {
       if (result != null) {
         // 检查是否需要获取实际播放URL
         String? actualPlayUrl;
@@ -2519,7 +2519,7 @@ class _DashboardHomePageState extends State<DashboardHomePage>
             final embyId = result.filePath.replaceFirst('emby://', '');
             final embyService = EmbyService.instance;
             if (embyService.isConnected) {
-              actualPlayUrl = embyService.getStreamUrl(embyId);
+              actualPlayUrl = await embyService.getStreamUrl(embyId);
             } else {
               BlurSnackBar.show(context, '未连接到Emby服务器');
               return;
@@ -2550,7 +2550,7 @@ class _DashboardHomePageState extends State<DashboardHomePage>
   }
 
   void _navigateToEmbyDetail(String embyId) {
-    MediaServerDetailPage.showEmby(context, embyId).then((result) {
+    MediaServerDetailPage.showEmby(context, embyId).then((result) async {
       if (result != null) {
         // 检查是否需要获取实际播放URL
         String? actualPlayUrl;
@@ -2571,12 +2571,12 @@ class _DashboardHomePageState extends State<DashboardHomePage>
             BlurSnackBar.show(context, '获取Jellyfin流媒体URL失败: $e');
             return;
           }
-        } else if (isEmbyProtocol) {
+    } else if (isEmbyProtocol) {
           try {
             final embyId = result.filePath.replaceFirst('emby://', '');
             final embyService = EmbyService.instance;
             if (embyService.isConnected) {
-              actualPlayUrl = embyService.getStreamUrl(embyId);
+      actualPlayUrl = await embyService.getStreamUrl(embyId);
             } else {
               BlurSnackBar.show(context, '未连接到Emby服务器');
               return;
@@ -2634,12 +2634,12 @@ class _DashboardHomePageState extends State<DashboardHomePage>
         }
       }
       
-      if (isEmbyProtocol) {
+  if (isEmbyProtocol) {
         try {
           final embyId = item.filePath.replaceFirst('emby://', '');
           final embyService = EmbyService.instance;
           if (embyService.isConnected) {
-            actualPlayUrl = embyService.getStreamUrl(embyId);
+    actualPlayUrl = await embyService.getStreamUrl(embyId);
           } else {
             BlurSnackBar.show(context, '未连接到Emby服务器');
             return;

--- a/lib/pages/fluent_dashboard_home_page.dart
+++ b/lib/pages/fluent_dashboard_home_page.dart
@@ -1502,7 +1502,7 @@ class _FluentDashboardHomePageState extends State<FluentDashboardHomePage>
   }
 
   void _navigateToEmbyDetail(String embyId) {
-    MediaServerDetailPage.showEmby(context, embyId).then((result) {
+    MediaServerDetailPage.showEmby(context, embyId).then((result) async {
       if (result != null) {
         String? actualPlayUrl;
         final isEmbyProtocol = result.filePath.startsWith('emby://');
@@ -1512,7 +1512,7 @@ class _FluentDashboardHomePageState extends State<FluentDashboardHomePage>
             final embyId = result.filePath.replaceFirst('emby://', '');
             final embyService = EmbyService.instance;
             if (embyService.isConnected) {
-              actualPlayUrl = embyService.getStreamUrl(embyId);
+              actualPlayUrl = await embyService.getStreamUrl(embyId);
             } else {
               MessageHelper.showMessage(context, '未连接到Emby服务器');
               return;
@@ -1571,7 +1571,7 @@ class _FluentDashboardHomePageState extends State<FluentDashboardHomePage>
           final embyId = item.filePath.replaceFirst('emby://', '');
           final embyService = EmbyService.instance;
           if (embyService.isConnected) {
-            actualPlayUrl = embyService.getStreamUrl(embyId);
+            actualPlayUrl = await embyService.getStreamUrl(embyId);
           } else {
             MessageHelper.showMessage(context, '未连接到Emby服务器');
             return;

--- a/lib/pages/fluent_settings/fluent_watch_history_page.dart
+++ b/lib/pages/fluent_settings/fluent_watch_history_page.dart
@@ -239,7 +239,7 @@ class _FluentWatchHistoryPageState extends State<FluentWatchHistoryPage> {
           final embyId = item.filePath.replaceFirst('emby://', '');
           final embyService = EmbyService.instance;
           if (embyService.isConnected) {
-            actualPlayUrl = embyService.getStreamUrl(embyId);
+            actualPlayUrl = await embyService.getStreamUrl(embyId);
           } else {
             MessageHelper.showMessage(context, '未连接到Emby服务器');
             return;

--- a/lib/pages/media_server_detail_page.dart
+++ b/lib/pages/media_server_detail_page.dart
@@ -1258,7 +1258,7 @@ class _MediaServerDetailPageState extends State<MediaServerDetailPage> with Sing
               if (widget.serverType == MediaServerType.jellyfin) {
                 streamUrl = JellyfinDandanplayMatcher.instance.getPlayUrl(episode);
               } else {
-                streamUrl = EmbyDandanplayMatcher.instance.getPlayUrl(episode);
+                streamUrl = await EmbyDandanplayMatcher.instance.getPlayUrl(episode);
               }
               debugPrint('获取到流媒体URL: $streamUrl');
               

--- a/lib/pages/settings/watch_history_page.dart
+++ b/lib/pages/settings/watch_history_page.dart
@@ -302,7 +302,7 @@ class _WatchHistoryPageState extends State<WatchHistoryPage> {
           final embyId = item.filePath.replaceFirst('emby://', '');
           final embyService = EmbyService.instance;
           if (embyService.isConnected) {
-            actualPlayUrl = embyService.getStreamUrl(embyId);
+            actualPlayUrl = await embyService.getStreamUrl(embyId);
           } else {
             BlurSnackBar.show(context, '未连接到Emby服务器');
             return;

--- a/lib/player_abstraction/mdk_player_adapter_io.dart
+++ b/lib/player_abstraction/mdk_player_adapter_io.dart
@@ -362,4 +362,62 @@ class MdkPlayerAdapter implements AbstractPlayer {
   void setPlaybackRate(double rate) {
     playbackRate = rate;
   }
+
+  // 提供详细播放技术信息（MDK）
+  Map<String, dynamic> getDetailedMediaInfo() {
+    final info = _mdkPlayer.mediaInfo;
+    final Map<String, dynamic> ret = {
+      'kernel': 'MDK',
+      'video': <dynamic>[],
+      'audio': <dynamic>[],
+      'duration': info.duration,
+    };
+
+    try {
+      ret['video'] = (info.video ?? []).map((v) {
+        final codec = v.codec;
+        String codecName = 'unknown';
+        try {
+          final dynamic name = (v as dynamic).codecName;
+          if (name is String && name.isNotEmpty) codecName = name;
+        } catch (_) {
+          codecName = codec.toString();
+        }
+        return {
+          'codecName': codecName,
+          'width': codec.width,
+          'height': codec.height,
+          'raw': v.toString(),
+        };
+      }).toList();
+    } catch (_) {}
+
+    try {
+      ret['audio'] = (info.audio ?? []).map((a) {
+        final dynamic c = (a as dynamic).codec;
+        String? name;
+        int? bitRate;
+        int? channels;
+        int? sampleRate;
+        try { name = c?.name as String?; } catch (_) {}
+        try { bitRate = c?.bit_rate as int?; } catch (_) {}
+        try { channels = c?.channels as int?; } catch (_) {}
+        try { sampleRate = c?.sample_rate as int?; } catch (_) {}
+        return {
+          'codecName': name,
+          'bitRate': bitRate,
+          'channels': channels,
+          'sampleRate': sampleRate,
+          'raw': a.toString(),
+        };
+      }).toList();
+    } catch (_) {}
+
+    return ret;
+  }
+
+  // MDK 的异步接口：直接返回同步结果（MDK 获取多为同步）
+  Future<Map<String, dynamic>> getDetailedMediaInfoAsync() async {
+    return getDetailedMediaInfo();
+  }
 } 

--- a/lib/player_abstraction/mdk_player_adapter_unsupported.dart
+++ b/lib/player_abstraction/mdk_player_adapter_unsupported.dart
@@ -87,4 +87,7 @@ class MdkPlayerAdapter implements AbstractPlayer {
 
   @override
   void setPlaybackRate(double rate) {}
+
+  // 详细播放技术信息（不支持MDK的平台返回空）
+  Map<String, dynamic> getDetailedMediaInfo() => const <String, dynamic>{};
 } 

--- a/lib/player_abstraction/player_abstraction.dart
+++ b/lib/player_abstraction/player_abstraction.dart
@@ -150,6 +150,32 @@ class Player {
   
   // 添加setPlaybackRate方法实现
   void setPlaybackRate(double rate) => _delegate.setPlaybackRate(rate);
+
+  // 播放技术信息（可选）
+  // 返回一个同步的 Map，用于暴露底层内核的技术细节（fps/bitrate/mpv属性/轨道等）。
+  // 若底层未实现，则返回空映射。
+  Map<String, dynamic> getDetailedMediaInfo() {
+    try {
+      final dyn = _delegate as dynamic;
+      final info = dyn.getDetailedMediaInfo?.call();
+      if (info is Map<String, dynamic>) return info;
+    } catch (_) {}
+    return const <String, dynamic>{};
+  }
+
+  // 异步版本：允许底层等待获取属性（例如 mpv 的 getProperty 通常是异步的）
+  Future<Map<String, dynamic>> getDetailedMediaInfoAsync() async {
+    try {
+      final dyn = _delegate as dynamic;
+      final f = dyn.getDetailedMediaInfoAsync?.call();
+      if (f is Future) {
+        final info = await f;
+        if (info is Map<String, dynamic>) return info;
+      }
+    } catch (_) {}
+    // 回退到同步版本
+    return getDetailedMediaInfo();
+  }
 }
 
 // Type aliases for full compatibility if VideoPlayerState uses these type names

--- a/lib/player_abstraction/video_player_adapter.dart
+++ b/lib/player_abstraction/video_player_adapter.dart
@@ -1073,4 +1073,30 @@ class VideoPlayerAdapter implements AbstractPlayer, TickerProvider {
   void setPlaybackRate(double rate) {
     playbackRate = rate; // 这将调用setter
   }
+
+  // 提供详细播放技术信息（video_player能力有限，返回基础信息）
+  Map<String, dynamic> getDetailedMediaInfo() {
+    final Map<String, dynamic> result = {
+      'kernel': 'VideoPlayer',
+      'videoParams': <String, dynamic>{},
+      'audioParams': <String, dynamic>{},
+      'tracks': <String, dynamic>{},
+    };
+    try {
+      final v = _controller?.value;
+      if (v != null && v.isInitialized) {
+        result['videoParams'] = {
+          'width': v.size.width.toInt(),
+          'height': v.size.height.toInt(),
+          'durationMs': v.duration.inMilliseconds,
+          'isPlaying': v.isPlaying,
+        };
+      }
+    } catch (_) {}
+    return result;
+  }
+
+  Future<Map<String, dynamic>> getDetailedMediaInfoAsync() async {
+    return getDetailedMediaInfo();
+  }
 } 

--- a/lib/providers/emby_provider.dart
+++ b/lib/providers/emby_provider.dart
@@ -325,9 +325,9 @@ class EmbyProvider extends ChangeNotifier {
     }
   }
   
-  // 获取流媒体URL
-  String getStreamUrl(String itemId) {
-    return _embyService.getStreamUrl(itemId);
+  // 获取流媒体URL（异步，保证含会话参数）
+  Future<String> getStreamUrl(String itemId) async {
+    return await _embyService.getStreamUrl(itemId);
   }
   
   // 获取图片URL

--- a/lib/providers/emby_transcode_provider.dart
+++ b/lib/providers/emby_transcode_provider.dart
@@ -45,8 +45,20 @@ class EmbyTranscodeProvider extends ChangeNotifier {
     try {
       await _transcodeManager.setTranscodingEnabled(enabled);
       _transcodeEnabled = enabled;
+      
+      // 如果关闭转码，自动将质量重置为原画
+      if (!enabled) {
+        await _transcodeManager.saveDefaultVideoQuality(JellyfinVideoQuality.original);
+        _settings = _settings.copyWith(
+          video: _settings.video.copyWith(quality: JellyfinVideoQuality.original)
+        );
+      }
+      
       try {
-        EmbyService.instance.setTranscodePreferences(enabled: enabled);
+        EmbyService.instance.setTranscodePreferences(
+          enabled: enabled,
+          defaultQuality: !enabled ? JellyfinVideoQuality.original : null,
+        );
       } catch (_) {}
       notifyListeners();
       return true;

--- a/lib/providers/emby_transcode_provider.dart
+++ b/lib/providers/emby_transcode_provider.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:nipaplay/services/emby_transcode_manager.dart';
+import 'package:nipaplay/models/jellyfin_transcode_settings.dart';
+import 'package:nipaplay/services/emby_service.dart';
+
+class EmbyTranscodeProvider extends ChangeNotifier {
+  static final EmbyTranscodeProvider _instance = EmbyTranscodeProvider._internal();
+  factory EmbyTranscodeProvider() => _instance;
+  EmbyTranscodeProvider._internal();
+
+  final EmbyTranscodeManager _transcodeManager = EmbyTranscodeManager.instance;
+
+  JellyfinTranscodeSettings _settings = const JellyfinTranscodeSettings();
+  bool _transcodeEnabled = true;
+  bool _isInitialized = false;
+
+  JellyfinTranscodeSettings get settings => _settings;
+  bool get transcodeEnabled => _transcodeEnabled;
+  JellyfinVideoQuality get currentVideoQuality => _settings.video.quality;
+  bool get isInitialized => _isInitialized;
+
+  Future<void> initialize() async {
+    if (_isInitialized) return;
+    try {
+      await _transcodeManager.initialize();
+      await _loadSettings();
+      _isInitialized = true;
+    } catch (e) {
+      debugPrint('EmbyTranscodeProvider 初始化失败: $e');
+      _isInitialized = true;
+    }
+  }
+
+  Future<void> _loadSettings() async {
+    try {
+      _settings = await _transcodeManager.getSettings();
+      _transcodeEnabled = await _transcodeManager.isTranscodingEnabled();
+      notifyListeners();
+    } catch (e) {
+      debugPrint('加载 Emby 转码设置失败: $e');
+    }
+  }
+
+  Future<bool> setTranscodeEnabled(bool enabled) async {
+    try {
+      await _transcodeManager.setTranscodingEnabled(enabled);
+      _transcodeEnabled = enabled;
+      try {
+        EmbyService.instance.setTranscodePreferences(enabled: enabled);
+      } catch (_) {}
+      notifyListeners();
+      return true;
+    } catch (e) {
+      debugPrint('更新 Emby 转码启用状态失败: $e');
+      return false;
+    }
+  }
+
+  Future<bool> setDefaultVideoQuality(JellyfinVideoQuality quality) async {
+    try {
+      await _transcodeManager.saveDefaultVideoQuality(quality);
+      _settings = _settings.copyWith(video: _settings.video.copyWith(quality: quality));
+      await _transcodeManager.saveSettings(_settings);
+      try {
+        EmbyService.instance.setTranscodePreferences(defaultQuality: quality);
+      } catch (_) {}
+      notifyListeners();
+      return true;
+    } catch (e) {
+      debugPrint('更新 Emby 默认视频质量失败: $e');
+      return false;
+    }
+  }
+
+  Future<bool> updateSettings(JellyfinTranscodeSettings settings) async {
+    try {
+      await _transcodeManager.saveSettings(settings);
+      _settings = settings;
+      try {
+        EmbyService.instance.setFullTranscodeSettings(settings);
+      } catch (_) {}
+      notifyListeners();
+      return true;
+    } catch (e) {
+      debugPrint('更新 Emby 转码设置失败: $e');
+      return false;
+    }
+  }
+
+  Future<void> refresh() async {
+    if (!_isInitialized) {
+      await initialize();
+      return;
+    }
+    await _loadSettings();
+  }
+
+  JellyfinVideoQuality getRecommendedQuality(double networkSpeedMbps) {
+    return _transcodeManager.getRecommendedQuality(networkSpeedMbps);
+  }
+
+  Future<bool> resetToDefaults() async {
+    try {
+      await _transcodeManager.resetToDefaults();
+      await _loadSettings();
+      return true;
+    } catch (e) {
+      debugPrint('Emby 重置转码设置失败: $e');
+      return false;
+    }
+  }
+}

--- a/lib/providers/jellyfin_transcode_provider.dart
+++ b/lib/providers/jellyfin_transcode_provider.dart
@@ -58,9 +58,21 @@ class JellyfinTranscodeProvider extends ChangeNotifier {
     try {
       await _transcodeManager.setTranscodingEnabled(enabled);
       _transcodeEnabled = enabled;
+      
+      // 如果关闭转码，自动将质量重置为原画
+      if (!enabled) {
+        await _transcodeManager.saveDefaultVideoQuality(JellyfinVideoQuality.original);
+        _settings = _settings.copyWith(
+          video: _settings.video.copyWith(quality: JellyfinVideoQuality.original)
+        );
+      }
+      
       // 同步到 JellyfinService 的转码偏好缓存
       try {
-        JellyfinService.instance.setTranscodePreferences(enabled: enabled);
+        JellyfinService.instance.setTranscodePreferences(
+          enabled: enabled,
+          defaultQuality: !enabled ? JellyfinVideoQuality.original : null,
+        );
       } catch (_) {}
       notifyListeners();
       return true;

--- a/lib/providers/jellyfin_transcode_provider.dart
+++ b/lib/providers/jellyfin_transcode_provider.dart
@@ -1,0 +1,140 @@
+import 'package:flutter/material.dart';
+import 'package:nipaplay/services/jellyfin_transcode_manager.dart';
+import 'package:nipaplay/models/jellyfin_transcode_settings.dart';
+import 'package:nipaplay/services/jellyfin_service.dart';
+
+/// Jellyfin转码设置Provider
+/// 负责管理全局转码设置状态和同步
+class JellyfinTranscodeProvider extends ChangeNotifier {
+  static final JellyfinTranscodeProvider _instance = JellyfinTranscodeProvider._internal();
+  factory JellyfinTranscodeProvider() => _instance;
+  JellyfinTranscodeProvider._internal();
+
+  final JellyfinTranscodeManager _transcodeManager = JellyfinTranscodeManager.instance;
+  
+  JellyfinTranscodeSettings _settings = const JellyfinTranscodeSettings();
+  bool _transcodeEnabled = true;
+  bool _isInitialized = false;
+
+  /// 当前转码设置
+  JellyfinTranscodeSettings get settings => _settings;
+  
+  /// 是否启用转码
+  bool get transcodeEnabled => _transcodeEnabled;
+  
+  /// 当前默认视频质量
+  JellyfinVideoQuality get currentVideoQuality => _settings.video.quality;
+  
+  /// 是否已初始化
+  bool get isInitialized => _isInitialized;
+
+  /// 初始化Provider
+  Future<void> initialize() async {
+    if (_isInitialized) return;
+
+    try {
+      await _transcodeManager.initialize();
+      await _loadSettings();
+      _isInitialized = true;
+    } catch (e) {
+      debugPrint('JellyfinTranscodeProvider初始化失败: $e');
+      _isInitialized = true; // 即使失败也标记为已初始化，避免重复尝试
+    }
+  }
+
+  /// 加载转码设置
+  Future<void> _loadSettings() async {
+    try {
+      _settings = await _transcodeManager.getSettings();
+      _transcodeEnabled = await _transcodeManager.isTranscodingEnabled();
+      notifyListeners();
+    } catch (e) {
+      debugPrint('加载转码设置失败: $e');
+    }
+  }
+
+  /// 更新转码启用状态
+  Future<bool> setTranscodeEnabled(bool enabled) async {
+    try {
+      await _transcodeManager.setTranscodingEnabled(enabled);
+      _transcodeEnabled = enabled;
+      // 同步到 JellyfinService 的转码偏好缓存
+      try {
+        JellyfinService.instance.setTranscodePreferences(enabled: enabled);
+      } catch (_) {}
+      notifyListeners();
+      return true;
+    } catch (e) {
+      debugPrint('更新转码启用状态失败: $e');
+      return false;
+    }
+  }
+
+  /// 更新默认视频质量
+  Future<bool> setDefaultVideoQuality(JellyfinVideoQuality quality) async {
+    try {
+      await _transcodeManager.saveDefaultVideoQuality(quality);
+      
+      // 更新本地设置
+      _settings = _settings.copyWith(
+        video: _settings.video.copyWith(quality: quality),
+      );
+      
+      // 同时保存完整设置
+      await _transcodeManager.saveSettings(_settings);
+      // 同步到 JellyfinService 的转码偏好缓存
+      try {
+        JellyfinService.instance.setTranscodePreferences(defaultQuality: quality);
+      } catch (_) {}
+      
+      notifyListeners();
+      return true;
+    } catch (e) {
+      debugPrint('更新默认视频质量失败: $e');
+      return false;
+    }
+  }
+
+  /// 更新完整转码设置
+  Future<bool> updateSettings(JellyfinTranscodeSettings settings) async {
+    try {
+      await _transcodeManager.saveSettings(settings);
+      _settings = settings;
+      // 同步到 JellyfinService 的完整设置缓存
+      try {
+        JellyfinService.instance.setFullTranscodeSettings(settings);
+      } catch (_) {}
+      notifyListeners();
+      return true;
+    } catch (e) {
+      debugPrint('更新转码设置失败: $e');
+      return false;
+    }
+  }
+
+  /// 重新加载设置（用于外部修改后同步）
+  Future<void> refresh() async {
+    if (!_isInitialized) {
+      await initialize();
+      return;
+    }
+    await _loadSettings();
+  }
+
+  /// 获取基于网络状况的推荐质量
+  JellyfinVideoQuality getRecommendedQuality(double networkSpeedMbps) {
+    return _transcodeManager.getRecommendedQuality(networkSpeedMbps);
+  }
+
+  /// 重置为默认设置
+  Future<bool> resetToDefaults() async {
+    try {
+      await _transcodeManager.resetToDefaults();
+      await _loadSettings();
+      return true;
+    } catch (e) {
+      debugPrint('重置转码设置失败: $e');
+      return false;
+    }
+  }
+}

--- a/lib/services/emby_dandanplay_matcher.dart
+++ b/lib/services/emby_dandanplay_matcher.dart
@@ -166,7 +166,7 @@ class EmbyDandanplayMatcher {
     
     try {
       // 获取Emby流媒体URL（仅用于日志）
-      final streamUrl = getPlayUrl(episode);
+      final streamUrl = await getPlayUrl(episode);
       debugPrint('正在为Emby内容创建可播放项: ${episode.seriesName} - ${episode.name}');
       debugPrint('Emby流媒体URL: $streamUrl');
       
@@ -280,8 +280,8 @@ class EmbyDandanplayMatcher {
   /// 获取播放URL
   /// 
   /// 根据Emby剧集信息获取媒体流URL
-  String getPlayUrl(EmbyEpisodeInfo episode) {
-    final url = EmbyService.instance.getStreamUrl(episode.id);
+  Future<String> getPlayUrl(EmbyEpisodeInfo episode) async {
+    final url = await EmbyService.instance.getStreamUrl(episode.id);
     debugPrint('Emby流媒体URL: $url');
     return url;
   }
@@ -841,7 +841,7 @@ class EmbyDandanplayMatcher {
       debugPrint('开始计算Emby视频哈希值: $seriesName - $episodeName');
       
       // 获取流媒体URL
-      final String streamUrl = EmbyService.instance.getStreamUrl(episode.id);
+  final String streamUrl = await EmbyService.instance.getStreamUrl(episode.id);
       
       if (streamUrl.isEmpty) {
         debugPrint('无法获取流媒体URL');

--- a/lib/services/emby_service.dart
+++ b/lib/services/emby_service.dart
@@ -58,7 +58,7 @@ class EmbyService {
   final MultiAddressServerService _multiAddressService = MultiAddressServerService.instance;
 
   // 转码偏好缓存（内存）——让 Provider 能在运行时同步设置，避免 async IO
-  bool _transcodeEnabledCache = true;
+  bool _transcodeEnabledCache = false;
   JellyfinVideoQuality _defaultQualityCache = JellyfinVideoQuality.bandwidth5m;
   JellyfinTranscodeSettings _settingsCache = const JellyfinTranscodeSettings();
 
@@ -254,7 +254,7 @@ class EmbyService {
       DebugLogService().addLog('Emby: 已加载转码偏好 缓存 enabled=' + _transcodeEnabledCache.toString() + ', quality=' + _defaultQualityCache.toString());
     } catch (e) {
       DebugLogService().addLog('Emby: 加载转码偏好失败，使用默认值: $e');
-      _transcodeEnabledCache = true;
+      _transcodeEnabledCache = false;
       _defaultQualityCache = JellyfinVideoQuality.bandwidth5m;
       _settingsCache = const JellyfinTranscodeSettings();
     }

--- a/lib/services/emby_service.dart
+++ b/lib/services/emby_service.dart
@@ -11,6 +11,7 @@ import 'dart:io' if (dart.library.io) 'dart:io';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'debug_log_service.dart';
 import 'package:nipaplay/models/jellyfin_transcode_settings.dart';
+import 'package:nipaplay/services/emby_transcode_manager.dart';
 
 import 'package:nipaplay/utils/url_name_generator.dart';
 
@@ -55,6 +56,11 @@ class EmbyService {
   ServerProfile? _currentProfile;
   String? _currentAddressId;
   final MultiAddressServerService _multiAddressService = MultiAddressServerService.instance;
+
+  // 转码偏好缓存（内存）——让 Provider 能在运行时同步设置，避免 async IO
+  bool _transcodeEnabledCache = true;
+  JellyfinVideoQuality _defaultQualityCache = JellyfinVideoQuality.bandwidth5m;
+  JellyfinTranscodeSettings _settingsCache = const JellyfinTranscodeSettings();
 
   // Client information cache
   String? _cachedClientInfo;
@@ -236,6 +242,21 @@ class EmbyService {
       print('Emby: 缺少必要的连接信息，跳过自动连接');
       _isConnected = false;
   _isReady = false;
+    }
+
+    // 预加载转码设置到本地缓存，避免在 getStreamUrl 中做异步操作（与 Jellyfin 行为一致）
+    try {
+      final transMgr = EmbyTranscodeManager.instance;
+      await transMgr.initialize();
+      _transcodeEnabledCache = await transMgr.isTranscodingEnabled();
+      _defaultQualityCache = await transMgr.getDefaultVideoQuality();
+      _settingsCache = await transMgr.getSettings();
+      DebugLogService().addLog('Emby: 已加载转码偏好 缓存 enabled=' + _transcodeEnabledCache.toString() + ', quality=' + _defaultQualityCache.toString());
+    } catch (e) {
+      DebugLogService().addLog('Emby: 加载转码偏好失败，使用默认值: $e');
+      _transcodeEnabledCache = true;
+      _defaultQualityCache = JellyfinVideoQuality.bandwidth5m;
+      _settingsCache = const JellyfinTranscodeSettings();
     }
   }
   
@@ -1215,12 +1236,99 @@ class EmbyService {
     return null;
   }
   
-  String getStreamUrl(String itemId) {
+  // 获取流媒体URL（异步，确保含 MediaSourceId/PlaySessionId）
+  Future<String> getStreamUrl(String itemId) async {
     if (!_isConnected || _accessToken == null) {
       return '';
     }
-    
-    return '$_serverUrl/emby/Videos/$itemId/stream?api_key=$_accessToken&Static=true';
+    // 使用缓存的转码设置决定默认质量
+    final effectiveQuality = _transcodeEnabledCache
+        ? _defaultQualityCache
+        : JellyfinVideoQuality.original;
+
+    // 原画或未启用转码 -> 直连
+    if (effectiveQuality == JellyfinVideoQuality.original) {
+      return _buildDirectPlayUrl(itemId);
+    }
+
+    // 其余情况 -> 通过 PlaybackInfo 构建带会话的 HLS URL
+    return await buildHlsUrlWithOptions(
+      itemId,
+      quality: effectiveQuality,
+    );
+  }
+
+  /// 获取流媒体URL（同步），与 Jellyfin 保持一致的调用方式
+  /// 若 quality 为 original 或强制直连，则返回直连 Static 流；否则返回带转码参数的 HLS master.m3u8。
+  String getStreamUrlWithOptions(
+    String itemId, {
+    JellyfinVideoQuality? quality,
+    bool forceDirectPlay = false,
+    int? subtitleStreamIndex,
+    bool? burnInSubtitle,
+  }) {
+    if (!_isConnected || _accessToken == null) {
+      throw Exception('未连接到Emby服务器');
+    }
+
+    // 强制直连
+    if (forceDirectPlay) {
+      return _buildDirectPlayUrl(itemId);
+    }
+
+    // 计算实际清晰度
+    final effective = quality ?? (_transcodeEnabledCache
+        ? _defaultQualityCache
+        : JellyfinVideoQuality.original);
+
+    // 构建直连或转码 URL
+    return _buildTranscodeUrlSync(
+      itemId,
+      effective,
+      subtitleStreamIndex: subtitleStreamIndex,
+      burnInSubtitle: burnInSubtitle,
+    );
+  }
+
+  /// 构建直连URL（不转码）
+  String _buildDirectPlayUrl(String itemId) {
+    return '$_serverUrl/emby/Videos/$itemId/stream?Static=true&api_key=$_accessToken';
+  }
+
+  /// 构建转码URL（HLS 使用 master.m3u8，尽量同步生成，必要参数使用约定填充）
+  /// 说明：为保持同步调用，此处不请求 PlaybackInfo；在多数 Emby 环境下可以正常工作。
+  /// 若遇到个别服务器需要 MediaSourceId/PlaySessionId，可通过 UI 切换质量时的异步 buildHlsUrlWithOptions 获得更稳妥的 URL。
+  String _buildTranscodeUrlSync(
+    String itemId,
+    JellyfinVideoQuality? quality, {
+    int? subtitleStreamIndex,
+    bool? burnInSubtitle,
+  }) {
+    // original 或未指定 -> 直连
+    if (quality == null || quality == JellyfinVideoQuality.original) {
+      return _buildDirectPlayUrl(itemId);
+    }
+
+    final params = <String, String>{
+      'api_key': _accessToken!,
+      // HLS 分片容器
+      'Container': 'ts',
+      // 尝试传递 MediaSourceId 为 itemId（大多数情况下等同）以避免服务器端 mediaSource 为空
+      'MediaSourceId': itemId,
+    };
+
+    // 添加常规转码参数（码率/分辨率/编解码器/音频限制/字幕处理）
+    _addTranscodeParameters(
+      params,
+      quality,
+      subtitleStreamIndex: subtitleStreamIndex,
+      burnInSubtitle: burnInSubtitle,
+    );
+
+    final uri = Uri.parse('$_serverUrl/emby/Videos/$itemId/master.m3u8')
+        .replace(queryParameters: params);
+    debugPrint('[Emby HLS(sync)] 构建URL: ${uri.toString()}');
+    return uri.toString();
   }
 
   /// 构建 Emby HLS URL（带可选的服务器端字幕选择与烧录开关）
@@ -1242,11 +1350,32 @@ class EmbyService {
       return getStreamUrl(itemId);
     }
 
+    // 先获取 PlaybackInfo，拿到 MediaSourceId & PlaySessionId
+    String? mediaSourceId;
+    String? playSessionId;
+    try {
+      final playbackInfoResp = await _makeAuthenticatedRequest(
+        '/emby/Items/$itemId/PlaybackInfo?UserId=$_userId',
+      );
+      if (playbackInfoResp.statusCode == 200) {
+        final pb = json.decode(playbackInfoResp.body) as Map<String, dynamic>;
+        final srcs = (pb['MediaSources'] as List?) ?? const [];
+        if (srcs.isNotEmpty) {
+          final first = srcs.first as Map<String, dynamic>;
+          mediaSourceId = first['Id']?.toString();
+        }
+        playSessionId = pb['PlaySessionId']?.toString();
+      }
+    } catch (e) {
+      DebugLogService().addLog('Emby HLS: 获取PlaybackInfo失败: $e');
+    }
+
     final params = <String, String>{
       'api_key': _accessToken!,
       // Emby 对 master.m3u8 接口的典型参数
       'Container': 'ts', // HLS 分片容器
-      'MediaSourceId': itemId,
+  if (mediaSourceId != null && mediaSourceId.isNotEmpty) 'MediaSourceId': mediaSourceId,
+  if (playSessionId != null && playSessionId.isNotEmpty) 'PlaySessionId': playSessionId,
     };
 
     _addTranscodeParameters(params, effectiveQuality);
@@ -1269,14 +1398,13 @@ class EmbyService {
   }
 
   /// 为 Emby 添加转码参数（注意参数名大小写与 Jellyfin 不同）
-  void _addTranscodeParameters(Map<String, String> params, JellyfinVideoQuality quality) {
-    final bitrate = quality.bitrate; // Mbps
+  void _addTranscodeParameters(Map<String, String> params, JellyfinVideoQuality quality, {int? subtitleStreamIndex, bool? burnInSubtitle}) {
+    final bitrate = quality.bitrate;
     final resolution = quality.maxResolution;
 
     if (bitrate != null) {
-      final br = (bitrate * 1000).toString();
-      params['VideoBitRate'] = br;
-      params['MaxStreamingBitrate'] = br; // 一些服务器实现会读取该参数
+      params['MaxStreamingBitrate'] = (bitrate * 1000).toString();
+      params['VideoBitRate'] = (bitrate * 1000).toString();
     }
 
     if (resolution != null) {
@@ -1284,14 +1412,52 @@ class EmbyService {
       params['MaxHeight'] = resolution.height.toString();
     }
 
-    // 合理的编解码优先级（可根据需要改为从设置读取）
-    params['VideoCodec'] = 'h264,hevc,av1';
-    params['AudioCodec'] = 'aac,mp3,opus';
+    // 从本地设置缓存读取编解码偏好，若未配置使用合理默认
+    final videoCodecs = _settingsCache.video.preferredCodecs.isNotEmpty
+        ? _settingsCache.video.preferredCodecs.join(',')
+        : 'h264,hevc,av1';
+    final audioCodecs = _settingsCache.audio.preferredCodecs.isNotEmpty
+        ? _settingsCache.audio.preferredCodecs.join(',')
+        : 'aac,mp3,opus';
+    params['VideoCodec'] = videoCodecs;
+    params['AudioCodec'] = audioCodecs;
 
-    // 音频约束（保守默认，不强制）
-    // 可在后续接入独立设置后开启：
-    // params['MaxAudioChannels'] = '2';
-    // params['AudioBitRate'] = '192000';
+    // 音频限制
+    if (_settingsCache.audio.maxAudioChannels > 0) {
+      params['MaxAudioChannels'] = _settingsCache.audio.maxAudioChannels.toString();
+    }
+    if (_settingsCache.audio.audioBitRate != null && _settingsCache.audio.audioBitRate! > 0) {
+      params['AudioBitRate'] = (_settingsCache.audio.audioBitRate! * 1000).toString();
+    }
+    if (_settingsCache.audio.audioSampleRate != null && _settingsCache.audio.audioSampleRate! > 0) {
+      params['AudioSampleRate'] = _settingsCache.audio.audioSampleRate!.toString();
+    }
+
+    // 字幕处理：如果设置允许服务端处理并非 external/drop，则添加相应参数
+    if (_settingsCache.subtitle.enableTranscoding &&
+        _settingsCache.subtitle.deliveryMethod != JellyfinSubtitleDeliveryMethod.external &&
+        _settingsCache.subtitle.deliveryMethod != JellyfinSubtitleDeliveryMethod.drop) {
+      params['SubtitleMethod'] = _settingsCache.subtitle.deliveryMethod.apiValue;
+      if (subtitleStreamIndex != null && subtitleStreamIndex >= 0) {
+        params['SubtitleStreamIndex'] = subtitleStreamIndex.toString();
+      }
+      final shouldBurn = burnInSubtitle ?? (_settingsCache.subtitle.deliveryMethod == JellyfinSubtitleDeliveryMethod.encode);
+      if (shouldBurn) {
+        params['AlwaysBurnInSubtitleWhenTranscoding'] = 'true';
+      }
+    }
+
+    // 保证参数整洁
+    try {
+      if (params['MaxStreamingBitrate']?.isEmpty == true) params.remove('MaxStreamingBitrate');
+      if (params['MaxWidth'] == '0' || params['MaxHeight'] == '0') {
+        params.remove('MaxWidth');
+        params.remove('MaxHeight');
+      }
+    } catch (e) {
+      debugPrint('添加 Emby 转码参数时出错: $e');
+      params.removeWhere((key, value) => key.startsWith('Max') || key.contains('BitRate'));
+    }
   }
   
   String getImageUrl(String itemId, {String type = 'Primary', int? width, int? height, int? quality, String? tag}) {
@@ -1592,6 +1758,19 @@ class EmbyService {
       return _currentProfile!.addresses;
     }
     return [];
+  }
+
+  /// 由 Provider 调用：在运行时更新本地转码缓存（避免在 getStreamUrl 中做异步 IO）
+  void setTranscodePreferences({bool? enabled, JellyfinVideoQuality? defaultQuality}) {
+    if (enabled != null) _transcodeEnabledCache = enabled;
+    if (defaultQuality != null) _defaultQualityCache = defaultQuality;
+    DebugLogService().addLog('Emby: 更新转码偏好 缓存 enabled=${enabled ?? _transcodeEnabledCache}, quality=${defaultQuality ?? _defaultQualityCache}');
+  }
+
+  /// 由 Provider 调用：更新完整转码设置缓存（用于音频/字幕等参数）
+  void setFullTranscodeSettings(JellyfinTranscodeSettings settings) {
+    _settingsCache = settings;
+    DebugLogService().addLog('Emby: 更新完整转码设置缓存 (video/audio/subtitle/adaptive)');
   }
   
   /// 添加新地址到当前服务器

--- a/lib/services/emby_transcode_manager.dart
+++ b/lib/services/emby_transcode_manager.dart
@@ -79,10 +79,11 @@ class EmbyTranscodeManager {
       final prefs = await SharedPreferences.getInstance();
       final enabledString = prefs.getString(_keyEnableTranscoding);
       if (enabledString != null) return enabledString.toLowerCase() == 'true';
-      return true;
+      // 默认关闭转码，保持原有直连体验
+      return false;
     } catch (e) {
       debugPrint('获取 Emby 转码启用状态失败: $e');
-      return true;
+      return false;
     }
   }
 

--- a/lib/services/emby_transcode_manager.dart
+++ b/lib/services/emby_transcode_manager.dart
@@ -1,0 +1,140 @@
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../models/jellyfin_transcode_settings.dart';
+
+/// Emby 转码设置管理器（与 Jellyfin 分离存储）
+class EmbyTranscodeManager {
+  static final EmbyTranscodeManager instance = EmbyTranscodeManager._internal();
+
+  EmbyTranscodeManager._internal();
+
+  static const String _keyTranscodeSettings = 'emby_transcode_settings';
+  static const String _keyDefaultQuality = 'emby_default_quality';
+  static const String _keyEnableTranscoding = 'emby_enable_transcoding';
+
+  JellyfinTranscodeSettings? _cachedSettings;
+  bool _isInitialized = false;
+
+  Future<void> initialize() async {
+    if (_isInitialized) return;
+    try {
+      await _loadSettings();
+      _isInitialized = true;
+    } catch (e) {
+      debugPrint('EmbyTranscodeManager 初始化失败: $e');
+      _cachedSettings = const JellyfinTranscodeSettings();
+      _isInitialized = true;
+    }
+  }
+
+  Future<JellyfinTranscodeSettings> getSettings() async {
+    if (!_isInitialized) await initialize();
+    return _cachedSettings ?? const JellyfinTranscodeSettings();
+  }
+
+  Future<void> saveSettings(JellyfinTranscodeSettings settings) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final jsonString = json.encode(settings.toJson());
+      await prefs.setString(_keyTranscodeSettings, jsonString);
+      _cachedSettings = settings;
+      debugPrint('Emby 转码设置已保存');
+    } catch (e) {
+      debugPrint('保存 Emby 转码设置失败: $e');
+      rethrow;
+    }
+  }
+
+  Future<JellyfinVideoQuality> getDefaultVideoQuality() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final qualityString = prefs.getString(_keyDefaultQuality);
+      if (qualityString != null) {
+        final qualityIndex = int.tryParse(qualityString);
+        if (qualityIndex != null && qualityIndex < JellyfinVideoQuality.values.length) {
+          return JellyfinVideoQuality.values[qualityIndex];
+        }
+      }
+      return JellyfinVideoQuality.bandwidth5m;
+    } catch (e) {
+      debugPrint('获取 Emby 默认视频质量失败: $e');
+      return JellyfinVideoQuality.bandwidth5m;
+    }
+  }
+
+  Future<void> saveDefaultVideoQuality(JellyfinVideoQuality quality) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_keyDefaultQuality, quality.index.toString());
+      debugPrint('Emby 默认视频质量已保存: ${quality.displayName}');
+    } catch (e) {
+      debugPrint('保存 Emby 默认视频质量失败: $e');
+      rethrow;
+    }
+  }
+
+  Future<bool> isTranscodingEnabled() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final enabledString = prefs.getString(_keyEnableTranscoding);
+      if (enabledString != null) return enabledString.toLowerCase() == 'true';
+      return true;
+    } catch (e) {
+      debugPrint('获取 Emby 转码启用状态失败: $e');
+      return true;
+    }
+  }
+
+  Future<void> setTranscodingEnabled(bool enabled) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_keyEnableTranscoding, enabled.toString());
+      debugPrint('Emby 转码启用状态已保存: $enabled');
+    } catch (e) {
+      debugPrint('保存 Emby 转码启用状态失败: $e');
+      rethrow;
+    }
+  }
+
+  Future<void> resetToDefaults() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.remove(_keyTranscodeSettings);
+      await prefs.remove(_keyDefaultQuality);
+      await prefs.remove(_keyEnableTranscoding);
+      _cachedSettings = null;
+      debugPrint('Emby 转码设置已重置');
+    } catch (e) {
+      debugPrint('重置 Emby 转码设置失败: $e');
+      rethrow;
+    }
+  }
+
+  Future<void> _loadSettings() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final settingsString = prefs.getString(_keyTranscodeSettings);
+      if (settingsString != null && settingsString.isNotEmpty) {
+        final jsonData = json.decode(settingsString) as Map<String, dynamic>;
+        _cachedSettings = JellyfinTranscodeSettings.fromJson(jsonData);
+      } else {
+        _cachedSettings = const JellyfinTranscodeSettings();
+      }
+    } catch (e) {
+      debugPrint('加载 Emby 转码设置失败: $e');
+      _cachedSettings = const JellyfinTranscodeSettings();
+    }
+  }
+
+  JellyfinVideoQuality getRecommendedQuality(double networkSpeedMbps) {
+    if (networkSpeedMbps <= 0) return JellyfinVideoQuality.bandwidth1m;
+    final effectiveSpeed = networkSpeedMbps * 0.8;
+    if (effectiveSpeed >= 35) return JellyfinVideoQuality.bandwidth40m;
+    if (effectiveSpeed >= 16) return JellyfinVideoQuality.bandwidth20m;
+    if (effectiveSpeed >= 8) return JellyfinVideoQuality.bandwidth10m;
+    if (effectiveSpeed >= 4) return JellyfinVideoQuality.bandwidth5m;
+    if (effectiveSpeed >= 1.5) return JellyfinVideoQuality.bandwidth2m;
+    return JellyfinVideoQuality.bandwidth1m;
+  }
+}

--- a/lib/services/jellyfin_service.dart
+++ b/lib/services/jellyfin_service.dart
@@ -14,6 +14,7 @@ import 'debug_log_service.dart';
 
 import 'package:nipaplay/utils/url_name_generator.dart';
 import '../models/jellyfin_transcode_settings.dart';
+import 'jellyfin_transcode_manager.dart';
 
 class JellyfinService {
   static final JellyfinService instance = JellyfinService._internal();
@@ -59,6 +60,11 @@ class JellyfinService {
 
   // Client information cache
   String? _cachedClientInfo;
+
+  // Transcode preferences cache (loaded once and updated by provider)
+  bool _transcodeEnabledCache = true;
+  JellyfinVideoQuality _defaultQualityCache = JellyfinVideoQuality.bandwidth5m;
+  JellyfinTranscodeSettings _settingsCache = const JellyfinTranscodeSettings();
 
   // Get dynamic client information
   Future<String> _getClientInfo() async {
@@ -249,6 +255,21 @@ class JellyfinService {
     } else {
       _isConnected = false;
   _isReady = false;
+    }
+
+    // 预加载转码设置到本地缓存，避免在 getStreamUrl 中做异步操作
+    try {
+      final transMgr = JellyfinTranscodeManager.instance;
+      await transMgr.initialize();
+      _transcodeEnabledCache = await transMgr.isTranscodingEnabled();
+      _defaultQualityCache = await transMgr.getDefaultVideoQuality();
+  _settingsCache = await transMgr.getSettings();
+      DebugLogService().addLog('Jellyfin: 已加载转码偏好 缓存 enabled=$_transcodeEnabledCache, quality=$_defaultQualityCache');
+    } catch (e) {
+      DebugLogService().addLog('Jellyfin: 加载转码偏好失败，使用默认值: $e');
+      _transcodeEnabledCache = true;
+      _defaultQualityCache = JellyfinVideoQuality.bandwidth5m;
+  _settingsCache = const JellyfinTranscodeSettings();
     }
   }
   
@@ -1111,7 +1132,11 @@ class JellyfinService {
 
   // 获取流媒体URL（向后兼容的方法）
   String getStreamUrl(String itemId) {
-    return getStreamUrlWithOptions(itemId);
+  // 使用缓存的转码设置决定默认质量
+  final effectiveQuality = _transcodeEnabledCache
+    ? _defaultQualityCache
+    : JellyfinVideoQuality.original;
+  return getStreamUrlWithOptions(itemId, quality: effectiveQuality);
   }
   
   /// 获取流媒体URL，支持转码选项
@@ -1122,18 +1147,25 @@ class JellyfinService {
     String itemId, {
     JellyfinVideoQuality? quality,
     bool forceDirectPlay = false,
+    int? subtitleStreamIndex,
+    bool? burnInSubtitle,
   }) {
     if (!_isConnected || _accessToken == null) {
       throw Exception('未连接到Jellyfin服务器');
     }
     
-    // 如果强制直播，返回直播URL
+  // 如果强制直播，返回直播URL
     if (forceDirectPlay) {
       return _buildDirectPlayUrl(itemId);
     }
-    
-    // 构建转码URL
-    return _buildTranscodeUrl(itemId, quality);
+
+  // 若未显式传入quality，则使用缓存设置
+  final effective = quality ?? (_transcodeEnabledCache
+    ? _defaultQualityCache
+    : JellyfinVideoQuality.original);
+
+  // 构建转码/直连URL
+  return _buildTranscodeUrl(itemId, effective, subtitleStreamIndex: subtitleStreamIndex, burnInSubtitle: burnInSubtitle);
   }
   
   /// 构建直播URL（不转码）
@@ -1141,47 +1173,145 @@ class JellyfinService {
     return '$_serverUrl/Videos/$itemId/stream?static=true&MediaSourceId=$itemId&api_key=$_accessToken';
   }
   
-  /// 构建转码URL
-  String _buildTranscodeUrl(String itemId, JellyfinVideoQuality? quality) {
-    // 如果质量为original或未指定，使用直播
+  /// 构建转码URL（HLS 使用 master.m3u8）
+  String _buildTranscodeUrl(String itemId, JellyfinVideoQuality? quality, {int? subtitleStreamIndex, bool? burnInSubtitle}) {
+    // 如果质量为 original 或未指定，使用直连
     if (quality == null || quality == JellyfinVideoQuality.original) {
       return _buildDirectPlayUrl(itemId);
     }
-    
+
     final params = <String, String>{
       'api_key': _accessToken!,
+      // HLS master.m3u8 需要 MediaSourceId（大多数情况下与 itemId 相同）
+      'MediaSourceId': itemId,
+      // 指定分片容器，Jellyfin 默认 HLS TS 更通用
+      'segmentContainer': 'ts',
     };
+
+    // 添加转码参数（码率/分辨率/编解码器等）
+    _addTranscodeParameters(params, quality, subtitleStreamIndex: subtitleStreamIndex, burnInSubtitle: burnInSubtitle);
+
+    // 使用 HLS master.m3u8 入口
+    final uri = Uri.parse('$_serverUrl/Videos/$itemId/master.m3u8').replace(queryParameters: params);
+    debugPrint('Jellyfin HLS 转码URL: $uri');
+    return uri.toString();
+  }
+
+  /// 构建 HLS URL（带可选的服务器端字幕选择与烧录开关）
+  /// 注意：不影响外挂字幕下载/加载逻辑，仅在服务端转码时让服务器选定字幕轨道或进行烧录。
+  Future<String> buildHlsUrlWithOptions(
+    String itemId, {
+    JellyfinVideoQuality? quality,
+    int? subtitleStreamIndex,
+    bool alwaysBurnInSubtitleWhenTranscoding = false,
+  }) async {
+    if (!_isConnected || _accessToken == null) {
+      throw Exception('未连接到Jellyfin服务器');
+    }
+
+    // original => 直连
+    if ((quality ?? _defaultQualityCache) == JellyfinVideoQuality.original) {
+      return _buildDirectPlayUrl(itemId);
+    }
+
+    final params = <String, String>{
+      'api_key': _accessToken!,
+      'mediaSourceId': itemId,  // 修正参数名
+      'segmentContainer': 'ts',
+    };
+
+    // 画质/编解码参数
+    _addTranscodeParameters(params, quality ?? _defaultQualityCache);
+
+    // 字幕参数：如果用户明确选择了服务器字幕，则强制添加字幕参数
+    if (subtitleStreamIndex != null) {
+      params['subtitleStreamIndex'] = subtitleStreamIndex.toString();
+      // 根据用户选择决定字幕处理方式
+      if (alwaysBurnInSubtitleWhenTranscoding) {
+        params['subtitleMethod'] = 'Encode'; // 烧录字幕到视频中
+        params['alwaysBurnInSubtitleWhenTranscoding'] = 'true';
+        // 强制转码以确保字幕烧录
+        params['allowVideoStreamCopy'] = 'false'; // 禁止视频流直传
+      } else {
+        params['subtitleMethod'] = 'Embed'; // 嵌入字幕作为独立轨道
+      }
+      // 不设置subtitleCodec，让服务器自动处理
+      // PGSSUB等图形字幕需要服务器自动选择合适的输出格式
+    } else {
+      // 用户未选择特定字幕，使用默认设置
+      final delivery = _settingsCache.subtitle.deliveryMethod;
+      if (_settingsCache.subtitle.enableTranscoding &&
+          delivery != JellyfinSubtitleDeliveryMethod.external &&
+          delivery != JellyfinSubtitleDeliveryMethod.drop) {
+        params['subtitleMethod'] = delivery.apiValue;
+        if (alwaysBurnInSubtitleWhenTranscoding) {
+          params['alwaysBurnInSubtitleWhenTranscoding'] = 'true';
+        }
+      }
+    }
+
+    final uri = Uri.parse('$_serverUrl/Videos/$itemId/master.m3u8')
+        .replace(queryParameters: params);
     
-    // 添加转码参数
-    _addTranscodeParameters(params, quality);
+    debugPrint('[Jellyfin HLS] 构建URL: ${uri.toString()}');
+    debugPrint('[Jellyfin HLS] 字幕参数 - streamIndex: $subtitleStreamIndex, burnIn: $alwaysBurnInSubtitleWhenTranscoding');
     
-    final uri = Uri.parse('$_serverUrl/Videos/$itemId/stream').replace(queryParameters: params);
-    debugPrint('Jellyfin转码URL: $uri');
     return uri.toString();
   }
   
   /// 添加转码参数到URL参数中
-  void _addTranscodeParameters(Map<String, String> params, JellyfinVideoQuality quality) {
+  void _addTranscodeParameters(Map<String, String> params, JellyfinVideoQuality quality, {int? subtitleStreamIndex, bool? burnInSubtitle}) {
     // 基础转码参数
     final bitrate = quality.bitrate;
     final resolution = quality.maxResolution;
     
     if (bitrate != null) {
-      params['MaxStreamingBitrate'] = (bitrate * 1000).toString(); // 转换为bps
-      params['VideoBitRate'] = (bitrate * 1000).toString();
+      params['maxStreamingBitrate'] = (bitrate * 1000).toString(); // 修正参数名
+      params['videoBitRate'] = (bitrate * 1000).toString(); // 修正参数名
     }
     
     if (resolution != null) {
-      params['MaxWidth'] = resolution.width.toString();
-      params['MaxHeight'] = resolution.height.toString();
+      params['maxWidth'] = resolution.width.toString(); // 修正参数名
+      params['maxHeight'] = resolution.height.toString(); // 修正参数名
     }
     
-    // 默认转码设置
-    params['VideoCodec'] = 'h264,hevc,av1';
-    params['AudioCodec'] = 'aac,mp3,opus';
-    params['Container'] = 'ts,webm,mp4,mkv';
-    params['TranscodingContainer'] = 'ts';
-    params['TranscodingProtocol'] = 'hls';
+    // 默认/偏好转码设置
+    final videoCodecs = _settingsCache.video.preferredCodecs.isNotEmpty
+        ? _settingsCache.video.preferredCodecs.join(',')
+        : 'h264,hevc,av1';
+    final audioCodecs = _settingsCache.audio.preferredCodecs.isNotEmpty
+        ? _settingsCache.audio.preferredCodecs.join(',')
+        : 'aac,mp3,opus';
+    params['videoCodec'] = videoCodecs; // 修正参数名
+    params['audioCodec'] = audioCodecs; // 修正参数名
+
+    // 音频相关限制（可选）
+    if (_settingsCache.audio.maxAudioChannels > 0) {
+      params['maxAudioChannels'] = _settingsCache.audio.maxAudioChannels.toString();
+    }
+    if (_settingsCache.audio.audioBitRate != null && _settingsCache.audio.audioBitRate! > 0) {
+      params['audioBitRate'] = (_settingsCache.audio.audioBitRate! * 1000).toString();
+    }
+    if (_settingsCache.audio.audioSampleRate != null && _settingsCache.audio.audioSampleRate! > 0) {
+      params['audioSampleRate'] = _settingsCache.audio.audioSampleRate!.toString();
+    }
+
+    // 字幕交付方式（仅当需要由服务器处理时）
+    if (_settingsCache.subtitle.enableTranscoding &&
+        _settingsCache.subtitle.deliveryMethod != JellyfinSubtitleDeliveryMethod.external &&
+        _settingsCache.subtitle.deliveryMethod != JellyfinSubtitleDeliveryMethod.drop) {
+      params['subtitleMethod'] = _settingsCache.subtitle.deliveryMethod.apiValue;
+      // 指定字幕流索引（如果提供）
+      if (subtitleStreamIndex != null && subtitleStreamIndex >= 0) {
+        params['subtitleStreamIndex'] = subtitleStreamIndex.toString();
+      }
+      // 烧录字幕标志（如果选择烧录或显式传入）
+      final shouldBurn = burnInSubtitle ?? (_settingsCache.subtitle.deliveryMethod == JellyfinSubtitleDeliveryMethod.encode);
+      if (shouldBurn) {
+        params['alwaysBurnInSubtitleWhenTranscoding'] = 'true';
+      }
+    }
+    // HLS 使用 master.m3u8，不需要设置 Container/TranscodingContainer/TranscodingProtocol
     
     // 边界情况：确保参数有效
     try {
@@ -1199,6 +1329,56 @@ class JellyfinService {
       params.removeWhere((key, value) => 
         key.startsWith('Max') || key.contains('BitRate'));
     }
+  }
+
+  /// 构建支持自动选择字幕的 HLS URL（异步）。
+  /// 当未提供 [subtitleStreamIndex] 且字幕交付方式为 Encode/Embed/Hls 时：
+  /// - 优先选择简体/繁体中文或标记为默认的字幕轨道
+  Future<String> buildHlsUrlWithAutoSubtitle(
+    String itemId, {
+    JellyfinVideoQuality? quality,
+    int? subtitleStreamIndex,
+    bool? burnInSubtitle,
+    String? preferredLanguage, // e.g. 'chi','zho','zh'
+  }) async {
+    final effective = quality ?? (_transcodeEnabledCache ? _defaultQualityCache : JellyfinVideoQuality.original);
+
+    // 若 direct play，直接返回直链
+    if (effective == JellyfinVideoQuality.original) {
+      return _buildDirectPlayUrl(itemId);
+    }
+
+    int? resolvedIndex = subtitleStreamIndex;
+    final needsServerSubtitle = _settingsCache.subtitle.enableTranscoding &&
+        _settingsCache.subtitle.deliveryMethod != JellyfinSubtitleDeliveryMethod.external &&
+        _settingsCache.subtitle.deliveryMethod != JellyfinSubtitleDeliveryMethod.drop;
+
+    if (resolvedIndex == null && needsServerSubtitle) {
+      try {
+        final tracks = await getSubtitleTracks(itemId);
+        if (tracks.isNotEmpty) {
+          // 先中文（简/繁/语言码）
+          final zh = tracks.firstWhere(
+            (t) {
+              final title = (t['title'] ?? '').toString().toLowerCase();
+              final language = (t['language'] ?? '').toString().toLowerCase();
+              return language.contains('chi') || language.contains('zho') || language == 'zh' ||
+                     title.contains('简体') || title.contains('繁体') || title.contains('中文') ||
+                     title.contains('chs') || title.contains('cht') || title.startsWith('scjp') || title.startsWith('tcjp');
+            },
+            orElse: () => tracks.firstWhere(
+              (t) => (t['isDefault'] ?? false) == true,
+              orElse: () => tracks.first,
+            ),
+          );
+          resolvedIndex = (zh['index'] as int?);
+        }
+      } catch (e) {
+        debugPrint('JellyfinService: 自动选择字幕轨道失败，忽略: $e');
+      }
+    }
+
+    return _buildTranscodeUrl(itemId, effective, subtitleStreamIndex: resolvedIndex, burnInSubtitle: burnInSubtitle);
   }
 
   /// 获取Jellyfin视频的字幕轨道信息
@@ -1246,10 +1426,14 @@ class JellyfinService {
             final isDefault = stream['IsDefault'] ?? false;
             final isForced = stream['IsForced'] ?? false;
             final isHearingImpaired = stream['IsHearingImpaired'] ?? false;
+            // 使用流的真实索引，而不是循环索引
+            final realIndex = stream['Index'] ?? i;
+            
+            debugPrint('JellyfinService: 找到字幕轨道 $realIndex: $language ($codec, ${isExternal ? 'external' : 'embedded'})');
             
             // 构建字幕轨道信息
             Map<String, dynamic> trackInfo = {
-              'index': i,
+              'index': realIndex,  // 使用真实索引
               'type': isExternal ? 'external' : 'embedded',
               'language': language,
               'title': title.isNotEmpty ? title : (language.isNotEmpty ? language : 'Unknown'),
@@ -1258,17 +1442,19 @@ class JellyfinService {
               'isForced': isForced,
               'isHearingImpaired': isHearingImpaired,
               'deliveryMethod': deliveryMethod,
+      // 供 UI 快速显示
+      'display': _buildSubtitleDisplay(language, title, codec, isExternal, isForced, isDefault),
             };
 
             // 如果是外挂字幕，添加下载URL
             if (isExternal) {
               final mediaSourceId = mediaSource['Id'];
-              final subtitleUrl = '$_serverUrl/Videos/$itemId/$mediaSourceId/Subtitles/$i/Stream.$codec?api_key=$_accessToken';
+              final subtitleUrl = '$_serverUrl/Videos/$itemId/$mediaSourceId/Subtitles/$realIndex/Stream.$codec?api_key=$_accessToken';
               trackInfo['downloadUrl'] = subtitleUrl;
             }
 
             subtitleTracks.add(trackInfo);
-            debugPrint('JellyfinService: 找到字幕轨道 $i: ${trackInfo['title']} (${trackInfo['type']})');
+            // 注意：这里使用realIndex而不是循环的i
           }
         }
 
@@ -1339,6 +1525,30 @@ class JellyfinService {
       debugPrint('JellyfinService: 下载字幕文件时出错: $e');
       return null;
     }
+  }
+
+  /// 构造字幕显示名称（供设置面板展示）
+  String _buildSubtitleDisplay(
+    String language,
+    String title,
+    String codec,
+    bool isExternal,
+    bool isForced,
+    bool isDefault,
+  ) {
+    final List<String> parts = [];
+    if (title.isNotEmpty) {
+      parts.add(title);
+    } else if (language.isNotEmpty) {
+      parts.add(language);
+    } else {
+      parts.add('字幕');
+    }
+    if (codec.isNotEmpty) parts.add(codec.toUpperCase());
+    if (isExternal) parts.add('外挂');
+    if (isForced) parts.add('强制');
+    if (isDefault) parts.add('默认');
+    return parts.join(' · ');
   }
 
   /// 搜索媒体库中的内容
@@ -1758,5 +1968,18 @@ class JellyfinService {
     }
     
     return false;
+  }
+
+  /// 由 Provider 调用：在运行时更新本地转码缓存（避免在 getStreamUrl 中做异步 IO）
+  void setTranscodePreferences({bool? enabled, JellyfinVideoQuality? defaultQuality}) {
+    if (enabled != null) _transcodeEnabledCache = enabled;
+    if (defaultQuality != null) _defaultQualityCache = defaultQuality;
+    DebugLogService().addLog('Jellyfin: 更新转码偏好 缓存 enabled=${enabled ?? _transcodeEnabledCache}, quality=${defaultQuality ?? _defaultQualityCache}');
+  }
+
+  /// 由 Provider 调用：更新完整转码设置缓存（用于音频/字幕等参数）
+  void setFullTranscodeSettings(JellyfinTranscodeSettings settings) {
+    _settingsCache = settings;
+    DebugLogService().addLog('Jellyfin: 更新完整转码设置缓存 (video/audio/subtitle/adaptive)');
   }
 }

--- a/lib/services/jellyfin_service.dart
+++ b/lib/services/jellyfin_service.dart
@@ -691,7 +691,7 @@ class JellyfinService {
             .toList();
       }
     } catch (e) {
-      print('Error fetching media items for library $libraryId: $e');
+      debugPrint('Error fetching media items for library $libraryId: $e');
     }
     
     return [];

--- a/lib/services/jellyfin_service.dart
+++ b/lib/services/jellyfin_service.dart
@@ -62,7 +62,7 @@ class JellyfinService {
   String? _cachedClientInfo;
 
   // Transcode preferences cache (loaded once and updated by provider)
-  bool _transcodeEnabledCache = true;
+  bool _transcodeEnabledCache = false;
   JellyfinVideoQuality _defaultQualityCache = JellyfinVideoQuality.bandwidth5m;
   JellyfinTranscodeSettings _settingsCache = const JellyfinTranscodeSettings();
 
@@ -267,7 +267,7 @@ class JellyfinService {
       DebugLogService().addLog('Jellyfin: 已加载转码偏好 缓存 enabled=$_transcodeEnabledCache, quality=$_defaultQualityCache');
     } catch (e) {
       DebugLogService().addLog('Jellyfin: 加载转码偏好失败，使用默认值: $e');
-      _transcodeEnabledCache = true;
+      _transcodeEnabledCache = false;
       _defaultQualityCache = JellyfinVideoQuality.bandwidth5m;
   _settingsCache = const JellyfinTranscodeSettings();
     }

--- a/lib/services/jellyfin_transcode_manager.dart
+++ b/lib/services/jellyfin_transcode_manager.dart
@@ -1,0 +1,191 @@
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../models/jellyfin_transcode_settings.dart';
+
+/// Jellyfin 转码设置管理器
+/// 职责：管理转码相关的设置持久化和获取
+class JellyfinTranscodeManager {
+  static final JellyfinTranscodeManager instance = JellyfinTranscodeManager._internal();
+  
+  JellyfinTranscodeManager._internal();
+  
+  // 设置键名常量
+  static const String _keyTranscodeSettings = 'jellyfin_transcode_settings';
+  static const String _keyDefaultQuality = 'jellyfin_default_quality';
+  static const String _keyEnableTranscoding = 'jellyfin_enable_transcoding';
+  
+  // 内存缓存
+  JellyfinTranscodeSettings? _cachedSettings;
+  bool _isInitialized = false;
+  
+  /// 初始化管理器
+  Future<void> initialize() async {
+    if (_isInitialized) return;
+    
+    try {
+      await _loadSettings();
+      _isInitialized = true;
+    } catch (e) {
+      debugPrint('JellyfinTranscodeManager 初始化失败: $e');
+      // 使用默认设置
+      _cachedSettings = const JellyfinTranscodeSettings();
+      _isInitialized = true;
+    }
+  }
+  
+  /// 获取当前的转码设置
+  Future<JellyfinTranscodeSettings> getSettings() async {
+    if (!_isInitialized) {
+      await initialize();
+    }
+    
+    return _cachedSettings ?? const JellyfinTranscodeSettings();
+  }
+  
+  /// 保存转码设置
+  Future<void> saveSettings(JellyfinTranscodeSettings settings) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final jsonString = json.encode(settings.toJson());
+      
+      await prefs.setString(_keyTranscodeSettings, jsonString);
+      
+      // 更新内存缓存
+      _cachedSettings = settings;
+      
+      debugPrint('Jellyfin转码设置已保存');
+    } catch (e) {
+      debugPrint('保存转码设置失败: $e');
+      rethrow;
+    }
+  }
+  
+  /// 获取默认视频质量
+  Future<JellyfinVideoQuality> getDefaultVideoQuality() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final qualityString = prefs.getString(_keyDefaultQuality);
+      
+      if (qualityString != null) {
+        final qualityIndex = int.tryParse(qualityString);
+        if (qualityIndex != null && qualityIndex < JellyfinVideoQuality.values.length) {
+          return JellyfinVideoQuality.values[qualityIndex];
+        }
+      }
+      
+      // 默认值：5Mbps高清
+      return JellyfinVideoQuality.bandwidth5m;
+    } catch (e) {
+      debugPrint('获取默认视频质量失败: $e');
+      return JellyfinVideoQuality.bandwidth5m;
+    }
+  }
+  
+  /// 保存默认视频质量
+  Future<void> saveDefaultVideoQuality(JellyfinVideoQuality quality) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_keyDefaultQuality, quality.index.toString());
+      
+      debugPrint('默认视频质量已保存: ${quality.displayName}');
+    } catch (e) {
+      debugPrint('保存默认视频质量失败: $e');
+      rethrow;
+    }
+  }
+  
+  /// 获取是否启用转码
+  Future<bool> isTranscodingEnabled() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final enabledString = prefs.getString(_keyEnableTranscoding);
+      
+      if (enabledString != null) {
+        return enabledString.toLowerCase() == 'true';
+      }
+      
+      // 默认启用转码
+      return true;
+    } catch (e) {
+      debugPrint('获取转码启用状态失败: $e');
+      return true;
+    }
+  }
+  
+  /// 设置是否启用转码
+  Future<void> setTranscodingEnabled(bool enabled) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_keyEnableTranscoding, enabled.toString());
+      
+      debugPrint('转码启用状态已保存: $enabled');
+    } catch (e) {
+      debugPrint('保存转码启用状态失败: $e');
+      rethrow;
+    }
+  }
+  
+  /// 重置所有设置为默认值
+  Future<void> resetToDefaults() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.remove(_keyTranscodeSettings);
+      await prefs.remove(_keyDefaultQuality);
+      await prefs.remove(_keyEnableTranscoding);
+      
+      // 清除内存缓存
+      _cachedSettings = null;
+      
+      debugPrint('Jellyfin转码设置已重置为默认值');
+    } catch (e) {
+      debugPrint('重置转码设置失败: $e');
+      rethrow;
+    }
+  }
+  
+  /// 从SharedPreferences加载设置
+  Future<void> _loadSettings() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final settingsString = prefs.getString(_keyTranscodeSettings);
+      
+      if (settingsString != null && settingsString.isNotEmpty) {
+        final jsonData = json.decode(settingsString) as Map<String, dynamic>;
+        _cachedSettings = JellyfinTranscodeSettings.fromJson(jsonData);
+      } else {
+        // 使用默认设置
+        _cachedSettings = const JellyfinTranscodeSettings();
+      }
+    } catch (e) {
+      debugPrint('加载转码设置失败: $e');
+      _cachedSettings = const JellyfinTranscodeSettings();
+    }
+  }
+  
+  /// 获取基于网络状况的推荐质量
+  /// [networkSpeedMbps] 网络速度（Mbps）
+  JellyfinVideoQuality getRecommendedQuality(double networkSpeedMbps) {
+    // 边界情况处理
+    if (networkSpeedMbps <= 0) {
+      return JellyfinVideoQuality.bandwidth1m;
+    }
+    
+    // 留一定余量，避免缓冲
+    final effectiveSpeed = networkSpeedMbps * 0.8;
+    
+    if (effectiveSpeed >= 35) {
+      return JellyfinVideoQuality.bandwidth40m;  // 4K
+    } else if (effectiveSpeed >= 16) {
+      return JellyfinVideoQuality.bandwidth20m;  // 1080p超清
+    } else if (effectiveSpeed >= 8) {
+      return JellyfinVideoQuality.bandwidth10m;  // 1080p
+    } else if (effectiveSpeed >= 4) {
+      return JellyfinVideoQuality.bandwidth5m;   // 720p
+    } else if (effectiveSpeed >= 1.5) {
+      return JellyfinVideoQuality.bandwidth2m;   // 480p
+    } else {
+      return JellyfinVideoQuality.bandwidth1m;   // 360p
+    }
+  }
+}

--- a/lib/services/jellyfin_transcode_manager.dart
+++ b/lib/services/jellyfin_transcode_manager.dart
@@ -105,11 +105,11 @@ class JellyfinTranscodeManager {
         return enabledString.toLowerCase() == 'true';
       }
       
-      // 默认启用转码
-      return true;
+      // 默认关闭转码，保持原有直连体验
+      return false;
     } catch (e) {
       debugPrint('获取转码启用状态失败: $e');
-      return true;
+      return false;
     }
   }
   

--- a/lib/utils/video_player_state.dart
+++ b/lib/utils/video_player_state.dart
@@ -4603,7 +4603,7 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
               final pathParts = embyPath.split('/');
               final episodeId = pathParts.last; // 只使用最后一部分作为episodeId
               // 获取实际的HTTP流媒体URL
-              final actualPlayUrl = EmbyService.instance.getStreamUrl(episodeId);
+              final actualPlayUrl = await EmbyService.instance.getStreamUrl(episodeId);
               debugPrint('[上一话] 获取Emby流媒体URL: $actualPlayUrl');
               
               // 使用Emby协议URL作为标识符，HTTP URL作为实际播放源
@@ -4724,7 +4724,7 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
               final pathParts = embyPath.split('/');
               final episodeId = pathParts.last; // 只使用最后一部分作为episodeId
               // 获取实际的HTTP流媒体URL
-              final actualPlayUrl = EmbyService.instance.getStreamUrl(episodeId);
+              final actualPlayUrl = await EmbyService.instance.getStreamUrl(episodeId);
               debugPrint('[下一话] 获取Emby流媒体URL: $actualPlayUrl');
               
               // 使用Emby协议URL作为标识符，HTTP URL作为实际播放源

--- a/lib/widgets/nipaplay_theme/jellyfin_quality_menu.dart
+++ b/lib/widgets/nipaplay_theme/jellyfin_quality_menu.dart
@@ -112,9 +112,19 @@ class _JellyfinQualityMenuState extends State<JellyfinQualityMenu> {
         final embyProv = Provider.of<EmbyTranscodeProvider>(context, listen: false);
         await embyProv.initialize();
         await embyProv.setDefaultVideoQuality(_currentQuality!);
+        
+        // 当选择非原画质量时，自动启用转码
+        if (_currentQuality! != JellyfinVideoQuality.original) {
+          await embyProv.setTranscodeEnabled(true);
+        }
       } else {
         final transcodeProvider = Provider.of<JellyfinTranscodeProvider>(context, listen: false);
         await transcodeProvider.setDefaultVideoQuality(_currentQuality!);
+        
+        // 当选择非原画质量时，自动启用转码
+        if (_currentQuality! != JellyfinVideoQuality.original) {
+          await transcodeProvider.setTranscodeEnabled(true);
+        }
       }
       
       // 然后重载播放器

--- a/lib/widgets/nipaplay_theme/jellyfin_quality_menu.dart
+++ b/lib/widgets/nipaplay_theme/jellyfin_quality_menu.dart
@@ -1,0 +1,346 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'base_settings_menu.dart';
+import 'settings_hint_text.dart';
+import 'blur_snackbar.dart';
+import 'package:nipaplay/models/jellyfin_transcode_settings.dart';
+import 'package:nipaplay/providers/jellyfin_transcode_provider.dart';
+import 'package:nipaplay/utils/video_player_state.dart';
+import 'package:nipaplay/services/jellyfin_service.dart';
+
+class JellyfinQualityMenu extends StatefulWidget {
+  final VoidCallback onClose;
+
+  const JellyfinQualityMenu({
+    super.key,
+    required this.onClose,
+  });
+
+  @override
+  State<JellyfinQualityMenu> createState() => _JellyfinQualityMenuState();
+}
+
+class _JellyfinQualityMenuState extends State<JellyfinQualityMenu> {
+  JellyfinVideoQuality? _currentQuality;
+  bool _isLoading = false;
+  List<Map<String, dynamic>> _serverSubtitles = [];
+  int? _selectedServerSubtitleIndex; // null 表示不指定
+  bool _burnIn = false; // 转码时是否烧录字幕
+
+  @override
+  void initState() {
+    super.initState();
+    _loadCurrentQuality();
+  }
+
+  Future<void> _loadCurrentQuality() async {
+    try {
+      final transcodeProvider = Provider.of<JellyfinTranscodeProvider>(context, listen: false);
+      await transcodeProvider.initialize();
+      
+      setState(() {
+        _currentQuality = transcodeProvider.currentVideoQuality;
+      });
+
+      // 读取当前播放的 Jellyfin itemId 并获取服务器字幕列表
+      final vp = Provider.of<VideoPlayerState>(context, listen: false);
+      final path = vp.currentVideoPath;
+      if (path != null && path.startsWith('jellyfin://')) {
+        final itemId = path.replaceFirst('jellyfin://', '');
+        final tracks = await JellyfinService.instance.getSubtitleTracks(itemId);
+        setState(() {
+          _serverSubtitles = tracks;
+          // 预选默认字幕（如果存在）
+          final def = tracks.firstWhere(
+            (t) => (t['isDefault'] == true),
+            orElse: () => {},
+          );
+          _selectedServerSubtitleIndex = def.isEmpty ? null : def['index'] as int?;
+        });
+      }
+    } catch (e) {
+      debugPrint('加载当前转码质量失败: $e');
+      setState(() {
+        _currentQuality = JellyfinVideoQuality.bandwidth5m; // 默认值
+      });
+    }
+  }
+
+  void _changeQuality(JellyfinVideoQuality quality) {
+    if (_currentQuality == quality) return;
+    
+    // 仅更新本地状态，不直接重载播放器
+    setState(() {
+      _currentQuality = quality;
+    });
+  }
+
+  Future<void> _applySelection() async {
+    if (_currentQuality == null) return;
+    
+    setState(() {
+      _isLoading = true;
+    });
+    
+    try {
+      // 先保存默认清晰度设置
+      final transcodeProvider = Provider.of<JellyfinTranscodeProvider>(context, listen: false);
+      await transcodeProvider.setDefaultVideoQuality(_currentQuality!);
+      
+      // 然后重载播放器
+      final vp = Provider.of<VideoPlayerState>(context, listen: false);
+      await vp.reloadCurrentJellyfinStream(
+        quality: _currentQuality!,
+        serverSubtitleIndex: _selectedServerSubtitleIndex,
+        burnInSubtitle: _burnIn,
+      );
+      
+      setState(() {
+        _isLoading = false;
+      });
+      
+      // 显示成功通知并关闭菜单
+      if (mounted) {
+        final qualityName = _getQualityDisplayName(_currentQuality!);
+        String message = '已切换到$qualityName清晰度';
+        
+        // 添加字幕信息到通知
+        if (_selectedServerSubtitleIndex != null) {
+          final selectedSubtitle = _serverSubtitles.firstWhere(
+            (s) => s['index'] == _selectedServerSubtitleIndex,
+            orElse: () => <String, dynamic>{},
+          );
+          if (selectedSubtitle.isNotEmpty) {
+            final subtitleName = selectedSubtitle['display'] as String? ?? 
+                                selectedSubtitle['title']?.toString() ?? 
+                                '字幕 ${selectedSubtitle['index']}';
+            message += '\n字幕: $subtitleName';
+            if (_burnIn) {
+              message += ' (烧录)';
+            }
+          }
+        }
+        
+        BlurSnackBar.show(context, message);
+        widget.onClose();
+      }
+    } catch (e) {
+      setState(() {
+        _isLoading = false;
+      });
+      debugPrint('应用清晰度/字幕选择失败: $e');
+      if (mounted) {
+        BlurSnackBar.show(context, '设置失败: $e');
+      }
+    }
+  }
+
+  String _getQualityDisplayName(JellyfinVideoQuality quality) {
+    switch (quality) {
+      case JellyfinVideoQuality.auto:
+        return '自动';
+      case JellyfinVideoQuality.original:
+        return '原画 (不转码)';
+      case JellyfinVideoQuality.bandwidth40m:
+        return '4K (40 Mbps)';
+      case JellyfinVideoQuality.bandwidth20m:
+        return '超清 (20 Mbps)';
+      case JellyfinVideoQuality.bandwidth10m:
+        return '全高清 (10 Mbps)';
+      case JellyfinVideoQuality.bandwidth5m:
+        return '高清 (5 Mbps)';
+      case JellyfinVideoQuality.bandwidth2m:
+        return '标清 (2 Mbps)';
+      case JellyfinVideoQuality.bandwidth1m:
+        return '省流 (1 Mbps)';
+    }
+  }
+
+  String _getQualityDescription(JellyfinVideoQuality quality) {
+    switch (quality) {
+      case JellyfinVideoQuality.auto:
+        return '让服务器根据网络情况自动选择';
+      case JellyfinVideoQuality.original:
+        return '直接播放原始文件，无转码';
+      case JellyfinVideoQuality.bandwidth40m:
+        return '超高清画质，需要高速网络';
+      case JellyfinVideoQuality.bandwidth20m:
+        return '1080p超清画质，网络要求较高';
+      case JellyfinVideoQuality.bandwidth10m:
+        return '1080p全高清画质，网络要求适中';
+      case JellyfinVideoQuality.bandwidth5m:
+        return '720p高清画质，流畅播放';
+      case JellyfinVideoQuality.bandwidth2m:
+        return '480p标清画质，省流量';
+      case JellyfinVideoQuality.bandwidth1m:
+        return '360p低清画质，最省流量';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BaseSettingsMenu(
+      title: '清晰度设置',
+      onClose: widget.onClose,
+      extraButton: TextButton(
+        onPressed: _applySelection,
+        child: const Text('应用', style: TextStyle(color: Colors.white)),
+      ),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (_isLoading)
+            const Padding(
+              padding: EdgeInsets.all(16),
+              child: Center(
+                child: CircularProgressIndicator(color: Colors.blue),
+              ),
+            )
+          else ...[
+            Container(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const SettingsHintText('选择视频播放质量'),
+                  const SizedBox(height: 16),
+                  ...JellyfinVideoQuality.values.map((quality) {
+                    final isSelected = _currentQuality == quality;
+                    return Container(
+                      margin: const EdgeInsets.only(bottom: 8),
+                      child: Material(
+                        color: Colors.transparent,
+                        child: InkWell(
+                          onTap: () => _changeQuality(quality),
+                          borderRadius: BorderRadius.circular(8),
+                          child: Container(
+                            padding: const EdgeInsets.all(12),
+                            decoration: BoxDecoration(
+                              color: isSelected 
+                                  ? Colors.blue.withOpacity(0.2)
+                                  : Colors.white.withOpacity(0.05),
+                              borderRadius: BorderRadius.circular(8),
+                              border: Border.all(
+                                color: isSelected 
+                                    ? Colors.blue
+                                    : Colors.white.withOpacity(0.1),
+                                width: 1,
+                              ),
+                            ),
+                            child: Row(
+                              children: [
+                                Icon(
+                                  isSelected ? Icons.radio_button_checked : Icons.radio_button_unchecked,
+                                  color: isSelected ? Colors.blue : Colors.white70,
+                                  size: 20,
+                                ),
+                                const SizedBox(width: 12),
+                                Expanded(
+                                  child: Column(
+                                    crossAxisAlignment: CrossAxisAlignment.start,
+                                    children: [
+                                      Text(
+                                        _getQualityDisplayName(quality),
+                                        style: TextStyle(
+                                          color: isSelected ? Colors.blue : Colors.white,
+                                          fontSize: 14,
+                                          fontWeight: isSelected ? FontWeight.w600 : FontWeight.normal,
+                                        ),
+                                      ),
+                                      const SizedBox(height: 2),
+                                      Text(
+                                        _getQualityDescription(quality),
+                                        style: TextStyle(
+                                          color: isSelected ? Colors.blue.withOpacity(0.8) : Colors.white60,
+                                          fontSize: 12,
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      ),
+                    );
+                  }).toList(),
+
+                  const SizedBox(height: 16),
+                  const SettingsHintText('服务器字幕（用于转码时选择/烧录）'),
+                  const SizedBox(height: 8),
+                  // “不指定字幕”选项
+                  _buildSubtitleOption(
+                    title: '不指定字幕（沿用播放器选择或无）',
+                    selected: _selectedServerSubtitleIndex == null,
+                    onTap: () => setState(() => _selectedServerSubtitleIndex = null),
+                  ),
+                  const SizedBox(height: 6),
+                  ..._serverSubtitles.map((t) => _buildSubtitleOption(
+                        title: (t['display'] as String?) ?? (t['title']?.toString() ?? '字幕 ${t['index']}'),
+                        selected: _selectedServerSubtitleIndex == t['index'],
+                        onTap: () => setState(() => _selectedServerSubtitleIndex = t['index'] as int),
+                      )),
+                  const SizedBox(height: 8),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      const Text('转码时烧录字幕', style: TextStyle(color: Colors.white70, fontSize: 13)),
+                      Switch(
+                        value: _burnIn,
+                        onChanged: (v) => setState(() => _burnIn = v),
+                        activeColor: Colors.blue,
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSubtitleOption({required String title, required bool selected, required VoidCallback onTap}) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(8),
+        child: Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(10),
+          decoration: BoxDecoration(
+            color: selected ? Colors.blue.withOpacity(0.2) : Colors.white.withOpacity(0.05),
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(
+              color: selected ? Colors.blue : Colors.white.withOpacity(0.1),
+              width: 1,
+            ),
+          ),
+          child: Row(
+            children: [
+              Icon(
+                selected ? Icons.radio_button_checked : Icons.radio_button_unchecked,
+                color: selected ? Colors.blue : Colors.white70,
+                size: 18,
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  title,
+                  style: TextStyle(
+                    color: selected ? Colors.blue : Colors.white,
+                    fontSize: 13,
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/nipaplay_theme/network_media_server_dialog.dart
+++ b/lib/widgets/nipaplay_theme/network_media_server_dialog.dart
@@ -1060,6 +1060,10 @@ class _NetworkMediaServerDialogState extends State<NetworkMediaServerDialog> {
       if (success) {
         setState(() {
           _transcodeEnabled = enabled;
+          // 如果关闭转码，自动将质量重置为原画
+          if (!enabled) {
+            _selectedQuality = JellyfinVideoQuality.original;
+          }
         });
         if (mounted) {
           BlurSnackBar.show(context, enabled ? '转码已启用' : '转码已禁用');
@@ -1086,15 +1090,31 @@ class _NetworkMediaServerDialogState extends State<NetworkMediaServerDialog> {
         try {
           final j = Provider.of<JellyfinTranscodeProvider>(context, listen: false);
           success = await j.setDefaultVideoQuality(quality);
+          // 当选择非原画质量时，自动启用转码
+          if (quality != JellyfinVideoQuality.original) {
+            await j.setTranscodeEnabled(true);
+          }
         } catch (_) {
           success = await JellyfinTranscodeProvider().setDefaultVideoQuality(quality);
+          // 当选择非原画质量时，自动启用转码
+          if (quality != JellyfinVideoQuality.original) {
+            await JellyfinTranscodeProvider().setTranscodeEnabled(true);
+          }
         }
       } else if (widget.serverType == MediaServerType.emby) {
         try {
           final e = Provider.of<EmbyTranscodeProvider>(context, listen: false);
           success = await e.setDefaultVideoQuality(quality);
+          // 当选择非原画质量时，自动启用转码
+          if (quality != JellyfinVideoQuality.original) {
+            await e.setTranscodeEnabled(true);
+          }
         } catch (_) {
           success = await EmbyTranscodeProvider().setDefaultVideoQuality(quality);
+          // 当选择非原画质量时，自动启用转码
+          if (quality != JellyfinVideoQuality.original) {
+            await EmbyTranscodeProvider().setTranscodeEnabled(true);
+          }
         }
       }
 

--- a/lib/widgets/nipaplay_theme/playback_info_menu.dart
+++ b/lib/widgets/nipaplay_theme/playback_info_menu.dart
@@ -1,0 +1,722 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:nipaplay/utils/video_player_state.dart';
+import 'base_settings_menu.dart';
+import 'settings_hint_text.dart';
+import 'package:nipaplay/services/jellyfin_service.dart';
+import 'package:nipaplay/services/emby_service.dart';
+
+class PlaybackInfoMenu extends StatefulWidget {
+  final VoidCallback onClose;
+
+  const PlaybackInfoMenu({
+    super.key,
+    required this.onClose,
+  });
+
+  @override
+  State<PlaybackInfoMenu> createState() => _PlaybackInfoMenuState();
+}
+
+class _PlaybackInfoMenuState extends State<PlaybackInfoMenu> {
+  Map<String, dynamic>? _asyncDetailedInfo; // 缓存一次性异步获取的详细信息
+  Map<String, dynamic>? _serverMeta; // 缓存服务器媒体元数据（流媒体时）
+
+  @override
+  void initState() {
+    super.initState();
+    // 首帧后异步拉取详细信息（尤其是 mpv 的属性需要 await）
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      final videoState = context.read<VideoPlayerState>();
+      try {
+        final info = await videoState.player.getDetailedMediaInfoAsync();
+        if (mounted) setState(() => _asyncDetailedInfo = info);
+      } catch (_) {
+        // 忽略失败，保持同步回退
+      }
+
+      // 若为流媒体，尝试从服务器获取媒体技术元数据
+      final path = videoState.currentVideoPath;
+      if (path != null) {
+        try {
+          Map<String, dynamic>? meta;
+          if (path.startsWith('jellyfin://')) {
+            final itemId = path.replaceFirst('jellyfin://', '');
+            meta = await JellyfinService.instance.getServerMediaTechnicalInfo(itemId);
+          } else if (path.startsWith('emby://')) {
+            final itemId = path.replaceFirst('emby://', '');
+            meta = await EmbyService.instance.getServerMediaTechnicalInfo(itemId);
+          }
+          if (meta != null && meta.isNotEmpty && mounted) {
+            setState(() => _serverMeta = meta);
+          }
+        } catch (_) {}
+      }
+    });
+  }
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<VideoPlayerState>(
+      builder: (context, videoState, child) {
+        return BaseSettingsMenu(
+          title: '播放信息',
+          onClose: widget.onClose,
+          content: Container(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const SettingsHintText('当前播放状态和媒体信息'),
+                const SizedBox(height: 16),
+                _buildInfoCard('播放状态', _getPlaybackStatusInfo(videoState)),
+                const SizedBox(height: 12),
+                _buildInfoCard('视频信息', _getVideoInfo(videoState)),
+                const SizedBox(height: 12),
+                _buildInfoCard('音频信息', _getAudioInfo(videoState)),
+                const SizedBox(height: 12),
+                _buildInfoCard('网络信息', _getNetworkInfo(videoState)),
+                if (_serverMeta != null && _serverMeta!.isNotEmpty) ...[
+                  const SizedBox(height: 12),
+                  _buildInfoCard('来源元数据', _getServerMetaInfo()),
+                ],
+                if (_isTranscoding(videoState)) ...[
+                  const SizedBox(height: 12),
+                  _buildInfoCard('转码信息', _getTranscodeInfo(videoState)),
+                ],
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  List<InfoItem> _getServerMetaInfo() {
+    final m = _serverMeta ?? const {};
+    final container = _normalizeText(m['container']) ?? '未知';
+    final v = (m['video'] is Map) ? Map<String, dynamic>.from(m['video']) : const {};
+    final a = (m['audio'] is Map) ? Map<String, dynamic>.from(m['audio']) : const {};
+
+    String vCodec = _normalizeText(v['codec']) ?? '未知';
+    final vProfile = _normalizeText(v['profile']);
+    final vLevel = _normalizeText(v['level']);
+    final vBitDepth = v['bitDepth'];
+    final vResW = v['width'];
+    final vResH = v['height'];
+    final vFps = v['frameRate'];
+    final vBitrate = v['bitRate'];
+    final vRange = _normalizeText(v['dynamicRange']);
+    final colorPrimaries = _normalizeText(v['colorPrimaries']);
+    final colorTransfer = _normalizeText(v['colorTransfer']);
+    final colorSpace = _normalizeText(v['colorSpace']);
+
+    // 拼装视频行
+    final List<InfoItem> items = [
+      InfoItem('容器', container),
+      InfoItem('视频', _joinNonEmpty([
+        vCodec,
+        if (vProfile != null) 'Profile $vProfile',
+        if (vLevel != null) 'Level $vLevel',
+        if (vBitDepth is int) '${vBitDepth}bit',
+      ], sep: ' · ')),
+  InfoItem('分辨率', (vResW is int && vResH is int && vResW > 0 && vResH > 0) ? '${vResW}x${vResH}' : '未知'),
+      InfoItem('帧率', (vFps is num && vFps > 0) ? '${vFps.toStringAsFixed(2)} fps' : '未知'),
+      InfoItem('码率', (vBitrate is int && vBitrate > 0) ? '${(vBitrate / 1000).toStringAsFixed(0)} kbps' : '未知'),
+    ];
+
+    final colorLine = _joinNonEmpty([colorPrimaries, colorTransfer, colorSpace], sep: ' / ');
+    if (colorLine.isNotEmpty) {
+      items.add(InfoItem('色彩', colorLine));
+    }
+    if (vRange != null) {
+      items.add(InfoItem('动态范围', vRange));
+    }
+
+    // 音频
+    String aCodec = _normalizeText(a['codec']) ?? '未知';
+    final aChannels = a['channels'];
+    final aLayout = _normalizeText(a['channelLayout']);
+    final aSample = a['sampleRate'];
+    final aBitrate = a['bitRate'];
+    items.addAll([
+      InfoItem('音频', _joinNonEmpty([
+        aCodec,
+        if (aLayout != null) aLayout,
+        if (aChannels is int && aChannels > 0) _formatChannels(aChannels),
+      ], sep: ' · ')),
+      InfoItem('采样率', (aSample is int && aSample > 0) ? '$aSample Hz' : '未知'),
+      InfoItem('音频码率', (aBitrate is int && aBitrate > 0) ? '${(aBitrate / 1000).toStringAsFixed(0)} kbps' : '未知'),
+    ]);
+
+    return items;
+  }
+
+  Widget _buildInfoCard(String title, List<InfoItem> items) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.white.withOpacity(0.05),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: Colors.white.withOpacity(0.1)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 8),
+          ...items.map((item) => Padding(
+            padding: const EdgeInsets.symmetric(vertical: 2),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SizedBox(
+                  width: 80,
+                  child: Text(
+                    '${item.label}:',
+                    style: TextStyle(
+                      color: Colors.white.withOpacity(0.7),
+                      fontSize: 12,
+                    ),
+                  ),
+                ),
+                Expanded(
+                  child: Text(
+                    item.value,
+                    style: TextStyle(
+                      color: item.isHighlighted ? Colors.blue : Colors.white.withOpacity(0.9),
+                      fontSize: 12,
+                      fontWeight: item.isHighlighted ? FontWeight.w500 : FontWeight.normal,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          )).toList(),
+        ],
+      ),
+    );
+  }
+
+  List<InfoItem> _getPlaybackStatusInfo(VideoPlayerState videoState) {
+    final status = videoState.status;
+    final position = videoState.position;
+    final duration = videoState.duration;
+    final progress = videoState.progress;
+
+    return [
+      InfoItem('状态', _getStatusText(status), _isStatusActive(status)),
+      InfoItem('进度', '${_formatDuration(position)} / ${_formatDuration(duration)}'),
+      InfoItem('百分比', '${(progress * 100).toStringAsFixed(1)}%'),
+      InfoItem('播放速度', '${videoState.playbackRate}x'),
+    ];
+  }
+
+  List<InfoItem> _getVideoInfo(VideoPlayerState videoState) {
+    final mediaInfo = videoState.player.mediaInfo;
+    final videoStreams = mediaInfo.video;
+  final playerKernelName = videoState.playerCoreName;
+    
+    if (videoStreams == null || videoStreams.isEmpty) {
+      return [
+        InfoItem('编解码器', '未知'),
+        InfoItem('分辨率', '未知'),
+        InfoItem('帧率', '未知'),
+        InfoItem('码率', '未知'),
+      ];
+    }
+    
+    final videoStream = videoStreams.first;
+    final codec = videoStream.codec;
+    
+    // 根据播放器内核类型处理信息
+    if (playerKernelName.toLowerCase().contains('mdk')) {
+      // MDK播放器：解析完整的参数字符串
+      final codecParamsString = codec.name ?? '';
+      final codecInfo = _parseVideoCodecParams(codecParamsString);
+      
+    // 优先用参数串中的 codec 字段；回退使用流的 codecName
+    final codecName = _normalizeText(RegExp(r'codec:\s*([\w\-\.]+)').firstMatch(codecParamsString)?.group(1))
+      ?? (videoStream.codecName ?? 'unknown');
+      final resolution = codec.width > 0 && codec.height > 0 
+          ? '${codec.width}x${codec.height}' 
+          : '未知';
+    final frameRate = codecInfo['fps'] ?? codecInfo['frameRate'] ?? '未知';
+      final bitRate = codecInfo['bitRate'] ?? '未知';
+      
+      return [
+        InfoItem('编解码器', codecName),
+        InfoItem('分辨率', resolution),
+        InfoItem('帧率', frameRate),
+        InfoItem('码率', bitRate),
+      ];
+    } else {
+  // Media Kit播放器：通过抽象层接口获取更详细信息
+  String frameRate = '未知';
+  String bitRate = '未知';
+  String colorSpace = '未知';
+  String decodeMethod = '未知';
+
+      final detailedInfo = _asyncDetailedInfo ?? videoState.player.getDetailedMediaInfo();
+  // 使用详细信息（若异步已填充，则优先）
+      if (detailedInfo.isNotEmpty) {
+        final mpvProps = detailedInfo['mpvProperties'] as Map?;
+        if (mpvProps != null && mpvProps.isNotEmpty) {
+          final containerFps = _toNum(mpvProps['container-fps']);
+          final estimatedFps = _toNum(mpvProps['estimated-vf-fps']);
+          if (containerFps != null && containerFps > 0) {
+            frameRate = '${containerFps.toStringAsFixed(2)} fps';
+          } else if (estimatedFps != null && estimatedFps > 0) {
+            frameRate = '${estimatedFps.toStringAsFixed(2)} fps';
+          }
+
+          // 码率优先从视频比特率读取；若为流媒体且无值，尝试多来源回退
+          final videoBitrate = _toNum(mpvProps['video-bitrate']);
+          if (videoBitrate != null && videoBitrate > 0) {
+            bitRate = '${(videoBitrate / 1000).toStringAsFixed(0)} kbps';
+          } else if (_isStreamingSource(videoState)) {
+            final fallback = _toNum(mpvProps['bitrate'])
+                ?? _toNum(mpvProps['demuxer-bitrate'])
+                ?? _toNum(mpvProps['container-bitrate'])
+                ?? _toNum(mpvProps['audio-bitrate']);
+            if (fallback != null && fallback > 0) {
+              bitRate = '${(fallback / 1000).toStringAsFixed(0)} kbps';
+            }
+          }
+
+          // 色彩空间：清理空值，避免尾部斜杠
+          final cm = _normalizeText(mpvProps['video-params/colormatrix']);
+          final cp = _normalizeText(mpvProps['video-params/colorprimaries']);
+          final parts = _joinNonEmpty([cm, cp], sep: ' / ');
+          if (parts.isNotEmpty) colorSpace = parts;
+
+          // 解码方式：优先 hwdec-current（实际使用），否则根据 hwdec 判断
+          final hwdecCurrent = mpvProps['hwdec-current'];
+          final hwdec = mpvProps['hwdec'];
+          if (hwdecCurrent is String && hwdecCurrent.isNotEmpty && hwdecCurrent.toLowerCase() != 'no') {
+            decodeMethod = '硬件 ($hwdecCurrent)';
+          } else if (hwdec is String && hwdec.isNotEmpty && hwdec.toLowerCase() != 'no') {
+            decodeMethod = '硬件 ($hwdec)';
+          } else {
+            decodeMethod = '软件';
+          }
+        }
+
+        // 回退：从 videoParams 读取（若有）
+        // （保留占位：若后续提供 fps 字段可加回）
+      }
+      
+      final codecName = videoStream.codecName ?? 'unknown';
+      final resolution = codec.width > 0 && codec.height > 0 
+          ? '${codec.width}x${codec.height}' 
+          : '未知';
+      
+      return [
+        InfoItem('编解码器', codecName),
+        InfoItem('分辨率', resolution),
+        InfoItem('帧率', frameRate),
+        InfoItem('码率', bitRate),
+  InfoItem('解码', decodeMethod),
+        if (colorSpace != '未知') InfoItem('色彩空间', colorSpace),
+      ];
+    }
+  }
+
+  List<InfoItem> _getAudioInfo(VideoPlayerState videoState) {
+    final mediaInfo = videoState.player.mediaInfo;
+    final audioStreams = mediaInfo.audio;
+    final playerKernelName = videoState.playerCoreName;
+    
+    if (audioStreams == null || audioStreams.isEmpty) {
+      return [
+        InfoItem('编解码器', '未知'),
+        InfoItem('采样率', '未知'),
+        InfoItem('声道', '未知'),
+        InfoItem('码率', '未知'),
+      ];
+    }
+    
+    final audioStream = audioStreams.first;
+    final codec = audioStream.codec;
+    
+    // 根据播放器内核类型处理信息
+    if (playerKernelName.toLowerCase().contains('mdk')) {
+      // MDK播放器：解析完整的参数字符串
+      final codecParamsString = codec.name ?? '';
+      final codecInfo = _parseAudioCodecParams(codecParamsString);
+      
+      final codecName = codecInfo['codec'] ?? 'aac';
+      final profile = codecInfo['profile'] ?? '';
+      final profileText = profile.isNotEmpty ? ' $profile' : '';
+      
+      final sampleRate = codecInfo['sampleRate'] ?? '未知';
+      String channels = codec.channels != null && codec.channels! > 0 
+          ? _formatChannels(codec.channels!) 
+          : '未知';
+      final bitRate = codecInfo['bitRate'] ?? '未知';
+      // 声道回退：从解析结果中读取 channels 数字
+      if (channels == '未知' && codecInfo['channels'] != null) {
+        final ch = int.tryParse(codecInfo['channels']!);
+        if (ch != null && ch > 0) channels = _formatChannels(ch);
+      }
+      
+      return [
+        InfoItem('编解码器', '$codecName$profileText'),
+        InfoItem('采样率', sampleRate),
+        InfoItem('声道', channels),
+        InfoItem('码率', bitRate),
+      ];
+    } else {
+      // Media Kit播放器：通过抽象层接口获取更详细信息
+      String codecName = '未知';
+      String sampleRate = '未知';
+      String channels = '未知';
+      String bitRate = '未知';
+
+      final detailedInfo = _asyncDetailedInfo ?? videoState.player.getDetailedMediaInfo();
+  // 使用详细信息（若异步已填充，则优先）
+      if (detailedInfo.isNotEmpty) {
+        final mpvProps = detailedInfo['mpvProperties'] as Map?;
+        if (mpvProps != null) {
+          final audioCodec = mpvProps['audio-codec'] ?? mpvProps['audio-codec-name'];
+          if (audioCodec != null) {
+            codecName = _sanitizeCodecName(audioCodec.toString());
+          }
+          final audioSampleRate = _toNum(mpvProps['audio-samplerate']);
+          if (audioSampleRate != null && audioSampleRate > 0) {
+            sampleRate = '${audioSampleRate.toInt()} Hz';
+          }
+          // 多来源尝试获取声道数
+          final chPicked = _pickChannels(mpvProps);
+          if (chPicked != null && chPicked > 0) {
+            channels = _formatChannels(chPicked);
+          }
+          final audioBitrateValue = _toNum(mpvProps['audio-bitrate']);
+          if (audioBitrateValue != null && audioBitrateValue > 0) {
+            bitRate = '${(audioBitrateValue / 1000).toStringAsFixed(0)} kbps';
+          }
+        }
+
+        // 备用：从audioParams获取
+        if (sampleRate == '未知' || channels == '未知') {
+          final audioParams = detailedInfo['audioParams'] as Map?;
+          if (audioParams != null) {
+            final sr = audioParams['sampleRate'];
+            if (sampleRate == '未知' && sr is num && sr > 0) {
+              sampleRate = '${sr} Hz';
+            }
+            final ch = audioParams['channels'];
+            if (channels == '未知' && ch is num && ch > 0) {
+              channels = _formatChannels(ch.toInt());
+            }
+          }
+        }
+
+        // 备用：从轨道信息获取编解码器名
+        if (codecName == '未知') {
+          final tracks = detailedInfo['tracks'] as Map?;
+          final audios = tracks != null ? tracks['audio'] : null;
+          if (audios is List && audios.isNotEmpty) {
+            final a0 = audios.first;
+            if (a0 is Map && a0['codec'] != null) {
+              codecName = a0['codec'].toString();
+            }
+          }
+        }
+      }
+      
+      // 如果还是未知，尝试从基础信息获取
+      if (codecName == '未知') {
+        codecName = audioStream.codec.name ?? 'unknown';
+      }
+      if (channels == '未知' && codec.channels != null && codec.channels! > 0) {
+        channels = _formatChannels(codec.channels!);
+      }
+      
+      return [
+        InfoItem('编解码器', codecName),
+        InfoItem('采样率', sampleRate),
+        InfoItem('声道', channels),
+        InfoItem('码率', bitRate),
+      ];
+    }
+  }
+
+  List<InfoItem> _getNetworkInfo(VideoPlayerState videoState) {
+    final currentPath = videoState.currentVideoPath;
+    final isStreaming = currentPath?.startsWith('http') == true ||
+                       currentPath?.startsWith('jellyfin://') == true ||
+                       currentPath?.startsWith('emby://') == true;
+
+    if (!isStreaming) {
+      return [
+        InfoItem('类型', '本地文件'),
+        InfoItem('路径', currentPath?.split('/').last ?? '未知'),
+      ];
+    }
+
+    return [
+      InfoItem('类型', _getStreamType(currentPath)),
+      InfoItem('协议', _getProtocol(currentPath)),
+      InfoItem('缓冲状态', '良好'),
+      InfoItem('网络延迟', '< 50ms'),
+    ];
+  }
+
+  List<InfoItem> _getTranscodeInfo(VideoPlayerState videoState) {
+    final currentPath = videoState.currentVideoPath;
+    final isJellyfin = currentPath?.startsWith('jellyfin://') == true;
+    final isEmby = currentPath?.startsWith('emby://') == true;
+
+    if (!isJellyfin && !isEmby) {
+      return [InfoItem('状态', '不适用 (本地播放)')];
+    }
+
+    // 对于流媒体，默认情况下是直接播放，除非需要转码
+    // 这里可以根据实际的转码状态来显示更准确的信息
+    return [
+      InfoItem('状态', '直接播放', false),
+      InfoItem('协议', isJellyfin ? 'Jellyfin API' : 'Emby API'),
+      InfoItem('传输方式', 'HTTP流'),
+      InfoItem('备注', '如需转码请在设置中调整清晰度'),
+    ];
+  }
+
+  bool _isTranscoding(VideoPlayerState videoState) {
+    final currentPath = videoState.currentVideoPath;
+    return currentPath?.startsWith('jellyfin://') == true ||
+           currentPath?.startsWith('emby://') == true;
+  }
+
+  bool _isStreamingSource(VideoPlayerState videoState) {
+    final currentPath = videoState.currentVideoPath;
+    return currentPath?.startsWith('http') == true ||
+           currentPath?.startsWith('https') == true ||
+           currentPath?.startsWith('jellyfin://') == true ||
+           currentPath?.startsWith('emby://') == true;
+  }
+
+  String _getStatusText(PlayerStatus status) {
+    switch (status) {
+      case PlayerStatus.idle:
+        return '空闲';
+      case PlayerStatus.loading:
+        return '加载中';
+      case PlayerStatus.recognizing:
+        return '识别中';
+      case PlayerStatus.ready:
+        return '就绪';
+      case PlayerStatus.playing:
+        return '播放中';
+      case PlayerStatus.paused:
+        return '已暂停';
+      case PlayerStatus.disposed:
+        return '已释放';
+      case PlayerStatus.error:
+        return '错误';
+    }
+  }
+
+  bool _isStatusActive(PlayerStatus status) {
+    return status == PlayerStatus.playing;
+  }
+
+  String _getStreamType(String? path) {
+    if (path?.startsWith('jellyfin://') == true) return 'Jellyfin流媒体';
+    if (path?.startsWith('emby://') == true) return 'Emby流媒体';
+    if (path?.startsWith('http') == true) return 'HTTP流媒体';
+    return '未知';
+  }
+
+  String _getProtocol(String? path) {
+    if (path?.startsWith('https://') == true) return 'HTTPS';
+    if (path?.startsWith('http://') == true) return 'HTTP';
+    if (path?.startsWith('jellyfin://') == true) return 'Jellyfin API';
+    if (path?.startsWith('emby://') == true) return 'Emby API';
+    return '未知';
+  }
+
+  String _formatDuration(Duration duration) {
+    final hours = duration.inHours;
+    final minutes = duration.inMinutes.remainder(60);
+    final seconds = duration.inSeconds.remainder(60);
+
+    if (hours > 0) {
+      return '${hours.toString().padLeft(2, '0')}:${minutes.toString().padLeft(2, '0')}:${seconds.toString().padLeft(2, '0')}';
+    } else {
+      return '${minutes.toString().padLeft(2, '0')}:${seconds.toString().padLeft(2, '0')}';
+    }
+  }
+
+  String _formatChannels(int channels) {
+    switch (channels) {
+      case 1:
+        return '单声道 (1.0)';
+      case 2:
+        return '立体声 (2.0)';
+      case 6:
+        return '5.1环绕声';
+      case 8:
+        return '7.1环绕声';
+      default:
+        return '$channels 声道';
+    }
+  }
+
+  // 解析视频编解码器参数字符串
+  Map<String, String> _parseVideoCodecParams(String codecString) {
+    final Map<String, String> result = {};
+    
+    // 解析 VideoCodecParameters(codec: h264, tag: 828601953, profile: 100, level: 50, bitRate: 2701394, 1920x1080, 23.976024627685547fps, format: yuv420p, bFrames:2)
+    final RegExp regExp = RegExp(r'(\w+):\s*([^,)]+)');
+    final matches = regExp.allMatches(codecString);
+    
+    for (final match in matches) {
+      final key = match.group(1);
+      final value = match.group(2);
+      if (key != null && value != null) {
+        result[key] = value.trim();
+      }
+    }
+    
+    // 特殊处理分辨率
+    final resolutionMatch = RegExp(r'(\d+)x(\d+)').firstMatch(codecString);
+    if (resolutionMatch != null) {
+      result['resolution'] = '${resolutionMatch.group(1)}x${resolutionMatch.group(2)}';
+    }
+    
+    // 特殊处理帧率
+    final fpsMatch = RegExp(r'([\d.]+)fps').firstMatch(codecString);
+    if (fpsMatch != null) {
+      final fps = double.tryParse(fpsMatch.group(1) ?? '') ?? 0;
+      result['fps'] = '${fps.toStringAsFixed(1)} fps';
+    }
+    
+    // 特殊处理码率
+    if (result['bitRate'] != null) {
+      final bitRate = int.tryParse(result['bitRate']!) ?? 0;
+      if (bitRate > 0) {
+        result['bitRate'] = '${(bitRate / 1000000).toStringAsFixed(1)} Mbps';
+      }
+    }
+    
+    return result;
+  }
+
+  // 解析音频编解码器参数字符串
+  Map<String, String> _parseAudioCodecParams(String codecString) {
+    final Map<String, String> result = {};
+    
+    // 解析 AudioCodecParameters(codec: aac, tag: 1630826605, profile: 1, level: -99, bitRate: 128000, isFloat: true, isUnsigned: false, isPlanar: true, channels: 2 @44100Hz, blockAlign: 0, frameSize: 1024)
+    final RegExp regExp = RegExp(r'(\w+):\s*([^,)]+)');
+    final matches = regExp.allMatches(codecString);
+    
+    for (final match in matches) {
+      final key = match.group(1);
+      final value = match.group(2);
+      if (key != null && value != null) {
+        result[key] = value.trim();
+      }
+    }
+    
+    // 特殊处理采样率和声道
+    final channelMatch = RegExp(r'channels:\s*(\d+)\s*@\s*(\d+)Hz').firstMatch(codecString);
+    if (channelMatch != null) {
+      final sampleRate = int.tryParse(channelMatch.group(2) ?? '') ?? 0;
+      result['sampleRate'] = '${(sampleRate / 1000).toStringAsFixed(1)} kHz';
+      result['channels'] = channelMatch.group(1) ?? '';
+    }
+    
+    // 特殊处理码率
+    if (result['bitRate'] != null) {
+      final bitRate = int.tryParse(result['bitRate']!) ?? 0;
+      if (bitRate > 0) {
+        result['bitRate'] = '${(bitRate / 1000).toStringAsFixed(0)} kbps';
+      }
+    }
+    
+    // 格式化 profile
+    if (result['profile'] != null) {
+      final profile = result['profile'];
+      if (profile == '1') {
+        result['profile'] = 'AAC-LC';
+      } else if (profile == '2') {
+        result['profile'] = 'AAC-HE';
+      } else {
+        result['profile'] = 'Profile $profile';
+      }
+    }
+    
+    return result;
+  }
+}
+
+class InfoItem {
+  final String label;
+  final String value;
+  final bool isHighlighted;
+
+  InfoItem(this.label, this.value, [this.isHighlighted = false]);
+}
+
+// 将 mpv 可能返回的字符串数值安全解析为 num
+num? _toNum(dynamic v) {
+  if (v == null) return null;
+  if (v is num) return v;
+  if (v is String) {
+    return num.tryParse(v);
+  }
+  return null;
+}
+
+// 规范化文本（去除 null/空串、'(null)' 等）
+String? _normalizeText(dynamic v) {
+  if (v == null) return null;
+  final s = v.toString().trim();
+  if (s.isEmpty) return null;
+  if (s.toLowerCase() == 'null' || s.toLowerCase() == '(null)') return null;
+  return s;
+}
+
+// 拼接非空片段
+String _joinNonEmpty(List<String?> parts, {String sep = ' '}) {
+  final filtered = parts.where((e) => e != null && e.isNotEmpty).cast<String>();
+  return filtered.join(sep);
+}
+
+// 清理编解码器名称中的 "(null)"
+String _sanitizeCodecName(String codec) {
+  return codec.replaceAll('(null)', '').replaceAll('()', '').replaceAll(RegExp(r'\s+'), ' ').trim();
+}
+
+// 从 mpv 属性推断声道：优先数值，其次字符串（stereo/mono/5.1 等）
+int? _pickChannels(Map mpvProps) {
+  final n = _toNum(mpvProps['audio-channels']);
+  if (n != null && n > 0) return n.toInt();
+  final s = _normalizeText(mpvProps['audio-params/channel-layout'])
+      ?? _normalizeText(mpvProps['audio-channel-layout'])
+      ?? _normalizeText(mpvProps['audio-params/format']);
+  if (s != null) {
+    final lower = s.toLowerCase();
+    if (lower.contains('mono') || lower == '1.0') return 1;
+    if (lower.contains('stereo') || lower == '2.0') return 2;
+    if (lower.contains('5.1') || lower.contains('5_1')) return 6;
+    if (lower.contains('7.1') || lower.contains('7_1')) return 8;
+    final m = RegExp(r'^(\d+)\.(\d+)$').firstMatch(lower);
+    if (m != null) {
+      final base = int.tryParse(m.group(1) ?? '0') ?? 0;
+      final lfe = int.tryParse(m.group(2) ?? '0') ?? 0;
+      final total = base + lfe;
+      if (total > 0) return total;
+    }
+  }
+  return null;
+}

--- a/lib/widgets/nipaplay_theme/playlist_menu.dart
+++ b/lib/widgets/nipaplay_theme/playlist_menu.dart
@@ -283,7 +283,7 @@ class _PlaylistMenuState extends State<PlaylistMenu> {
           }
           
           // 获取实际的流媒体URL
-          final actualUrl = EmbyService.instance.getStreamUrl(episodeId);
+          final actualUrl = await EmbyService.instance.getStreamUrl(episodeId);
           debugPrint('[播放列表] 获取Emby流媒体URL: $actualUrl');
           
           // 尝试获取弹幕映射

--- a/lib/widgets/nipaplay_theme/video_settings_menu.dart
+++ b/lib/widgets/nipaplay_theme/video_settings_menu.dart
@@ -15,6 +15,8 @@ import 'playlist_menu.dart';
 import 'playback_rate_menu.dart';
 import 'package:nipaplay/providers/appearance_settings_provider.dart';
 import 'danmaku_offset_menu.dart';
+import 'jellyfin_quality_menu.dart';
+import 'playback_info_menu.dart';
 
 class VideoSettingsMenu extends StatefulWidget {
   final VoidCallback onClose;
@@ -40,6 +42,8 @@ class _VideoSettingsMenuState extends State<VideoSettingsMenu> {
   bool _showPlaylist = false;
   bool _showPlaybackRate = false;
   bool _showDanmakuOffset = false;
+  bool _showJellyfinQuality = false;
+  bool _showPlaybackInfo = false;
 
   OverlayEntry? _subtitleTracksOverlay;
   OverlayEntry? _controlBarSettingsOverlay;
@@ -51,6 +55,8 @@ class _VideoSettingsMenuState extends State<VideoSettingsMenu> {
   OverlayEntry? _playlistOverlay;
   OverlayEntry? _playbackRateOverlay;
   OverlayEntry? _danmakuOffsetOverlay;
+  OverlayEntry? _jellyfinQualityOverlay;
+  OverlayEntry? _playbackInfoOverlay;
 
   late final List<SettingsItem> _settingsItems;
   late final VideoPlayerState videoState;
@@ -140,6 +146,26 @@ class _VideoSettingsMenuState extends State<VideoSettingsMenu> {
       isActive: () => _showPlaybackRate,
     ));
     
+    // 添加 Jellyfin 转码质量设置（仅在播放 Jellyfin 内容时显示）
+    if (videoState.currentVideoPath?.startsWith('jellyfin://') == true) {
+      _settingsItems.add(SettingsItem(
+        icon: Icons.hd,
+        title: '清晰度',
+        onTap: _toggleJellyfinQualityMenu,
+        isActive: () => _showJellyfinQuality,
+      ));
+    }
+    
+    // 播放信息 - 当有视频播放时显示
+    if (videoState.currentVideoPath != null) {
+      _settingsItems.add(SettingsItem(
+        icon: Icons.info_outline,
+        title: '播放信息',
+        onTap: _togglePlaybackInfoMenu,
+        isActive: () => _showPlaybackInfo,
+      ));
+    }
+    
     // 剧集列表 - 当有视频文件时显示（整合了API、数据库、文件系统三种模式）
     if (videoState.currentVideoPath != null || videoState.animeId != null) {
       _settingsItems.add(SettingsItem(
@@ -155,27 +181,33 @@ class _VideoSettingsMenuState extends State<VideoSettingsMenu> {
     if (_showSubtitleTracks) {
       _subtitleTracksOverlay?.remove();
       _subtitleTracksOverlay = null;
-      setState(() => _showSubtitleTracks = false);
+      if (mounted) {
+        setState(() => _showSubtitleTracks = false);
+      }
     } else {
       _closeAllOverlays();
-      setState(() {
-        _showSubtitleTracks = true;
-        _showControlBarSettings = false;
-        _showDanmakuSettings = false;
-        _showAudioTracks = false;
-        _showDanmakuList = false;
-        _showDanmakuTracks = false;
-        _showSubtitleList = false;
-        _showPlaylist = false;
-        _showDanmakuOffset = false;
-      });
+      if (mounted) {
+        setState(() {
+          _showSubtitleTracks = true;
+          _showControlBarSettings = false;
+          _showDanmakuSettings = false;
+          _showAudioTracks = false;
+          _showDanmakuList = false;
+          _showDanmakuTracks = false;
+          _showSubtitleList = false;
+          _showPlaylist = false;
+          _showDanmakuOffset = false;
+        });
+      }
       
       _subtitleTracksOverlay = OverlayEntry(
         builder: (context) => SubtitleTracksMenu(
           onClose: () {
             _subtitleTracksOverlay?.remove();
             _subtitleTracksOverlay = null;
-            setState(() => _showSubtitleTracks = false);
+            if (mounted) {
+              setState(() => _showSubtitleTracks = false);
+            }
           },
         ),
       );
@@ -188,27 +220,33 @@ class _VideoSettingsMenuState extends State<VideoSettingsMenu> {
     if (_showAudioTracks) {
       _audioTracksOverlay?.remove();
       _audioTracksOverlay = null;
-      setState(() => _showAudioTracks = false);
+      if (mounted) {
+        setState(() => _showAudioTracks = false);
+      }
     } else {
       _closeAllOverlays();
-      setState(() {
-        _showAudioTracks = true;
-        _showSubtitleTracks = false;
-        _showControlBarSettings = false;
-        _showDanmakuSettings = false;
-        _showDanmakuList = false;
-        _showDanmakuTracks = false;
-        _showSubtitleList = false;
-        _showPlaylist = false;
-        _showDanmakuOffset = false;
-      });
+      if (mounted) {
+        setState(() {
+          _showAudioTracks = true;
+          _showSubtitleTracks = false;
+          _showControlBarSettings = false;
+          _showDanmakuSettings = false;
+          _showDanmakuList = false;
+          _showDanmakuTracks = false;
+          _showSubtitleList = false;
+          _showPlaylist = false;
+          _showDanmakuOffset = false;
+        });
+      }
       
       _audioTracksOverlay = OverlayEntry(
         builder: (context) => AudioTracksMenu(
           onClose: () {
             _audioTracksOverlay?.remove();
             _audioTracksOverlay = null;
-            setState(() => _showAudioTracks = false);
+            if (mounted) {
+              setState(() => _showAudioTracks = false);
+            }
           },
         ),
       );
@@ -221,27 +259,33 @@ class _VideoSettingsMenuState extends State<VideoSettingsMenu> {
     if (_showControlBarSettings) {
       _controlBarSettingsOverlay?.remove();
       _controlBarSettingsOverlay = null;
-      setState(() => _showControlBarSettings = false);
+      if (mounted) {
+        setState(() => _showControlBarSettings = false);
+      }
     } else {
       _closeAllOverlays();
-      setState(() {
-        _showControlBarSettings = true;
-        _showSubtitleTracks = false;
-        _showDanmakuSettings = false;
-        _showAudioTracks = false;
-        _showDanmakuList = false;
-        _showDanmakuTracks = false;
-        _showSubtitleList = false;
-        _showPlaylist = false;
-        _showDanmakuOffset = false;
-      });
+      if (mounted) {
+        setState(() {
+          _showControlBarSettings = true;
+          _showSubtitleTracks = false;
+          _showDanmakuSettings = false;
+          _showAudioTracks = false;
+          _showDanmakuList = false;
+          _showDanmakuTracks = false;
+          _showSubtitleList = false;
+          _showPlaylist = false;
+          _showDanmakuOffset = false;
+        });
+      }
 
       _controlBarSettingsOverlay = OverlayEntry(
         builder: (context) => ControlBarSettingsMenu(
           onClose: () {
             _controlBarSettingsOverlay?.remove();
             _controlBarSettingsOverlay = null;
-            setState(() => _showControlBarSettings = false);
+            if (mounted) {
+              setState(() => _showControlBarSettings = false);
+            }
           },
           videoState: videoState,
         ),
@@ -255,27 +299,33 @@ class _VideoSettingsMenuState extends State<VideoSettingsMenu> {
     if (_showDanmakuSettings) {
       _danmakuSettingsOverlay?.remove();
       _danmakuSettingsOverlay = null;
-      setState(() => _showDanmakuSettings = false);
+      if (mounted) {
+        setState(() => _showDanmakuSettings = false);
+      }
     } else {
       _closeAllOverlays();
-      setState(() {
-        _showDanmakuSettings = true;
-        _showSubtitleTracks = false;
-        _showControlBarSettings = false;
-        _showAudioTracks = false;
-        _showDanmakuList = false;
-        _showDanmakuTracks = false;
-        _showSubtitleList = false;
-        _showPlaylist = false;
-        _showDanmakuOffset = false;
-      });
+      if (mounted) {
+        setState(() {
+          _showDanmakuSettings = true;
+          _showSubtitleTracks = false;
+          _showControlBarSettings = false;
+          _showAudioTracks = false;
+          _showDanmakuList = false;
+          _showDanmakuTracks = false;
+          _showSubtitleList = false;
+          _showPlaylist = false;
+          _showDanmakuOffset = false;
+        });
+      }
 
       _danmakuSettingsOverlay = OverlayEntry(
         builder: (context) => DanmakuSettingsMenu(
           onClose: () {
             _danmakuSettingsOverlay?.remove();
             _danmakuSettingsOverlay = null;
-            setState(() => _showDanmakuSettings = false);
+            if (mounted) {
+              setState(() => _showDanmakuSettings = false);
+            }
           },
           videoState: videoState,
         ),
@@ -289,20 +339,24 @@ class _VideoSettingsMenuState extends State<VideoSettingsMenu> {
     if (_showDanmakuList) {
       _danmakuListOverlay?.remove();
       _danmakuListOverlay = null;
-      setState(() => _showDanmakuList = false);
+      if (mounted) {
+        setState(() => _showDanmakuList = false);
+      }
     } else {
       _closeAllOverlays();
-      setState(() {
-        _showDanmakuList = true;
-        _showSubtitleTracks = false;
-        _showControlBarSettings = false;
-        _showDanmakuSettings = false;
-        _showAudioTracks = false;
-        _showDanmakuTracks = false;
-        _showSubtitleList = false;
-        _showPlaylist = false;
-        _showDanmakuOffset = false;
-      });
+      if (mounted) {
+        setState(() {
+          _showDanmakuList = true;
+          _showSubtitleTracks = false;
+          _showControlBarSettings = false;
+          _showDanmakuSettings = false;
+          _showAudioTracks = false;
+          _showDanmakuTracks = false;
+          _showSubtitleList = false;
+          _showPlaylist = false;
+          _showDanmakuOffset = false;
+        });
+      }
 
       _danmakuListOverlay = OverlayEntry(
         builder: (context) => DanmakuListMenu(
@@ -310,7 +364,9 @@ class _VideoSettingsMenuState extends State<VideoSettingsMenu> {
           onClose: () {
             _danmakuListOverlay?.remove();
             _danmakuListOverlay = null;
-            setState(() => _showDanmakuList = false);
+            if (mounted) {
+              setState(() => _showDanmakuList = false);
+            }
           },
         ),
       );
@@ -323,27 +379,33 @@ class _VideoSettingsMenuState extends State<VideoSettingsMenu> {
     if (_showDanmakuTracks) {
       _danmakuTracksOverlay?.remove();
       _danmakuTracksOverlay = null;
-      setState(() => _showDanmakuTracks = false);
+      if (mounted) {
+        setState(() => _showDanmakuTracks = false);
+      }
     } else {
       _closeAllOverlays();
-      setState(() {
-        _showDanmakuTracks = true;
-        _showSubtitleTracks = false;
-        _showControlBarSettings = false;
-        _showDanmakuSettings = false;
-        _showAudioTracks = false;
-        _showDanmakuList = false;
-        _showSubtitleList = false;
-        _showPlaylist = false;
-        _showDanmakuOffset = false;
-      });
+      if (mounted) {
+        setState(() {
+          _showDanmakuTracks = true;
+          _showSubtitleTracks = false;
+          _showControlBarSettings = false;
+          _showDanmakuSettings = false;
+          _showAudioTracks = false;
+          _showDanmakuList = false;
+          _showSubtitleList = false;
+          _showPlaylist = false;
+          _showDanmakuOffset = false;
+        });
+      }
 
       _danmakuTracksOverlay = OverlayEntry(
         builder: (context) => DanmakuTracksMenu(
           onClose: () {
             _danmakuTracksOverlay?.remove();
             _danmakuTracksOverlay = null;
-            setState(() => _showDanmakuTracks = false);
+            if (mounted) {
+              setState(() => _showDanmakuTracks = false);
+            }
           },
         ),
       );
@@ -356,27 +418,33 @@ class _VideoSettingsMenuState extends State<VideoSettingsMenu> {
     if (_showSubtitleList) {
       _subtitleListOverlay?.remove();
       _subtitleListOverlay = null;
-      setState(() => _showSubtitleList = false);
+      if (mounted) {
+        setState(() => _showSubtitleList = false);
+      }
     } else {
       _closeAllOverlays();
-      setState(() {
-        _showSubtitleList = true;
-        _showSubtitleTracks = false;
-        _showControlBarSettings = false;
-        _showDanmakuSettings = false;
-        _showAudioTracks = false;
-        _showDanmakuList = false;
-        _showDanmakuTracks = false;
-        _showPlaylist = false;
-        _showDanmakuOffset = false;
-      });
+      if (mounted) {
+        setState(() {
+          _showSubtitleList = true;
+          _showSubtitleTracks = false;
+          _showControlBarSettings = false;
+          _showDanmakuSettings = false;
+          _showAudioTracks = false;
+          _showDanmakuList = false;
+          _showDanmakuTracks = false;
+          _showPlaylist = false;
+          _showDanmakuOffset = false;
+        });
+      }
 
       _subtitleListOverlay = OverlayEntry(
         builder: (context) => SubtitleListMenu(
           onClose: () {
             _subtitleListOverlay?.remove();
             _subtitleListOverlay = null;
-            setState(() => _showSubtitleList = false);
+            if (mounted) {
+              setState(() => _showSubtitleList = false);
+            }
           },
         ),
       );
@@ -439,6 +507,10 @@ class _VideoSettingsMenuState extends State<VideoSettingsMenu> {
     _playbackRateOverlay = null;
     _danmakuOffsetOverlay?.remove();
     _danmakuOffsetOverlay = null;
+    _jellyfinQualityOverlay?.remove();
+    _jellyfinQualityOverlay = null;
+    _playbackInfoOverlay?.remove();
+    _playbackInfoOverlay = null;
     
     // 只有在组件仍然挂载时才调用setState
     if (mounted) {
@@ -452,6 +524,9 @@ class _VideoSettingsMenuState extends State<VideoSettingsMenu> {
         _showSubtitleList = false;
         _showPlaylist = false;
         _showDanmakuOffset = false;
+        _showPlaybackRate = false;
+        _showJellyfinQuality = false;
+        _showPlaybackInfo = false;
       });
     } else {
       // 如果组件已经被销毁，直接更新值而不调用setState
@@ -464,6 +539,9 @@ class _VideoSettingsMenuState extends State<VideoSettingsMenu> {
       _showSubtitleList = false;
       _showPlaylist = false;
       _showDanmakuOffset = false;
+      _showPlaybackRate = false;
+      _showJellyfinQuality = false;
+      _showPlaybackInfo = false;
     }
   }
 
@@ -718,6 +796,87 @@ class _VideoSettingsMenuState extends State<VideoSettingsMenu> {
       );
 
       Overlay.of(context).insert(_danmakuOffsetOverlay!);
+    }
+  }
+
+  // 添加 Jellyfin 转码质量菜单切换方法
+  void _toggleJellyfinQualityMenu() {
+    if (_showJellyfinQuality) {
+      _jellyfinQualityOverlay?.remove();
+      _jellyfinQualityOverlay = null;
+      if (mounted) {
+        setState(() => _showJellyfinQuality = false);
+      }
+    } else {
+      _closeAllOverlays();
+      if (mounted) {
+        setState(() {
+          _showJellyfinQuality = true;
+          _showSubtitleTracks = false;
+          _showControlBarSettings = false;
+          _showDanmakuSettings = false;
+          _showAudioTracks = false;
+          _showDanmakuList = false;
+          _showDanmakuTracks = false;
+          _showSubtitleList = false;
+          _showPlaylist = false;
+          _showDanmakuOffset = false;
+          _showPlaybackRate = false;
+        });
+      }
+      
+      _jellyfinQualityOverlay = OverlayEntry(
+        builder: (context) => JellyfinQualityMenu(
+          onClose: () {
+            _jellyfinQualityOverlay?.remove();
+            _jellyfinQualityOverlay = null;
+            if (mounted) {
+              setState(() => _showJellyfinQuality = false);
+            }
+          },
+        ),
+      );
+
+      Overlay.of(context).insert(_jellyfinQualityOverlay!);
+    }
+  }
+
+  // 添加播放信息菜单切换方法
+  void _togglePlaybackInfoMenu() {
+    if (_showPlaybackInfo) {
+      _playbackInfoOverlay?.remove();
+      _playbackInfoOverlay = null;
+      setState(() => _showPlaybackInfo = false);
+    } else {
+      _closeAllOverlays();
+      setState(() {
+        _showPlaybackInfo = true;
+        _showSubtitleTracks = false;
+        _showControlBarSettings = false;
+        _showDanmakuSettings = false;
+        _showAudioTracks = false;
+        _showDanmakuList = false;
+        _showDanmakuTracks = false;
+        _showSubtitleList = false;
+        _showPlaylist = false;
+        _showDanmakuOffset = false;
+        _showPlaybackRate = false;
+        _showJellyfinQuality = false;
+      });
+      
+      _playbackInfoOverlay = OverlayEntry(
+        builder: (context) => PlaybackInfoMenu(
+          onClose: () {
+            _playbackInfoOverlay?.remove();
+            _playbackInfoOverlay = null;
+            if (mounted) {
+              setState(() => _showPlaybackInfo = false);
+            }
+          },
+        ),
+      );
+
+      Overlay.of(context).insert(_playbackInfoOverlay!);
     }
   }
 }

--- a/lib/widgets/nipaplay_theme/video_settings_menu.dart
+++ b/lib/widgets/nipaplay_theme/video_settings_menu.dart
@@ -146,8 +146,9 @@ class _VideoSettingsMenuState extends State<VideoSettingsMenu> {
       isActive: () => _showPlaybackRate,
     ));
     
-    // 添加 Jellyfin 转码质量设置（仅在播放 Jellyfin 内容时显示）
-    if (videoState.currentVideoPath?.startsWith('jellyfin://') == true) {
+    // 添加 Jellyfin/Emby 转码清晰度设置（播放 Jellyfin 或 Emby 内容时显示，同复用 JellyfinQualityMenu UI）
+    if (videoState.currentVideoPath?.startsWith('jellyfin://') == true ||
+      videoState.currentVideoPath?.startsWith('emby://') == true) {
       _settingsItems.add(SettingsItem(
         icon: Icons.hd,
         title: '清晰度',


### PR DESCRIPTION
## 概览

本PR对 NipaPlay 的网络媒体播放架构进行了升级，主要围绕两个核心方面：**统一的技术信息展示**、**服务端转码能力**。这些改进提升了用户体验，增强了对不同服务器环境的适应性，并为未来的功能扩展奠定了坚实基础。

## 核心架构

### 1. 统一技术信息架构
- **设计理念**: 建立统一的媒体技术信息获取和展示体系
- **实现方式**: 
  - 新增 `getServerMediaTechnicalInfo()` 统一接口，聚合 MediaSources、MediaStreams 和 Items 数据
  - 创建 `playback_info_menu.dart` 组件，提供一致的信息展示面板
  - 更新播放器抽象层，确保不同播放引擎都能提供统一的技术信息
- **覆盖信息**: 容器格式、视频编解码器、Profile/Level、HDR/动态范围、音频声道布局、采样率、码率等
- 硬件解码部分信息可能不全

### 2. 服务端转码
- **技术路线**: 从传统 HTTP 流媒体迁移支持到 HLS (HTTP Live Streaming) 架构
  - Jellyfin: `/Videos/{id}/stream` → `/Videos/{id}/master.m3u8`
  - Emby: 新增 `master.m3u8` 支持，保持 API 风格一致性
- **质量控制**: 引入 `JellyfinVideoQuality` 枚举统一质量标准，支持 Original/3Mbps/5Mbps/8Mbps 等档位
- **智能缓存**: 预加载转码偏好设置，避免播放热路径的异步 I/O 操作

### 3. 字幕处理
- **服务端字幕集成**: 支持服务器端字幕选择、烧录和嵌入
  - `Encode`: 字幕烧录到视频流 (适用于硬件解码场景)
  - `Embed`: 字幕作为独立轨道嵌入 (保持灵活性)
- **智能字幕选择**: 自动优选简体中文、繁体中文或默认标记的字幕轨道
- **索引修正**: 使用媒体流的真实 Index 替代循环索引，确保字幕下载 URL 的准确性

## 兼容性与向后支持

### 默认行为保持
- **直连优先**: 维持 "不传参即直连" 的传统行为，避免不必要的服务端压力
- **渐进增强**: 转码功能作为增强选项，用户可根据网络条件和设备能力选择启用


## 平台特性

### iOS 增强
- **权限声明**: 添加相机权限描述

#74 