### PR TITLE
Add custom playback rate and subtitle delay inputs

### DIFF
--- a/lib/player_menu/player_menu_pane_controllers.dart
+++ b/lib/player_menu/player_menu_pane_controllers.dart
@@ -52,6 +52,10 @@ class PlaybackRatePaneController extends PlayerMenuPaneController {
 
   double get currentRate => videoState.playbackRate;
 
+  double get minCustomRate => VideoPlayerState.minPlaybackRate;
+
+  double get maxCustomRate => VideoPlayerState.maxPlaybackRate;
+
   bool get isSpeedBoostActive => videoState.isSpeedBoostActive;
 
   Future<void> setPlaybackRate(double rate) => videoState.setPlaybackRate(rate);
@@ -135,8 +139,8 @@ typedef PlayerMenuPaneControllerBuilder = PlayerMenuPaneController Function(
 class PlayerMenuPaneControllerFactory {
   PlayerMenuPaneControllerFactory._();
 
-  static final Map<PlayerMenuPaneId, PlayerMenuPaneControllerBuilder> _builders =
-      {
+  static final Map<PlayerMenuPaneId, PlayerMenuPaneControllerBuilder>
+      _builders = {
     PlayerMenuPaneId.playbackRate: (videoState) =>
         PlaybackRatePaneController(videoState: videoState),
     PlayerMenuPaneId.seekStep: (videoState) =>
@@ -145,7 +149,8 @@ class PlayerMenuPaneControllerFactory {
         SubtitleSettingsPaneController(videoState: videoState),
   };
 
-  static bool supports(PlayerMenuPaneId paneId) => _builders.containsKey(paneId);
+  static bool supports(PlayerMenuPaneId paneId) =>
+      _builders.containsKey(paneId);
 
   static PlayerMenuPaneController? tryCreate(
     PlayerMenuPaneId paneId,

--- a/lib/themes/cupertino/widgets/player_menu/cupertino_playback_rate_pane.dart
+++ b/lib/themes/cupertino/widgets/player_menu/cupertino_playback_rate_pane.dart
@@ -4,15 +4,99 @@ import 'package:provider/provider.dart';
 import 'package:nipaplay/player_menu/player_menu_pane_controllers.dart';
 import 'package:nipaplay/themes/cupertino/widgets/cupertino_bottom_sheet.dart';
 import 'package:nipaplay/themes/cupertino/widgets/player_menu/cupertino_pane_back_button.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/blur_snackbar.dart';
 
-class CupertinoPlaybackRatePane extends StatelessWidget {
+class CupertinoPlaybackRatePane extends StatefulWidget {
   const CupertinoPlaybackRatePane({super.key, required this.onBack});
 
   final VoidCallback onBack;
 
   @override
+  State<CupertinoPlaybackRatePane> createState() =>
+      _CupertinoPlaybackRatePaneState();
+}
+
+class _CupertinoPlaybackRatePaneState extends State<CupertinoPlaybackRatePane> {
+  final TextEditingController _customRateController = TextEditingController();
+  final FocusNode _customRateFocus = FocusNode();
+  bool _customRateDirty = false;
+
+  @override
+  void dispose() {
+    _customRateController.dispose();
+    _customRateFocus.dispose();
+    super.dispose();
+  }
+
+  String _trimTrailingZeros(String value) {
+    if (!value.contains('.')) return value;
+    return value
+        .replaceFirst(RegExp(r'0+$'), '')
+        .replaceFirst(RegExp(r'\.$'), '');
+  }
+
+  String _formatRate(double value) {
+    return _trimTrailingZeros(value.toStringAsFixed(2));
+  }
+
+  String _normalizeNumberInput(String value) {
+    return value
+        .trim()
+        .replaceAll('，', '.')
+        .replaceAll(',', '.')
+        .replaceAll('＋', '+')
+        .replaceAll('－', '-');
+  }
+
+  void _syncCustomRateController(PlaybackRatePaneController controller) {
+    if (_customRateFocus.hasFocus || _customRateDirty) return;
+    final value = _formatRate(controller.currentRate);
+    if (_customRateController.text != value) {
+      _customRateController.text = value;
+    }
+  }
+
+  Future<void> _applyCustomRate(PlaybackRatePaneController controller) async {
+    final input = _normalizeNumberInput(_customRateController.text);
+    if (input.isEmpty) {
+      BlurSnackBar.show(context, '请输入倍速');
+      return;
+    }
+
+    final value = double.tryParse(input);
+    if (value == null) {
+      BlurSnackBar.show(context, '请输入有效数字');
+      return;
+    }
+
+    if (value < controller.minCustomRate || value > controller.maxCustomRate) {
+      BlurSnackBar.show(
+        context,
+        '请输入 ${_formatRate(controller.minCustomRate)}x ~ ${_formatRate(controller.maxCustomRate)}x',
+      );
+      return;
+    }
+
+    await controller.setPlaybackRate(value);
+    if (!mounted) return;
+    FocusScope.of(context).unfocus();
+    setState(() {
+      _customRateDirty = false;
+    });
+    BlurSnackBar.show(context, '已设置播放速度为 ${_formatRate(value)}x');
+  }
+
+  void _handleCustomRateChanged(String _) {
+    if (_customRateDirty) return;
+    setState(() {
+      _customRateDirty = true;
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
     final controller = context.watch<PlaybackRatePaneController>();
+    _syncCustomRateController(controller);
 
     return CupertinoBottomSheetContentLayout(
       sliversBuilder: (context, topSpacing) => [
@@ -24,14 +108,18 @@ class CupertinoPlaybackRatePane extends StatelessWidget {
               children: [
                 Text(
                   '当前倍速',
-                  style: CupertinoTheme.of(context).textTheme.textStyle.copyWith(
+                  style: CupertinoTheme.of(context)
+                      .textTheme
+                      .textStyle
+                      .copyWith(
                         fontSize: 15,
-                        color: CupertinoColors.secondaryLabel.resolveFrom(context),
+                        color:
+                            CupertinoColors.secondaryLabel.resolveFrom(context),
                       ),
                 ),
                 const SizedBox(height: 4),
                 Text(
-                  '${controller.currentRate}x',
+                  '${_formatRate(controller.currentRate)}x',
                   style: CupertinoTheme.of(context)
                       .textTheme
                       .navLargeTitleTextStyle
@@ -39,10 +127,11 @@ class CupertinoPlaybackRatePane extends StatelessWidget {
                 ),
                 const SizedBox(height: 6),
                 Text(
-                  controller.isSpeedBoostActive
-                      ? '正在使用长按倍速'
-                      : '点选下方倍速或长按方向键加速',
-                  style: CupertinoTheme.of(context).textTheme.textStyle.copyWith(
+                  controller.isSpeedBoostActive ? '正在使用长按倍速' : '点选预设或输入精确倍速',
+                  style: CupertinoTheme.of(context)
+                      .textTheme
+                      .textStyle
+                      .copyWith(
                         fontSize: 13,
                         color: CupertinoColors.systemGrey2.resolveFrom(context),
                       ),
@@ -56,11 +145,64 @@ class CupertinoPlaybackRatePane extends StatelessWidget {
           sliver: SliverList(
             delegate: SliverChildListDelegate.fixed([
               CupertinoListSection.insetGrouped(
+                header: const Text('手动输入'),
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        CupertinoTextField(
+                          controller: _customRateController,
+                          focusNode: _customRateFocus,
+                          placeholder: '例如 0.01 / 1.25 / 3.5',
+                          keyboardType: const TextInputType.numberWithOptions(
+                            signed: false,
+                            decimal: true,
+                          ),
+                          suffix: const Padding(
+                            padding: EdgeInsets.only(right: 10),
+                            child: Text('x'),
+                          ),
+                          onChanged: _handleCustomRateChanged,
+                          onSubmitted: (_) => _applyCustomRate(controller),
+                        ),
+                        const SizedBox(height: 8),
+                        Text(
+                          '可输入 ${_formatRate(controller.minCustomRate)}x ~ ${_formatRate(controller.maxCustomRate)}x，常用预设仍保留在下方',
+                          style: CupertinoTheme.of(context)
+                              .textTheme
+                              .textStyle
+                              .copyWith(
+                                fontSize: 13,
+                                color: CupertinoColors.secondaryLabel
+                                    .resolveFrom(context),
+                              ),
+                        ),
+                        const SizedBox(height: 10),
+                        Align(
+                          alignment: Alignment.centerRight,
+                          child: CupertinoButton(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 18,
+                              vertical: 8,
+                            ),
+                            onPressed: () => _applyCustomRate(controller),
+                            child: const Text('应用'),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+              CupertinoListSection.insetGrouped(
                 header: const Text('选择倍速'),
                 children: controller.speedOptions.map((speed) {
-                  final bool isSelected = controller.currentRate == speed;
+                  final bool isSelected =
+                      (controller.currentRate - speed).abs() < 0.0001;
                   return CupertinoListTile(
-                    title: Text('${speed}x'),
+                    title: Text('${_formatRate(speed)}x'),
                     subtitle: Text(_speedDescription(speed)),
                     trailing: isSelected
                         ? Icon(
@@ -68,7 +210,13 @@ class CupertinoPlaybackRatePane extends StatelessWidget {
                             color: CupertinoTheme.of(context).primaryColor,
                           )
                         : null,
-                    onTap: () => controller.setPlaybackRate(speed),
+                    onTap: () {
+                      FocusScope.of(context).unfocus();
+                      controller.setPlaybackRate(speed);
+                      setState(() {
+                        _customRateDirty = false;
+                      });
+                    },
                   );
                 }).toList(),
               ),
@@ -76,7 +224,7 @@ class CupertinoPlaybackRatePane extends StatelessWidget {
           ),
         ),
         SliverToBoxAdapter(
-          child: CupertinoPaneBackButton(onPressed: onBack),
+          child: CupertinoPaneBackButton(onPressed: widget.onBack),
         ),
       ],
     );

--- a/lib/themes/cupertino/widgets/player_menu/cupertino_player_slider.dart
+++ b/lib/themes/cupertino/widgets/player_menu/cupertino_player_slider.dart
@@ -6,6 +6,8 @@ class CupertinoPlayerSlider extends StatelessWidget {
     super.key,
     required this.value,
     required this.onChanged,
+    this.onChangeStart,
+    this.onChangeEnd,
     this.min = 0.0,
     this.max = 1.0,
     this.divisions,
@@ -16,6 +18,8 @@ class CupertinoPlayerSlider extends StatelessWidget {
   final double min;
   final double max;
   final ValueChanged<double> onChanged;
+  final ValueChanged<double>? onChangeStart;
+  final ValueChanged<double>? onChangeEnd;
   final int? divisions;
   final Color? activeColor;
 
@@ -35,6 +39,8 @@ class CupertinoPlayerSlider extends StatelessWidget {
             max: max,
             divisions: divisions,
             activeColor: activeColor ?? CupertinoTheme.of(context).primaryColor,
+            onChangeStart: onChangeStart,
+            onChangeEnd: onChangeEnd,
             onChanged: onChanged,
           ),
         );

--- a/lib/themes/cupertino/widgets/player_menu/cupertino_subtitle_settings_pane.dart
+++ b/lib/themes/cupertino/widgets/player_menu/cupertino_subtitle_settings_pane.dart
@@ -6,6 +6,7 @@ import 'package:nipaplay/player_menu/player_menu_pane_controllers.dart';
 import 'package:nipaplay/themes/cupertino/widgets/cupertino_bottom_sheet.dart';
 import 'package:nipaplay/themes/cupertino/widgets/player_menu/cupertino_pane_back_button.dart';
 import 'package:nipaplay/themes/cupertino/widgets/player_menu/cupertino_player_slider.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/blur_snackbar.dart';
 import 'package:nipaplay/utils/video_player_state.dart';
 
 class CupertinoSubtitleSettingsPane extends StatefulWidget {
@@ -20,21 +21,28 @@ class CupertinoSubtitleSettingsPane extends StatefulWidget {
 
 class _CupertinoSubtitleSettingsPaneState
     extends State<CupertinoSubtitleSettingsPane> {
+  final TextEditingController _subtitleDelayController =
+      TextEditingController();
   final TextEditingController _fontNameController = TextEditingController();
   final TextEditingController _textColorController = TextEditingController();
   final TextEditingController _borderColorController = TextEditingController();
   final TextEditingController _shadowColorController = TextEditingController();
+  final FocusNode _subtitleDelayFocus = FocusNode();
   final FocusNode _fontNameFocus = FocusNode();
   final FocusNode _textColorFocus = FocusNode();
   final FocusNode _borderColorFocus = FocusNode();
   final FocusNode _shadowColorFocus = FocusNode();
+  bool _subtitleDelayDirty = false;
+  double? _subtitleDelayPreviewValue;
 
   @override
   void dispose() {
+    _subtitleDelayController.dispose();
     _fontNameController.dispose();
     _textColorController.dispose();
     _borderColorController.dispose();
     _shadowColorController.dispose();
+    _subtitleDelayFocus.dispose();
     _fontNameFocus.dispose();
     _textColorFocus.dispose();
     _borderColorFocus.dispose();
@@ -76,10 +84,125 @@ class _CupertinoSubtitleSettingsPaneState
     await videoState.importSubtitleFontFile(file.path);
   }
 
+  double _currentSubtitleDelayDisplayValue(VideoPlayerState videoState) {
+    return _subtitleDelayPreviewValue ?? videoState.subtitleDelaySeconds;
+  }
+
+  void _syncSubtitleDelayController(VideoPlayerState videoState) {
+    if (_subtitleDelayFocus.hasFocus || _subtitleDelayDirty) return;
+    final value =
+        _formatDelayInput(_currentSubtitleDelayDisplayValue(videoState));
+    if (_subtitleDelayController.text != value) {
+      _subtitleDelayController.text = value;
+    }
+  }
+
+  String _trimTrailingZeros(String value) {
+    if (!value.contains('.')) return value;
+    return value
+        .replaceFirst(RegExp(r'0+$'), '')
+        .replaceFirst(RegExp(r'\.$'), '');
+  }
+
+  String _formatDelayInput(double value) {
+    if (value.abs() < 0.0001) return '0';
+    return _trimTrailingZeros(value.toStringAsFixed(3));
+  }
+
+  String _formatDelayDisplay(double value) {
+    final prefix = value > 0 ? '+' : '';
+    return '$prefix${value.toStringAsFixed(1)}s';
+  }
+
+  String _normalizeNumberInput(String value) {
+    return value
+        .trim()
+        .replaceAll('，', '.')
+        .replaceAll(',', '.')
+        .replaceAll('＋', '+')
+        .replaceAll('－', '-');
+  }
+
+  String _buildSubtitleDelayLimitHint(VideoPlayerState videoState) {
+    final limit = _formatDelayInput(videoState.subtitleDelayCustomLimitSeconds);
+    if (videoState.hasSubtitleDelayDurationLimit) {
+      return '可输入 -$limit ~ +$limit 秒（按当前视频时长限制）';
+    }
+    return '可输入 -$limit ~ +$limit 秒（当前时长未就绪时先按默认范围处理）';
+  }
+
+  Future<void> _applyCustomSubtitleDelay(VideoPlayerState videoState) async {
+    final input = _normalizeNumberInput(_subtitleDelayController.text);
+    if (input.isEmpty) {
+      BlurSnackBar.show(context, '请输入字幕延迟秒数');
+      return;
+    }
+
+    final value = double.tryParse(input);
+    if (value == null) {
+      BlurSnackBar.show(context, '请输入有效数字');
+      return;
+    }
+
+    final limit = videoState.subtitleDelayCustomLimitSeconds;
+    if (value.abs() - limit > 0.0001) {
+      final limitText = _formatDelayInput(limit);
+      BlurSnackBar.show(context, '当前视频仅支持 -$limitText ~ +$limitText 秒');
+      return;
+    }
+
+    await videoState.setSubtitleDelaySeconds(value);
+    if (!mounted) return;
+    FocusScope.of(context).unfocus();
+    setState(() {
+      _subtitleDelayDirty = false;
+      _subtitleDelayPreviewValue = null;
+    });
+    BlurSnackBar.show(context, '已设置字幕延迟为 ${_formatDelayDisplay(value)}');
+  }
+
+  void _handleSubtitleDelayInputChanged(String _) {
+    if (_subtitleDelayDirty) return;
+    setState(() {
+      _subtitleDelayDirty = true;
+      _subtitleDelayPreviewValue = null;
+    });
+  }
+
+  void _handleSubtitleDelaySliderStart(
+    VideoPlayerState videoState,
+    double _,
+  ) {
+    FocusScope.of(context).unfocus();
+    setState(() {
+      _subtitleDelayDirty = false;
+      _subtitleDelayPreviewValue = videoState.subtitleDelaySeconds;
+    });
+  }
+
+  void _handleSubtitleDelaySliderChanged(double value) {
+    setState(() {
+      _subtitleDelayPreviewValue = value;
+    });
+  }
+
+  Future<void> _handleSubtitleDelaySliderEnd(
+    VideoPlayerState videoState,
+    double value,
+  ) async {
+    await videoState.setSubtitleDelaySeconds(value);
+    if (!mounted) return;
+    setState(() {
+      _subtitleDelayDirty = false;
+      _subtitleDelayPreviewValue = null;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     final controller = context.watch<SubtitleSettingsPaneController>();
     final videoState = controller.videoState;
+    _syncSubtitleDelayController(videoState);
     _syncController(
       controller: _fontNameController,
       focus: _fontNameFocus,
@@ -118,7 +241,8 @@ class _CupertinoSubtitleSettingsPaneState
                   ),
                 ),
                 CupertinoButton(
-                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                   onPressed: videoState.resetSubtitleSettings,
                   child: const Text('回到默认'),
                 ),
@@ -137,31 +261,36 @@ class _CupertinoSubtitleSettingsPaneState
                   _buildSliderTile(
                     context,
                     title: '字幕大小',
-                    description:
-                        '${(controller.subtitleScale * 100).round()}%',
+                    description: '${(controller.subtitleScale * 100).round()}%',
                     value: controller.subtitleScale,
                     min: controller.minScale,
                     max: controller.maxScale,
-                    divisions: ((controller.maxScale - controller.minScale) /
-                            0.05)
-                        .round(),
+                    divisions:
+                        ((controller.maxScale - controller.minScale) / 0.05)
+                            .round(),
                     onChanged: controller.setSubtitleScale,
                   ),
                   _buildSliderTile(
                     context,
                     title: '字幕延迟',
-                    description:
-                        '${videoState.subtitleDelaySeconds >= 0 ? '+' : ''}${videoState.subtitleDelaySeconds.toStringAsFixed(1)}s',
-                    value: videoState.subtitleDelaySeconds,
-                    min: -5.0,
-                    max: 5.0,
-                    divisions: 100,
-                    onChanged: videoState.setSubtitleDelaySeconds,
+                    description: _formatDelayDisplay(
+                        _currentSubtitleDelayDisplayValue(videoState)),
+                    value: _currentSubtitleDelayDisplayValue(videoState),
+                    min: videoState.subtitleDelaySliderMinSeconds,
+                    max: videoState.subtitleDelaySliderMaxSeconds,
+                    divisions: videoState.subtitleDelaySliderDivisions,
+                    onChangeStart: (value) =>
+                        _handleSubtitleDelaySliderStart(videoState, value),
+                    onChanged: _handleSubtitleDelaySliderChanged,
+                    onChangeEnd: (value) =>
+                        _handleSubtitleDelaySliderEnd(videoState, value),
                   ),
+                  _buildSubtitleDelayInputTile(context, videoState),
                   _buildSliderTile(
                     context,
                     title: '字幕位置',
-                    description: '${videoState.subtitlePosition.toStringAsFixed(0)}%',
+                    description:
+                        '${videoState.subtitlePosition.toStringAsFixed(0)}%',
                     value: videoState.subtitlePosition,
                     min: VideoPlayerState.minSubtitlePosition,
                     max: VideoPlayerState.maxSubtitlePosition,
@@ -178,7 +307,8 @@ class _CupertinoSubtitleSettingsPaneState
                   _buildSliderTile(
                     context,
                     title: '水平边距',
-                    description: '${videoState.subtitleMarginX.toStringAsFixed(0)}px',
+                    description:
+                        '${videoState.subtitleMarginX.toStringAsFixed(0)}px',
                     value: videoState.subtitleMarginX,
                     min: 0,
                     max: 200,
@@ -188,7 +318,8 @@ class _CupertinoSubtitleSettingsPaneState
                   _buildSliderTile(
                     context,
                     title: '垂直边距',
-                    description: '${videoState.subtitleMarginY.toStringAsFixed(0)}px',
+                    description:
+                        '${videoState.subtitleMarginY.toStringAsFixed(0)}px',
                     value: videoState.subtitleMarginY,
                     min: 0,
                     max: 200,
@@ -203,7 +334,8 @@ class _CupertinoSubtitleSettingsPaneState
                   _buildSliderTile(
                     context,
                     title: '不透明度',
-                    description: '${(videoState.subtitleOpacity * 100).round()}%',
+                    description:
+                        '${(videoState.subtitleOpacity * 100).round()}%',
                     value: videoState.subtitleOpacity,
                     min: 0,
                     max: 1,
@@ -213,7 +345,8 @@ class _CupertinoSubtitleSettingsPaneState
                   _buildSliderTile(
                     context,
                     title: '描边大小',
-                    description: videoState.subtitleBorderSize.toStringAsFixed(1),
+                    description:
+                        videoState.subtitleBorderSize.toStringAsFixed(1),
                     value: videoState.subtitleBorderSize,
                     min: 0,
                     max: 10,
@@ -389,6 +522,73 @@ class _CupertinoSubtitleSettingsPaneState
     );
   }
 
+  Widget _buildSubtitleDelayInputTile(
+    BuildContext context,
+    VideoPlayerState videoState,
+  ) {
+    final secondaryColor = CupertinoColors.secondaryLabel.resolveFrom(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '手动输入秒数',
+            style: CupertinoTheme.of(context)
+                .textTheme
+                .textStyle
+                .copyWith(fontWeight: FontWeight.w600),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            '滑块用于快速微调，正值延后，负值提前',
+            style: CupertinoTheme.of(context).textTheme.textStyle.copyWith(
+                  fontSize: 13,
+                  color: secondaryColor,
+                ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            _buildSubtitleDelayLimitHint(videoState),
+            style: CupertinoTheme.of(context).textTheme.textStyle.copyWith(
+                  fontSize: 13,
+                  color: secondaryColor,
+                ),
+          ),
+          const SizedBox(height: 10),
+          Row(
+            children: [
+              Expanded(
+                child: CupertinoTextField(
+                  controller: _subtitleDelayController,
+                  focusNode: _subtitleDelayFocus,
+                  placeholder: '例如 -12.5 或 8',
+                  keyboardType: const TextInputType.numberWithOptions(
+                    signed: true,
+                    decimal: true,
+                  ),
+                  suffix: const Padding(
+                    padding: EdgeInsets.only(right: 10),
+                    child: Text('秒'),
+                  ),
+                  onChanged: _handleSubtitleDelayInputChanged,
+                  onSubmitted: (_) => _applyCustomSubtitleDelay(videoState),
+                ),
+              ),
+              const SizedBox(width: 10),
+              CupertinoButton(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 18, vertical: 8),
+                onPressed: () => _applyCustomSubtitleDelay(videoState),
+                child: const Text('应用'),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
   Widget _buildSliderTile(
     BuildContext context, {
     required String title,
@@ -398,6 +598,8 @@ class _CupertinoSubtitleSettingsPaneState
     required double max,
     required int divisions,
     required ValueChanged<double> onChanged,
+    ValueChanged<double>? onChangeStart,
+    ValueChanged<double>? onChangeEnd,
   }) {
     final textTheme = CupertinoTheme.of(context).textTheme.textStyle;
     final valueStyle = textTheme.copyWith(
@@ -426,6 +628,8 @@ class _CupertinoSubtitleSettingsPaneState
             min: min,
             max: max,
             divisions: divisions,
+            onChangeStart: onChangeStart,
+            onChangeEnd: onChangeEnd,
             onChanged: onChanged,
           ),
         ],

--- a/lib/themes/nipaplay/widgets/playback_rate_menu.dart
+++ b/lib/themes/nipaplay/widgets/playback_rate_menu.dart
@@ -1,8 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 
 import 'package:nipaplay/player_menu/player_menu_pane_controllers.dart';
 import 'base_settings_menu.dart';
+import 'blur_button.dart';
+import 'blur_snackbar.dart';
+import 'settings_hint_text.dart';
 
 class PlaybackRateMenu extends StatefulWidget {
   final VoidCallback onClose;
@@ -19,10 +23,94 @@ class PlaybackRateMenu extends StatefulWidget {
 }
 
 class _PlaybackRateMenuState extends State<PlaybackRateMenu> {
+  final TextEditingController _customRateController = TextEditingController();
+  final FocusNode _customRateFocus = FocusNode();
+  String? _customRateError;
+  bool _customRateDirty = false;
+
+  @override
+  void dispose() {
+    _customRateController.dispose();
+    _customRateFocus.dispose();
+    super.dispose();
+  }
+
+  String _trimTrailingZeros(String value) {
+    if (!value.contains('.')) return value;
+    return value
+        .replaceFirst(RegExp(r'0+$'), '')
+        .replaceFirst(RegExp(r'\.$'), '');
+  }
+
+  String _formatRate(double value) {
+    return _trimTrailingZeros(value.toStringAsFixed(2));
+  }
+
+  String _normalizeNumberInput(String value) {
+    return value
+        .trim()
+        .replaceAll('，', '.')
+        .replaceAll(',', '.')
+        .replaceAll('＋', '+')
+        .replaceAll('－', '-');
+  }
+
+  void _syncCustomRateController(PlaybackRatePaneController controller) {
+    if (_customRateFocus.hasFocus || _customRateDirty) return;
+    final value = _formatRate(controller.currentRate);
+    if (_customRateController.text != value) {
+      _customRateController.text = value;
+    }
+  }
+
+  Future<void> _applyCustomRate(PlaybackRatePaneController controller) async {
+    final input = _normalizeNumberInput(_customRateController.text);
+    if (input.isEmpty) {
+      setState(() {
+        _customRateError = '请输入倍速';
+      });
+      return;
+    }
+
+    final value = double.tryParse(input);
+    if (value == null) {
+      setState(() {
+        _customRateError = '请输入有效数字';
+      });
+      return;
+    }
+
+    if (value < controller.minCustomRate || value > controller.maxCustomRate) {
+      setState(() {
+        _customRateError =
+            '请输入 ${_formatRate(controller.minCustomRate)}x ~ ${_formatRate(controller.maxCustomRate)}x';
+      });
+      return;
+    }
+
+    await controller.setPlaybackRate(value);
+    if (!mounted) return;
+    FocusScope.of(context).unfocus();
+    setState(() {
+      _customRateError = null;
+      _customRateDirty = false;
+    });
+    BlurSnackBar.show(context, '已设置播放速度为 ${_formatRate(value)}x');
+  }
+
+  void _handleCustomRateChanged(String _) {
+    if (_customRateDirty && _customRateError == null) return;
+    setState(() {
+      _customRateDirty = true;
+      _customRateError = null;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return Consumer<PlaybackRatePaneController>(
       builder: (context, controller, child) {
+        _syncCustomRateController(controller);
         return BaseSettingsMenu(
           title: '倍速设置',
           onClose: widget.onClose,
@@ -30,7 +118,6 @@ class _PlaybackRateMenuState extends State<PlaybackRateMenu> {
           content: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              // 当前倍速显示
               Container(
                 padding: const EdgeInsets.all(16),
                 child: Column(
@@ -41,14 +128,14 @@ class _PlaybackRateMenuState extends State<PlaybackRateMenu> {
                       children: [
                         const Text(
                           '当前倍速',
-                          locale:Locale("zh-Hans","zh"),
-style: TextStyle(
+                          locale: Locale("zh-Hans", "zh"),
+                          style: TextStyle(
                             color: Colors.white,
                             fontSize: 14,
                           ),
                         ),
                         Text(
-                          '${controller.currentRate}x',
+                          '${_formatRate(controller.currentRate)}x',
                           style: const TextStyle(
                             color: Colors.white,
                             fontSize: 16,
@@ -61,9 +148,9 @@ style: TextStyle(
                     Text(
                       controller.isSpeedBoostActive
                           ? '正在倍速播放'
-                          : '点击下方选项或长按屏幕倍速播放',
-                      locale:Locale("zh-Hans","zh"),
-style: TextStyle(
+                          : '点击下方预设或输入精确倍速',
+                      locale: Locale("zh-Hans", "zh"),
+                      style: const TextStyle(
                         fontSize: 12,
                         color: Colors.white,
                       ),
@@ -71,47 +158,141 @@ style: TextStyle(
                   ],
                 ),
               ),
-              
+              Container(
+                padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text(
+                      '手动输入倍速',
+                      locale: Locale("zh-Hans", "zh"),
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 14,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: TextField(
+                            controller: _customRateController,
+                            focusNode: _customRateFocus,
+                            keyboardType: const TextInputType.numberWithOptions(
+                              signed: false,
+                              decimal: true,
+                            ),
+                            inputFormatters: [
+                              FilteringTextInputFormatter.allow(
+                                RegExp(r'[0-9.,，]'),
+                              ),
+                            ],
+                            style: const TextStyle(color: Colors.white),
+                            decoration: InputDecoration(
+                              hintText: '例如 0.01 / 1.25 / 3.5',
+                              hintStyle: TextStyle(
+                                color: Colors.white.withOpacity(0.5),
+                              ),
+                              filled: true,
+                              fillColor: Colors.white.withOpacity(0.08),
+                              suffixText: 'x',
+                              suffixStyle:
+                                  const TextStyle(color: Colors.white70),
+                              errorText: _customRateError,
+                              enabledBorder: OutlineInputBorder(
+                                borderSide: BorderSide(
+                                  color: Colors.white.withOpacity(0.2),
+                                ),
+                                borderRadius: BorderRadius.circular(8),
+                              ),
+                              focusedBorder: OutlineInputBorder(
+                                borderSide: BorderSide(
+                                  color: Colors.white.withOpacity(0.6),
+                                ),
+                                borderRadius: BorderRadius.circular(8),
+                              ),
+                              errorBorder: OutlineInputBorder(
+                                borderSide:
+                                    const BorderSide(color: Colors.redAccent),
+                                borderRadius: BorderRadius.circular(8),
+                              ),
+                              focusedErrorBorder: OutlineInputBorder(
+                                borderSide:
+                                    const BorderSide(color: Colors.redAccent),
+                                borderRadius: BorderRadius.circular(8),
+                              ),
+                            ),
+                            onSubmitted: (_) => _applyCustomRate(controller),
+                            onChanged: _handleCustomRateChanged,
+                          ),
+                        ),
+                        const SizedBox(width: 12),
+                        BlurButton(
+                          text: '应用',
+                          icon: Icons.check,
+                          onTap: () => _applyCustomRate(controller),
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 16,
+                            vertical: 10,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 4),
+                    SettingsHintText(
+                      '可输入 ${_formatRate(controller.minCustomRate)}x ~ ${_formatRate(controller.maxCustomRate)}x，常用预设仍保留在下方',
+                    ),
+                  ],
+                ),
+              ),
               const Divider(color: Colors.white24, height: 1),
-              
-              // 倍速选项列表
               ...controller.speedOptions.map((speed) {
-                final isSelected = controller.currentRate == speed;
+                final isSelected =
+                    (controller.currentRate - speed).abs() < 0.0001;
                 final isNormalSpeed = speed == 1.0;
-                
+
                 return Material(
                   color: Colors.transparent,
                   child: InkWell(
                     onTap: () {
+                      FocusScope.of(context).unfocus();
                       controller.setPlaybackRate(speed);
+                      setState(() {
+                        _customRateError = null;
+                        _customRateDirty = false;
+                      });
                     },
                     borderRadius: BorderRadius.circular(8),
                     child: Container(
-                      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 16,
+                        vertical: 12,
+                      ),
                       decoration: BoxDecoration(
-                        color: isSelected ? Colors.white.withOpacity(0.15) : Colors.transparent,
+                        color: isSelected
+                            ? Colors.white.withOpacity(0.15)
+                            : Colors.transparent,
                         borderRadius: BorderRadius.circular(8),
                       ),
                       child: Row(
                         children: [
                           Icon(
                             _getSpeedIcon(speed, isNormalSpeed),
-                            color: isSelected 
-                                ? Colors.white 
-                                : isNormalSpeed 
-                                    ? Colors.white 
-                                    : Colors.white,
+                            color: Colors.white,
                             size: 20,
                           ),
                           const SizedBox(width: 12),
                           Expanded(
                             child: Text(
-                              '${speed}x ${_getSpeedDescription(speed, isNormalSpeed)}',
-                              locale:Locale("zh-Hans","zh"),
-style: TextStyle(
-                                color: isSelected ? Colors.white : Colors.white,
+                              '${_formatRate(speed)}x ${_getSpeedDescription(speed, isNormalSpeed)}',
+                              locale: Locale("zh-Hans", "zh"),
+                              style: TextStyle(
+                                color: Colors.white,
                                 fontSize: 14,
-                                fontWeight: isSelected ? FontWeight.w600 : FontWeight.normal,
+                                fontWeight: isSelected
+                                    ? FontWeight.w600
+                                    : FontWeight.normal,
                               ),
                             ),
                           ),
@@ -130,7 +311,6 @@ style: TextStyle(
                   ),
                 );
               }),
-              
               const SizedBox(height: 8),
             ],
           ),
@@ -139,7 +319,6 @@ style: TextStyle(
     );
   }
 
-  // 获取圆滑的速度图标
   IconData _getSpeedIcon(double speed, bool isNormalSpeed) {
     if (isNormalSpeed) {
       return Icons.play_circle_outline_rounded;
@@ -152,7 +331,6 @@ style: TextStyle(
     }
   }
 
-  // 获取速度描述
   String _getSpeedDescription(double speed, bool isNormalSpeed) {
     if (isNormalSpeed) {
       return '(正常速度)';
@@ -164,4 +342,4 @@ style: TextStyle(
       return '(极速)';
     }
   }
-} 
+}

--- a/lib/themes/nipaplay/widgets/settings_slider.dart
+++ b/lib/themes/nipaplay/widgets/settings_slider.dart
@@ -6,6 +6,8 @@ const Color _fluentAccentColor = Color(0xFFFF2E55);
 class SettingsSlider extends StatefulWidget {
   final double value;
   final ValueChanged<double> onChanged;
+  final ValueChanged<double>? onChangeStart;
+  final ValueChanged<double>? onChangeEnd;
   final String label;
   final String Function(double value) displayTextBuilder;
   final double min;
@@ -16,6 +18,8 @@ class SettingsSlider extends StatefulWidget {
     super.key,
     required this.value,
     required this.onChanged,
+    this.onChangeStart,
+    this.onChangeEnd,
     required this.label,
     required this.displayTextBuilder,
     this.min = 0.0,
@@ -82,6 +86,8 @@ class _SettingsSliderState extends State<SettingsSlider> {
               min: widget.min,
               max: widget.max,
               divisions: divisions,
+              onChangeStart: widget.onChangeStart,
+              onChangeEnd: widget.onChangeEnd,
               onChanged: widget.onChanged,
               label: displayText,
             ),

--- a/lib/themes/nipaplay/widgets/subtitle_settings_menu.dart
+++ b/lib/themes/nipaplay/widgets/subtitle_settings_menu.dart
@@ -1,11 +1,13 @@
 import 'package:file_selector/file_selector.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 
 import 'package:nipaplay/player_menu/player_menu_pane_controllers.dart';
 import 'package:nipaplay/utils/video_player_state.dart';
 import 'base_settings_menu.dart';
 import 'blur_button.dart';
+import 'blur_snackbar.dart';
 import 'blur_dropdown.dart';
 import 'fluent_settings_switch.dart';
 import 'settings_hint_text.dart';
@@ -26,21 +28,29 @@ class SubtitleSettingsMenu extends StatefulWidget {
 }
 
 class _SubtitleSettingsMenuState extends State<SubtitleSettingsMenu> {
+  final TextEditingController _subtitleDelayController =
+      TextEditingController();
   final TextEditingController _fontNameController = TextEditingController();
   final TextEditingController _textColorController = TextEditingController();
   final TextEditingController _borderColorController = TextEditingController();
   final TextEditingController _shadowColorController = TextEditingController();
+  final FocusNode _subtitleDelayFocus = FocusNode();
   final FocusNode _fontNameFocus = FocusNode();
   final FocusNode _textColorFocus = FocusNode();
   final FocusNode _borderColorFocus = FocusNode();
   final FocusNode _shadowColorFocus = FocusNode();
+  String? _subtitleDelayError;
+  bool _subtitleDelayDirty = false;
+  double? _subtitleDelayPreviewValue;
 
   @override
   void dispose() {
+    _subtitleDelayController.dispose();
     _fontNameController.dispose();
     _textColorController.dispose();
     _borderColorController.dispose();
     _shadowColorController.dispose();
+    _subtitleDelayFocus.dispose();
     _fontNameFocus.dispose();
     _textColorFocus.dispose();
     _borderColorFocus.dispose();
@@ -85,11 +95,136 @@ class _SubtitleSettingsMenuState extends State<SubtitleSettingsMenu> {
     await videoState.importSubtitleFontFile(file.path);
   }
 
+  double _currentSubtitleDelayDisplayValue(VideoPlayerState videoState) {
+    return _subtitleDelayPreviewValue ?? videoState.subtitleDelaySeconds;
+  }
+
+  void _syncSubtitleDelayController(VideoPlayerState videoState) {
+    if (_subtitleDelayFocus.hasFocus || _subtitleDelayDirty) return;
+    final value =
+        _formatDelayInput(_currentSubtitleDelayDisplayValue(videoState));
+    if (_subtitleDelayController.text != value) {
+      _subtitleDelayController.text = value;
+    }
+  }
+
+  String _trimTrailingZeros(String value) {
+    if (!value.contains('.')) return value;
+    return value
+        .replaceFirst(RegExp(r'0+$'), '')
+        .replaceFirst(RegExp(r'\.$'), '');
+  }
+
+  String _formatDelayInput(double value) {
+    if (value.abs() < 0.0001) return '0';
+    return _trimTrailingZeros(value.toStringAsFixed(3));
+  }
+
+  String _formatDelayDisplay(double value) {
+    final prefix = value > 0 ? '+' : '';
+    return '$prefix${value.toStringAsFixed(1)}s';
+  }
+
+  String _normalizeNumberInput(String value) {
+    return value
+        .trim()
+        .replaceAll('，', '.')
+        .replaceAll(',', '.')
+        .replaceAll('＋', '+')
+        .replaceAll('－', '-');
+  }
+
+  String _buildSubtitleDelayLimitHint(VideoPlayerState videoState) {
+    final limit = _formatDelayInput(videoState.subtitleDelayCustomLimitSeconds);
+    if (videoState.hasSubtitleDelayDurationLimit) {
+      return '手动输入范围：-$limit ~ +$limit 秒（按当前视频时长限制）';
+    }
+    return '手动输入范围：-$limit ~ +$limit 秒（当前时长未就绪时先按默认范围处理）';
+  }
+
+  Future<void> _applyCustomSubtitleDelay(VideoPlayerState videoState) async {
+    final input = _normalizeNumberInput(_subtitleDelayController.text);
+    if (input.isEmpty) {
+      setState(() {
+        _subtitleDelayError = '请输入字幕延迟秒数';
+      });
+      return;
+    }
+
+    final value = double.tryParse(input);
+    if (value == null) {
+      setState(() {
+        _subtitleDelayError = '请输入有效的数字';
+      });
+      return;
+    }
+
+    final limit = videoState.subtitleDelayCustomLimitSeconds;
+    if (value.abs() - limit > 0.0001) {
+      final limitText = _formatDelayInput(limit);
+      setState(() {
+        _subtitleDelayError = '当前视频仅支持 -$limitText ~ +$limitText 秒';
+      });
+      return;
+    }
+
+    await videoState.setSubtitleDelaySeconds(value);
+    if (!mounted) return;
+    FocusScope.of(context).unfocus();
+    setState(() {
+      _subtitleDelayError = null;
+      _subtitleDelayDirty = false;
+      _subtitleDelayPreviewValue = null;
+    });
+    BlurSnackBar.show(context, '已设置字幕延迟为 ${_formatDelayDisplay(value)}');
+  }
+
+  void _handleSubtitleDelayInputChanged(String _) {
+    if (_subtitleDelayDirty && _subtitleDelayError == null) return;
+    setState(() {
+      _subtitleDelayDirty = true;
+      _subtitleDelayError = null;
+      _subtitleDelayPreviewValue = null;
+    });
+  }
+
+  void _handleSubtitleDelaySliderStart(
+    VideoPlayerState videoState,
+    double _,
+  ) {
+    FocusScope.of(context).unfocus();
+    setState(() {
+      _subtitleDelayDirty = false;
+      _subtitleDelayError = null;
+      _subtitleDelayPreviewValue = videoState.subtitleDelaySeconds;
+    });
+  }
+
+  void _handleSubtitleDelaySliderChanged(double value) {
+    setState(() {
+      _subtitleDelayPreviewValue = value;
+    });
+  }
+
+  Future<void> _handleSubtitleDelaySliderEnd(
+    VideoPlayerState videoState,
+    double value,
+  ) async {
+    await videoState.setSubtitleDelaySeconds(value);
+    if (!mounted) return;
+    setState(() {
+      _subtitleDelayDirty = false;
+      _subtitleDelayError = null;
+      _subtitleDelayPreviewValue = null;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return Consumer<SubtitleSettingsPaneController>(
       builder: (context, controller, child) {
         final videoState = controller.videoState;
+        _syncSubtitleDelayController(videoState);
         _syncController(
           controller: _fontNameController,
           focus: _fontNameFocus,
@@ -145,8 +280,8 @@ class _SubtitleSettingsMenuState extends State<SubtitleSettingsMenu> {
   }
 
   Widget _buildOverrideModeSection(VideoPlayerState videoState) {
-    final items =
-        SubtitleStyleOverrideMode.values.map<DropdownMenuItemData<SubtitleStyleOverrideMode>>((mode) {
+    final items = SubtitleStyleOverrideMode.values
+        .map<DropdownMenuItemData<SubtitleStyleOverrideMode>>((mode) {
       final String label;
       switch (mode) {
         case SubtitleStyleOverrideMode.auto:
@@ -191,16 +326,97 @@ class _SubtitleSettingsMenuState extends State<SubtitleSettingsMenu> {
   }
 
   Widget _buildDelaySection(VideoPlayerState videoState) {
-    return _buildSliderSection(
-      label: '字幕延迟',
-      value: videoState.subtitleDelaySeconds,
-      min: -5.0,
-      max: 5.0,
-      step: 0.1,
-      displayTextBuilder: (v) =>
-          '${v >= 0 ? '+' : ''}${v.toStringAsFixed(1)}s',
-      onChanged: videoState.setSubtitleDelaySeconds,
-      hint: '正值延后，负值提前',
+    final displayValue = _currentSubtitleDelayDisplayValue(videoState);
+    return Container(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SettingsSlider(
+            value: displayValue,
+            onChangeStart: (value) =>
+                _handleSubtitleDelaySliderStart(videoState, value),
+            onChanged: _handleSubtitleDelaySliderChanged,
+            onChangeEnd: (value) =>
+                _handleSubtitleDelaySliderEnd(videoState, value),
+            label: '字幕延迟',
+            displayTextBuilder: _formatDelayDisplay,
+            min: videoState.subtitleDelaySliderMinSeconds,
+            max: videoState.subtitleDelaySliderMaxSeconds,
+            step: VideoPlayerState.subtitleDelayStep,
+          ),
+          const SizedBox(height: 8),
+          Text(
+            '手动输入秒数',
+            style: TextStyle(
+              color: Colors.white.withOpacity(0.9),
+              fontSize: 14,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: _subtitleDelayController,
+                  focusNode: _subtitleDelayFocus,
+                  keyboardType: const TextInputType.numberWithOptions(
+                    signed: true,
+                    decimal: true,
+                  ),
+                  inputFormatters: [
+                    FilteringTextInputFormatter.allow(
+                      RegExp(r'[0-9+\-.,，＋－]'),
+                    ),
+                  ],
+                  style: const TextStyle(color: Colors.white),
+                  decoration: InputDecoration(
+                    hintText: '例如 -12.5 或 8',
+                    hintStyle: TextStyle(color: Colors.white.withOpacity(0.5)),
+                    filled: true,
+                    fillColor: Colors.white.withOpacity(0.08),
+                    suffixText: '秒',
+                    suffixStyle: const TextStyle(color: Colors.white70),
+                    errorText: _subtitleDelayError,
+                    enabledBorder: OutlineInputBorder(
+                      borderSide:
+                          BorderSide(color: Colors.white.withOpacity(0.2)),
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    focusedBorder: OutlineInputBorder(
+                      borderSide:
+                          BorderSide(color: Colors.white.withOpacity(0.6)),
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    errorBorder: OutlineInputBorder(
+                      borderSide: const BorderSide(color: Colors.redAccent),
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    focusedErrorBorder: OutlineInputBorder(
+                      borderSide: const BorderSide(color: Colors.redAccent),
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                  ),
+                  onSubmitted: (_) => _applyCustomSubtitleDelay(videoState),
+                  onChanged: _handleSubtitleDelayInputChanged,
+                ),
+              ),
+              const SizedBox(width: 12),
+              BlurButton(
+                text: '应用',
+                icon: Icons.check,
+                onTap: () => _applyCustomSubtitleDelay(videoState),
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          const SettingsHintText('滑块用于快速微调，正值延后，负值提前'),
+          SettingsHintText(_buildSubtitleDelayLimitHint(videoState)),
+        ],
+      ),
     );
   }
 
@@ -218,8 +434,8 @@ class _SubtitleSettingsMenuState extends State<SubtitleSettingsMenu> {
   }
 
   Widget _buildAlignSection(VideoPlayerState videoState) {
-    final alignXItems =
-        SubtitleAlignX.values.map<DropdownMenuItemData<SubtitleAlignX>>((align) {
+    final alignXItems = SubtitleAlignX.values
+        .map<DropdownMenuItemData<SubtitleAlignX>>((align) {
       final label = switch (align) {
         SubtitleAlignX.left => '左对齐',
         SubtitleAlignX.center => '居中',
@@ -231,8 +447,8 @@ class _SubtitleSettingsMenuState extends State<SubtitleSettingsMenu> {
         isSelected: videoState.subtitleAlignX == align,
       );
     }).toList();
-    final alignYItems =
-        SubtitleAlignY.values.map<DropdownMenuItemData<SubtitleAlignY>>((align) {
+    final alignYItems = SubtitleAlignY.values
+        .map<DropdownMenuItemData<SubtitleAlignY>>((align) {
       final label = switch (align) {
         SubtitleAlignY.top => '顶部',
         SubtitleAlignY.center => '垂直居中',

--- a/lib/utils/video_player_state.dart
+++ b/lib/utils/video_player_state.dart
@@ -470,6 +470,8 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
   static const double minSubtitleScale = 0.5;
   static const double maxSubtitleScale = 2.5;
   static const double defaultSubtitleScale = 1.0;
+  static const double subtitleDelayQuickAdjustRangeSeconds = 30.0;
+  static const double subtitleDelayStep = 0.1;
   static const double defaultSubtitleDelaySeconds = 0.0;
   static const double defaultSubtitlePosition = 100.0;
   static const double minSubtitlePosition = 0.0;
@@ -540,6 +542,8 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
   double _autoDanmakuOffset = 0.0; // 弹弹Play自动匹配的时间偏移
 
   // 添加播放速度相关状态
+  static const double minPlaybackRate = 0.01;
+  static const double maxPlaybackRate = 5.0;
   final String _playbackRateKey = 'playback_rate';
   double _playbackRate = 1.0; // 默认1倍速
   bool _isSpeedBoostActive = false; // 是否正在倍速播放（长按状态）
@@ -814,7 +818,50 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
   DanmakuOutlineStyle get danmakuOutlineStyle => _danmakuOutlineStyle;
   DanmakuShadowStyle get danmakuShadowStyle => _danmakuShadowStyle;
   double get subtitleScale => _subtitleScale;
-  double get subtitleDelaySeconds => _subtitleDelaySeconds;
+  double get subtitleDelayCustomLimitSeconds {
+    final durationSeconds = _duration.inMilliseconds / 1000;
+    if (durationSeconds <= 0) {
+      return subtitleDelayQuickAdjustRangeSeconds;
+    }
+    return durationSeconds.toDouble();
+  }
+
+  bool get hasSubtitleDelayDurationLimit => _duration.inMilliseconds > 0;
+
+  double _resolveSubtitleDelaySecondsForCurrentVideo(double value) {
+    final limit = subtitleDelayCustomLimitSeconds;
+    return value.clamp(-limit, limit).toDouble();
+  }
+
+  double clampSubtitleDelayToCurrentVideoDuration(double value) {
+    return _resolveSubtitleDelaySecondsForCurrentVideo(value);
+  }
+
+  double get subtitleDelaySeconds =>
+      _resolveSubtitleDelaySecondsForCurrentVideo(_subtitleDelaySeconds);
+
+  double get subtitleDelaySliderMinSeconds {
+    final limit = subtitleDelayCustomLimitSeconds;
+    final current = subtitleDelaySeconds;
+    return (current - subtitleDelayQuickAdjustRangeSeconds)
+        .clamp(-limit, limit)
+        .toDouble();
+  }
+
+  double get subtitleDelaySliderMaxSeconds {
+    final limit = subtitleDelayCustomLimitSeconds;
+    final current = subtitleDelaySeconds;
+    return (current + subtitleDelayQuickAdjustRangeSeconds)
+        .clamp(-limit, limit)
+        .toDouble();
+  }
+
+  int get subtitleDelaySliderDivisions {
+    final span = subtitleDelaySliderMaxSeconds - subtitleDelaySliderMinSeconds;
+    if (span <= 0) return 1;
+    return (span / subtitleDelayStep).round().clamp(1, 600);
+  }
+
   double get subtitlePosition => _subtitlePosition;
   SubtitleAlignX get subtitleAlignX => _subtitleAlignX;
   SubtitleAlignY get subtitleAlignY => _subtitleAlignY;

--- a/lib/utils/video_player_state/video_player_state_navigation.dart
+++ b/lib/utils/video_player_state/video_player_state_navigation.dart
@@ -113,8 +113,7 @@ extension VideoPlayerStateNavigation on VideoPlayerState {
                     ? resolvedHistory.lastPosition
                     : null,
               );
-              debugPrint(
-                  '[上一话] 获取Jellyfin播放会话: ${playbackSession.streamUrl}');
+              debugPrint('[上一话] 获取Jellyfin播放会话: ${playbackSession.streamUrl}');
 
               await initializePlayer(
                 resolvedHistory.filePath,
@@ -129,7 +128,8 @@ extension VideoPlayerStateNavigation on VideoPlayerState {
           } else if (resolvedHistory.filePath.startsWith('emby://')) {
             try {
               // 从emby://协议URL中提取episodeId（只取最后一部分）
-              final embyPath = resolvedHistory.filePath.replaceFirst('emby://', '');
+              final embyPath =
+                  resolvedHistory.filePath.replaceFirst('emby://', '');
               final pathParts = embyPath.split('/');
               final episodeId = pathParts.last; // 只使用最后一部分作为episodeId
               final playbackSession =
@@ -139,8 +139,7 @@ extension VideoPlayerStateNavigation on VideoPlayerState {
                     ? resolvedHistory.lastPosition
                     : null,
               );
-              debugPrint(
-                  '[上一话] 获取Emby播放会话: ${playbackSession.streamUrl}');
+              debugPrint('[上一话] 获取Emby播放会话: ${playbackSession.streamUrl}');
 
               await initializePlayer(
                 resolvedHistory.filePath,
@@ -284,8 +283,7 @@ extension VideoPlayerStateNavigation on VideoPlayerState {
                     ? resolvedHistory.lastPosition
                     : null,
               );
-              debugPrint(
-                  '[下一话] 获取Jellyfin播放会话: ${playbackSession.streamUrl}');
+              debugPrint('[下一话] 获取Jellyfin播放会话: ${playbackSession.streamUrl}');
 
               await initializePlayer(
                 resolvedHistory.filePath,
@@ -300,7 +298,8 @@ extension VideoPlayerStateNavigation on VideoPlayerState {
           } else if (resolvedHistory.filePath.startsWith('emby://')) {
             try {
               // 从emby://协议URL中提取episodeId（只取最后一部分）
-              final embyPath = resolvedHistory.filePath.replaceFirst('emby://', '');
+              final embyPath =
+                  resolvedHistory.filePath.replaceFirst('emby://', '');
               final pathParts = embyPath.split('/');
               final episodeId = pathParts.last; // 只使用最后一部分作为episodeId
               final playbackSession =
@@ -310,8 +309,7 @@ extension VideoPlayerStateNavigation on VideoPlayerState {
                     ? resolvedHistory.lastPosition
                     : null,
               );
-              debugPrint(
-                  '[下一话] 获取Emby播放会话: ${playbackSession.streamUrl}');
+              debugPrint('[下一话] 获取Emby播放会话: ${playbackSession.streamUrl}');
 
               await initializePlayer(
                 resolvedHistory.filePath,
@@ -541,15 +539,20 @@ extension VideoPlayerStateNavigation on VideoPlayerState {
           if (playerPosition >= 0 && playerDuration > 0) {
             // 更新UI显示
             _position = Duration(milliseconds: playerPosition);
+            final previousDurationMs = _duration.inMilliseconds;
+            final previousSubtitleDelay = subtitleDelaySeconds;
             _duration = Duration(milliseconds: playerDuration);
+            if (previousDurationMs != playerDuration &&
+                (previousSubtitleDelay - subtitleDelaySeconds).abs() >=
+                    0.0001) {
+              unawaited(applySubtitleStylePreference());
+            }
             _progress = _position.inMilliseconds / _duration.inMilliseconds;
             final bufferedMs = player.bufferedPosition;
             _bufferedPositionMs = bufferedMs <= 0
                 ? 0
                 : (_duration.inMilliseconds > 0
-                    ? bufferedMs
-                        .clamp(0, _duration.inMilliseconds)
-                        .toInt()
+                    ? bufferedMs.clamp(0, _duration.inMilliseconds).toInt()
                     : bufferedMs);
             // 高频时间轴：每帧更新弹幕时间
             _playbackTimeMs.value = _position.inMilliseconds.toDouble();
@@ -717,9 +720,7 @@ extension VideoPlayerStateNavigation on VideoPlayerState {
             final bufferedMs = player.bufferedPosition;
             _bufferedPositionMs = bufferedMs <= 0
                 ? 0
-                : bufferedMs
-                    .clamp(0, _duration.inMilliseconds)
-                    .toInt();
+                : bufferedMs.clamp(0, _duration.inMilliseconds).toInt();
             // 暂停下也节流保存位置
             if (_currentVideoPath != null) {
               final int posMs = _position.inMilliseconds;

--- a/lib/utils/video_player_state/video_player_state_player_setup.dart
+++ b/lib/utils/video_player_state/video_player_state_player_setup.dart
@@ -66,8 +66,7 @@ extension VideoPlayerStatePlayerSetup on VideoPlayerState {
       notifyListeners();
     } else if (isEmbyStream) {
       final infoUrl = playbackSession?.streamUrl ?? actualPlayUrl;
-      debugPrint(
-          '检测到Emby流媒体: videoPath=$videoPath, actualPlayUrl=$infoUrl');
+      debugPrint('检测到Emby流媒体: videoPath=$videoPath, actualPlayUrl=$infoUrl');
       _statusMessages.add('正在准备Emby流媒体播放...');
       notifyListeners();
     }
@@ -220,8 +219,7 @@ extension VideoPlayerStatePlayerSetup on VideoPlayerState {
         );
       } catch (e) {
         // 如果网络请求失败，使用专门的错误处理逻辑
-        await _handleStreamUrlLoadingError(
-            resolvedActualPlayUrl,
+        await _handleStreamUrlLoadingError(resolvedActualPlayUrl,
             e is Exception ? e : Exception(e.toString()));
         return; // 避免继续处理
       }
@@ -507,7 +505,11 @@ extension VideoPlayerStatePlayerSetup on VideoPlayerState {
       // 异步计算视频哈希值，不阻塞主要初始化流程
       _precomputeVideoHash(videoPath);
 
+      final previousSubtitleDelay = subtitleDelaySeconds;
       _duration = Duration(milliseconds: player.mediaInfo.duration);
+      if ((previousSubtitleDelay - subtitleDelaySeconds).abs() >= 0.0001) {
+        unawaited(applySubtitleStylePreference());
+      }
       unawaited(_setupTimelinePreviewForVideo(videoPath));
 
       // 对于Jellyfin流媒体，先进行同步，再获取播放位置
@@ -713,8 +715,7 @@ extension VideoPlayerStatePlayerSetup on VideoPlayerState {
             errorText.contains('MEDIA_ERR_SRC_NOT_SUPPORTED') ||
             errorText.contains('Format error');
         if (isUnsupportedFormat) {
-          const message =
-              '浏览器不支持该视频格式/编码，请转换为 H.264/AAC 的 MP4 或更换支持的浏览器';
+          const message = '浏览器不支持该视频格式/编码，请转换为 H.264/AAC 的 MP4 或更换支持的浏览器';
           _error = message;
           _setStatus(PlayerStatus.error, message: message);
           return;

--- a/lib/utils/video_player_state/video_player_state_preferences.dart
+++ b/lib/utils/video_player_state/video_player_state_preferences.dart
@@ -388,7 +388,10 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
   // 加载播放速度设置
   Future<void> _loadPlaybackRate() async {
     final prefs = await SharedPreferences.getInstance();
-    _playbackRate = prefs.getDouble(_playbackRateKey) ?? 1.0; // 默认1倍速
+    _playbackRate = (prefs.getDouble(_playbackRateKey) ?? 1.0).clamp(
+      VideoPlayerState.minPlaybackRate,
+      VideoPlayerState.maxPlaybackRate,
+    ); // 默认1倍速
     _speedBoostRate = prefs.getDouble(_speedBoostRateKey) ?? 2.0; // 默认2倍速
     _normalPlaybackRate = 1.0; // 始终重置为1.0
     notifyListeners();
@@ -456,14 +459,21 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
 
   // 保存播放速度设置
   Future<void> setPlaybackRate(double rate) async {
-    _playbackRate = rate;
+    final resolved = rate.clamp(
+      VideoPlayerState.minPlaybackRate,
+      VideoPlayerState.maxPlaybackRate,
+    );
+    if ((_playbackRate - resolved).abs() < 0.0001) {
+      return;
+    }
+    _playbackRate = resolved;
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setDouble(_playbackRateKey, rate);
+    await prefs.setDouble(_playbackRateKey, resolved);
 
     // 立即应用新的播放速度
     if (hasVideo) {
-      player.setPlaybackRate(rate);
-      debugPrint('设置播放速度: ${rate}x');
+      player.setPlaybackRate(resolved);
+      debugPrint('设置播放速度: ${resolved}x');
     }
     notifyListeners();
   }
@@ -1654,7 +1664,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
         return;
       }
       player.setProperty('sub-scale', _subtitleScale.toStringAsFixed(2));
-      player.setProperty('sub-delay', _subtitleDelaySeconds.toStringAsFixed(2));
+      player.setProperty('sub-delay', subtitleDelaySeconds.toStringAsFixed(2));
       player.setProperty('sub-pos', _subtitlePosition.toStringAsFixed(0));
       player.setProperty('sub-align-x', _subtitleAlignXToMpv(_subtitleAlignX));
       player.setProperty('sub-align-y', _subtitleAlignYToMpv(_subtitleAlignY));


### PR DESCRIPTION
## Summary
- add manual playback rate input while keeping the existing preset rate options
- allow custom playback rates down to 0.01x and clamp saved playback rate values consistently
- add manual subtitle delay input with a dynamic limit based on the current video's duration, while keeping slider-based quick adjustment
- apply the updated playback rate and subtitle delay UI in both Nipaplay and Cupertino player menus

## Testing
- flutter build windows