### PR TITLE
feat: 新增允许自签名证书及无效证书的媒体库连接选项及提升默认 HTTP 超时时长

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -61,6 +61,7 @@ import 'utils/shortcut_tooltip_manager.dart';
 import 'utils/hotkey_service.dart';
 import 'package:nipaplay/providers/settings_provider.dart';
 import 'package:nipaplay/models/watch_history_database.dart';
+import 'package:nipaplay/services/http_client_initializer.dart';
 
 final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 // 将通道定义为全局变量
@@ -70,6 +71,9 @@ final GlobalKey<State<DefaultTabController>> tabControllerKey = GlobalKey<State<
 
 void main(List<String> args) async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  // 安装 HTTP 客户端覆盖（自签名证书信任规则），尽早生效
+  await HttpClientInitializer.install();
 
   // 初始化hotkey_manager
   if (globals.isDesktop) {

--- a/lib/pages/settings/developer_options_page.dart
+++ b/lib/pages/settings/developer_options_page.dart
@@ -12,6 +12,7 @@ import 'package:provider/provider.dart';
 import 'package:kmbal_ionicons/kmbal_ionicons.dart';
 import 'package:glassmorphism/glassmorphism.dart';
 import 'package:nipaplay/widgets/nipaplay_theme/settings_item.dart';
+// 证书相关的主机快捷信任按钮应用户要求移除，仅保留全局开关
 
 /// 开发者选项设置页面
 class DeveloperOptionsPage extends StatelessWidget {
@@ -23,6 +24,21 @@ class DeveloperOptionsPage extends StatelessWidget {
       builder: (context, devOptions, child) {
         return ListView(
           children: [
+            // 危险：全局允许无效/自签名证书（仅 IO 平台生效）
+            SettingsItem.toggle(
+              title: '允许自签名证书（全局）',
+              subtitle: '仅桌面/Android/iOS生效，Web无效。极度危险，仅在内网或调试时开启。',
+              icon: Ionicons.alert_circle_outline,
+              value: devOptions.allowInvalidCertsGlobal,
+              onChanged: (bool value) async {
+                await devOptions.setAllowInvalidCertsGlobal(value);
+                // 立即反馈
+                final status = value ? '已开启（不安全）' : '已关闭（默认安全）';
+                BlurSnackBar.show(context, '自签名证书全局开关：$status');
+              },
+            ),
+
+            const Divider(color: Colors.white12, height: 1),
             // 显示系统资源监控开关（所有平台可用）
             SettingsItem.toggle(
               title: '显示系统资源监控',

--- a/lib/providers/developer_options_provider.dart
+++ b/lib/providers/developer_options_provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:nipaplay/utils/settings_storage.dart';
+import 'package:nipaplay/services/certificate_trust_service.dart';
 
 /// 开发者选项Provider
 /// 管理应用中的开发者相关设置
@@ -21,6 +22,9 @@ class DeveloperOptionsProvider extends ChangeNotifier {
   
   // 是否显示GPUDanmaku弹幕内核轨道编号
   bool _showGPUDanmakuTrackNumbers = false;
+
+  // 是否全局允许无效/自签名证书（仅 IO 平台生效，极度危险）
+  bool _allowInvalidCertsGlobal = false;
   
   // 获取显示系统资源监控状态
   bool get showSystemResources => _showSystemResources;
@@ -39,6 +43,9 @@ class DeveloperOptionsProvider extends ChangeNotifier {
   
   // 获取GPUDanmaku弹幕内核轨道编号显示状态
   bool get showGPUDanmakuTrackNumbers => _showGPUDanmakuTrackNumbers;
+
+  // 获取是否全局允许无效/自签名证书（仅 IO 平台生效）
+  bool get allowInvalidCertsGlobal => _allowInvalidCertsGlobal;
   
   // 构造函数
   DeveloperOptionsProvider() {
@@ -76,6 +83,9 @@ class DeveloperOptionsProvider extends ChangeNotifier {
       'show_gpu_danmaku_track_numbers',
       defaultValue: false
     );
+
+    // 从证书信任服务加载全局允许开关（服务自身已持久化到 SharedPreferences）
+    _allowInvalidCertsGlobal = CertificateTrustService.instance.globalAllow;
     
     notifyListeners();
   }
@@ -137,6 +147,15 @@ class DeveloperOptionsProvider extends ChangeNotifier {
     if (_showGPUDanmakuTrackNumbers != value) {
       _showGPUDanmakuTrackNumbers = value;
       await SettingsStorage.saveBool('show_gpu_danmaku_track_numbers', _showGPUDanmakuTrackNumbers);
+      notifyListeners();
+    }
+  }
+
+  // 设置是否全局允许无效/自签名证书（仅 IO 平台生效）
+  Future<void> setAllowInvalidCertsGlobal(bool value) async {
+    if (_allowInvalidCertsGlobal != value) {
+      _allowInvalidCertsGlobal = value;
+      await CertificateTrustService.instance.setGlobalAllow(value);
       notifyListeners();
     }
   }

--- a/lib/services/certificate_trust_service.dart
+++ b/lib/services/certificate_trust_service.dart
@@ -1,0 +1,125 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class TrustedCertRule {
+  final String host; // 不含协议与端口，例如: example.com 或 10.0.0.2
+  final bool allowInvalid; // 允许该主机的无效/自签名证书
+  final List<String> sha256Pins; // 证书指纹(sha256 der)十六进制字符串列表，可选
+
+  TrustedCertRule({
+    required this.host,
+    this.allowInvalid = false,
+    List<String>? sha256Pins,
+  }) : sha256Pins = sha256Pins ?? const [];
+
+  Map<String, dynamic> toJson() => {
+        'host': host,
+        'allowInvalid': allowInvalid,
+        'sha256Pins': sha256Pins,
+      };
+
+  static TrustedCertRule fromJson(Map<String, dynamic> json) => TrustedCertRule(
+        host: json['host'] as String,
+        allowInvalid: json['allowInvalid'] as bool? ?? false,
+        sha256Pins: (json['sha256Pins'] as List?)?.cast<String>() ?? const [],
+      );
+}
+
+/// 管理自签名/无效证书的信任策略（仅影响 Dart 层发起的 HTTP 请求）
+class CertificateTrustService {
+  static final CertificateTrustService instance = CertificateTrustService._internal();
+  CertificateTrustService._internal();
+
+  static const _prefsKey = 'trusted_cert_rules_v1';
+  static const _prefsGlobalAllowKey = 'trusted_cert_global_allow_v1';
+
+  bool _globalAllow = false; // 极不推荐，一刀切允许所有无效证书
+  final List<TrustedCertRule> _rules = [];
+
+  bool get globalAllow => _globalAllow;
+  List<TrustedCertRule> get rules => List.unmodifiable(_rules);
+
+  Future<void> initialize() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      _globalAllow = prefs.getBool(_prefsGlobalAllowKey) ?? false;
+      final raw = prefs.getString(_prefsKey);
+      if (raw != null && raw.isNotEmpty) {
+        final list = jsonDecode(raw) as List;
+        _rules
+          ..clear()
+          ..addAll(list.map((e) => TrustedCertRule.fromJson(e as Map<String, dynamic>)));
+      }
+    } catch (e) {
+      debugPrint('CertificateTrustService 初始化失败: $e');
+    }
+  }
+
+  Future<void> setGlobalAllow(bool allow) async {
+    _globalAllow = allow;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_prefsGlobalAllowKey, allow);
+  }
+
+  Future<void> upsertRule(TrustedCertRule rule) async {
+    final idx = _rules.indexWhere((r) => r.host == rule.host);
+    if (idx >= 0) {
+      _rules[idx] = rule;
+    } else {
+      _rules.add(rule);
+    }
+    await _persist();
+  }
+
+  Future<void> removeRule(String host) async {
+    _rules.removeWhere((r) => r.host == host);
+    await _persist();
+  }
+
+  Future<void> _persist() async {
+    final prefs = await SharedPreferences.getInstance();
+    final encoded = jsonEncode(_rules.map((e) => e.toJson()).toList());
+    await prefs.setString(_prefsKey, encoded);
+  }
+
+  /// 在 IO 平台下由 HttpOverrides 调用：判断是否允许该主机证书
+  /// - host: 目标主机名（不含协议）
+  /// - derBytes: 服务器返回的证书 DER 原始字节，用于指纹校验（可为空，若为空仅根据 allowInvalid 判断）
+  bool allowHost(String host, {Uint8List? derBytes}) {
+    if (_globalAllow) return true;
+    final rule = _rules.firstWhere(
+      (r) => _hostEquals(r.host, host),
+      orElse: () => TrustedCertRule(host: '__none__'),
+    );
+
+    if (rule.host == '__none__') return false;
+
+    // 若配置了指纹，则必须匹配其一
+    if (rule.sha256Pins.isNotEmpty && derBytes != null) {
+      final digest = sha256.convert(derBytes).bytes;
+      final hex = _toHex(digest);
+      return rule.sha256Pins.map((s) => s.toLowerCase()).contains(hex.toLowerCase());
+    }
+
+    // 未配置指纹，纯允许该主机的无效证书
+    return rule.allowInvalid;
+  }
+
+  bool _hostEquals(String a, String b) {
+    // 忽略端口与大小写，简单匹配
+    String norm(String h) => h.trim().toLowerCase().split(':').first;
+    return norm(a) == norm(b);
+  }
+
+  String _toHex(List<int> bytes) {
+    final StringBuffer sb = StringBuffer();
+    for (final b in bytes) {
+      sb.write(b.toRadixString(16).padLeft(2, '0'));
+    }
+    return sb.toString();
+  }
+}

--- a/lib/services/emby_service.dart
+++ b/lib/services/emby_service.dart
@@ -600,8 +600,8 @@ class EmbyService {
       'X-Emby-Authorization': authHeader,
     };
     
-    // 设置默认超时时间为10秒
-    final requestTimeout = timeout ?? const Duration(seconds: 10);
+    // 设置默认超时时间为30秒
+    final requestTimeout = timeout ?? const Duration(seconds: 30);
     
     http.Response response;
     try {
@@ -651,7 +651,7 @@ class EmbyService {
       'X-Emby-Authorization': authHeader,
     };
     
-    final requestTimeout = timeout ?? const Duration(seconds: 10);
+  final requestTimeout = timeout ?? const Duration(seconds: 30);
     
     Exception? lastError;
     

--- a/lib/services/http_client_initializer.dart
+++ b/lib/services/http_client_initializer.dart
@@ -1,0 +1,20 @@
+import 'certificate_trust_service.dart';
+
+// 分平台导入：IO 使用 HttpOverrides，Web 使用空实现
+import 'http_overrides_io.dart' if (dart.library.html) 'http_overrides_web.dart';
+
+class HttpClientInitializer {
+  static bool _installed = false;
+
+  static Future<void> install() async {
+    if (_installed) return;
+
+    // 加载用户保存的证书信任规则
+    await CertificateTrustService.instance.initialize();
+
+    // 安装平台对应的 HttpOverrides（Web 无操作）
+    installNipaHttpOverrides();
+
+    _installed = true;
+  }
+}

--- a/lib/services/http_overrides_io.dart
+++ b/lib/services/http_overrides_io.dart
@@ -1,0 +1,35 @@
+// ignore: avoid_web_libraries_in_flutter
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'certificate_trust_service.dart';
+
+/// 在非 Web 平台，为 Dart IO 网络栈设置证书例外规则
+class NipaHttpOverrides extends HttpOverrides {
+  @override
+  HttpClient createHttpClient(SecurityContext? context) {
+    final client = super.createHttpClient(context);
+
+    // 仅在真正的 IO 环境下设置回调
+    if (!kIsWeb) {
+      client.badCertificateCallback = (X509Certificate cert, String host, int port) {
+        try {
+          final der = cert.der; // 证书原始 DER
+          final allow = CertificateTrustService.instance.allowHost(host, derBytes: der);
+          if (!allow) {
+            debugPrint('TLS 拒绝: $host:${port} - 自签名/无效证书未被允许');
+          }
+          return allow;
+        } catch (e) {
+          debugPrint('badCertificateCallback 异常: $e');
+          return false;
+        }
+      };
+    }
+    return client;
+  }
+}
+
+void installNipaHttpOverrides() {
+  HttpOverrides.global = NipaHttpOverrides();
+}

--- a/lib/services/http_overrides_web.dart
+++ b/lib/services/http_overrides_web.dart
@@ -1,0 +1,4 @@
+// Web 平台无法绕过浏览器的 TLS 校验，文件仅作为说明与 API 对齐占位
+void installNipaHttpOverrides() {
+  // Web 平台无效，不能覆盖浏览器 TLS 验证
+}

--- a/lib/services/jellyfin_service.dart
+++ b/lib/services/jellyfin_service.dart
@@ -1699,8 +1699,8 @@ class JellyfinService {
       headers['Content-Type'] = 'application/json';
     }
     
-    // 设置默认超时时间为10秒
-    final requestTimeout = timeout ?? const Duration(seconds: 10);
+    // 设置默认超时时间为30秒（弱网/公网/隧道场景更稳妥）
+    final requestTimeout = timeout ?? const Duration(seconds: 30);
     
     http.Response response;
     try {
@@ -1754,7 +1754,7 @@ class JellyfinService {
       headers['Content-Type'] = 'application/json';
     }
     
-    final requestTimeout = timeout ?? const Duration(seconds: 10);
+  final requestTimeout = timeout ?? const Duration(seconds: 30);
     
     Exception? lastError;
     


### PR DESCRIPTION
- 概要
    - 增加证书策略的全局开关，允许 IO 平台信任自签名/无效证书
    - 将 Jellyfin/Emby 的默认 HTTP 超时从 10s 提升到 30s，降低“所有地址连接失败”的概率