### PR TITLE
feat: 添加自定义Tab选择器以切换弹弹play和Bangumi页面

### DIFF
--- a/lib/pages/account/fluent_account_page.dart
+++ b/lib/pages/account/fluent_account_page.dart
@@ -15,6 +15,9 @@ class FluentAccountPage extends StatefulWidget {
 class _FluentAccountPageState extends State<FluentAccountPage> 
     with AccountPageController {
 
+  // 页面切换状态：true为弹弹play页面，false为Bangumi页面
+  bool _showDandanplayPage = true;
+
   @override
   void showMessage(String message) {
     FluentInfoBar.show(
@@ -145,13 +148,101 @@ class _FluentAccountPageState extends State<FluentAccountPage>
   @override
   Widget build(BuildContext context) {
     return ScaffoldPage(
-      header: const PageHeader(
-        title: Text('弹弹play账号'),
+      header: PageHeader(
+        title: const Text('账号管理'),
+        commandBar: _buildTabSelector(),
       ),
       content: Padding(
         padding: const EdgeInsets.all(24.0),
-        child: isLoggedIn ? _buildLoggedInView() : _buildLoggedOutView(),
+        child: _showDandanplayPage 
+            ? _buildDandanplayContent() 
+            : _buildBangumiContent(),
       ),
+    );
+  }
+
+  /// 构建Fluent风格的Tab选择器
+  Widget _buildTabSelector() {
+    return Container(
+      height: 36,
+      decoration: BoxDecoration(
+        color: FluentTheme.of(context).acrylicBackgroundColor.withOpacity(0.3),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: FluentTheme.of(context).resources.dividerStrokeColorDefault,
+          width: 0.5,
+        ),
+      ),
+      child: Stack(
+        children: [
+          // 滑动指示器（放在底层）
+          AnimatedPositioned(
+            duration: const Duration(milliseconds: 250),
+            curve: Curves.easeInOut,
+            left: _showDandanplayPage ? 2 : null,
+            right: _showDandanplayPage ? null : 2,
+            top: 2,
+            bottom: 2,
+            width: 118, // 精确控制宽度
+            child: Container(
+              decoration: BoxDecoration(
+                color: FluentTheme.of(context).accentColor.withOpacity(0.2),
+                borderRadius: BorderRadius.circular(6),
+                border: Border.all(
+                  color: FluentTheme.of(context).accentColor,
+                  width: 1,
+                ),
+              ),
+            ),
+          ),
+          // 可点击选项（只有一层，带文字）
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _buildFluentTabOption('Dandanplay账户', true),
+              _buildFluentTabOption('Bangumi同步', false),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFluentTabOption(String text, bool isDandanplay) {
+    final isActive = _showDandanplayPage == isDandanplay;
+    
+    return GestureDetector(
+      onTap: () {
+        setState(() {
+          _showDandanplayPage = isDandanplay;
+        });
+      },
+      behavior: HitTestBehavior.opaque,
+      child: Container(
+        width: 120,
+        alignment: Alignment.center,
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+        child: Text(
+          text,
+          style: TextStyle(
+            color: isActive 
+                ? FluentTheme.of(context).accentColor 
+                : FluentTheme.of(context).typography.body?.color,
+            fontSize: 13,
+            fontWeight: isActive ? FontWeight.bold : FontWeight.normal,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDandanplayContent() {
+    return isLoggedIn ? _buildLoggedInView() : _buildLoggedOutView();
+  }
+
+  Widget _buildBangumiContent() {
+    return SingleChildScrollView(
+      child: _buildBangumiSyncSection(),
     );
   }
 


### PR DESCRIPTION
按钮方式比较不直观，尝试改为Tabview
<img width="722" height="340" alt="image" src="https://github.com/user-attachments/assets/156f3ea4-959a-4759-a84d-4a76e00a1d12" />

**只在macOS测试过fluent UI**