### PR TITLE
Remove -Werror from compile options

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -41,7 +41,7 @@ endif()
 # of modifying this function.
 function(APPLY_STANDARD_SETTINGS TARGET)
   target_compile_features(${TARGET} PUBLIC cxx_std_14)
-  target_compile_options(${TARGET} PRIVATE -Wall -Werror)
+  target_compile_options(${TARGET} PRIVATE -Wall)
   target_compile_options(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:-O3>")
   target_compile_definitions(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:NDEBUG>")
 endfunction()


### PR DESCRIPTION
https://github.com/leanflutter/tray_manager/issues/67
Arch Linux 上最新版 libayatana-appindicator(0.5.94) 因为有了个过时警告，tray_manager 无法编译。在使用 libayatana-appindicator-glib 的 [nativeapi](https://github.com/libnativeapi/nativeapi) 更新正式版之前，Linux 的 CMakeLists.txt 只能删掉 `-Werror` 了。