### PR TITLE
Add direct URL playback entry to empty player state

### DIFF
--- a/lib/themes/nipaplay/widgets/video_upload_ui.dart
+++ b/lib/themes/nipaplay/widgets/video_upload_ui.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:nipaplay/utils/video_player_state.dart';
 import 'dart:io' as io;
@@ -23,9 +24,13 @@ class VideoUploadUI extends StatefulWidget {
 class _VideoUploadUIState extends State<VideoUploadUI>
     with SingleTickerProviderStateMixin {
   bool _isHovered = false;
-  bool _isPressed = false;
+  bool _isUrlActionHovered = false;
+  bool _showUrlInput = false;
+  bool _isSubmittingUrl = false;
   late final AnimationController _mascotController;
   late final Animation<double> _mascotScale;
+  final TextEditingController _urlController = TextEditingController();
+  final FocusNode _urlFocusNode = FocusNode();
 
   @override
   void initState() {
@@ -36,18 +41,24 @@ class _VideoUploadUIState extends State<VideoUploadUI>
     );
     _mascotScale = TweenSequence<double>([
       TweenSequenceItem(
-        tween: Tween(begin: 1.0, end: 1.18)
-            .chain(CurveTween(curve: Curves.easeOut)),
+        tween: Tween(
+          begin: 1.0,
+          end: 1.18,
+        ).chain(CurveTween(curve: Curves.easeOut)),
         weight: 40,
       ),
       TweenSequenceItem(
-        tween: Tween(begin: 1.18, end: 0.95)
-            .chain(CurveTween(curve: Curves.easeInOut)),
+        tween: Tween(
+          begin: 1.18,
+          end: 0.95,
+        ).chain(CurveTween(curve: Curves.easeInOut)),
         weight: 30,
       ),
       TweenSequenceItem(
-        tween: Tween(begin: 0.95, end: 1.0)
-            .chain(CurveTween(curve: Curves.easeOut)),
+        tween: Tween(
+          begin: 0.95,
+          end: 1.0,
+        ).chain(CurveTween(curve: Curves.easeOut)),
         weight: 30,
       ),
     ]).animate(_mascotController);
@@ -56,6 +67,8 @@ class _VideoUploadUIState extends State<VideoUploadUI>
   @override
   void dispose() {
     _mascotController.dispose();
+    _urlController.dispose();
+    _urlFocusNode.dispose();
     super.dispose();
   }
 
@@ -69,6 +82,7 @@ class _VideoUploadUIState extends State<VideoUploadUI>
     return Center(
       child: Row(
         mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.center,
         children: [
           MouseRegion(
             cursor: SystemMouseCursors.click,
@@ -85,51 +99,288 @@ class _VideoUploadUIState extends State<VideoUploadUI>
               ),
             ),
           ),
-          const SizedBox(width: 12),
+          const SizedBox(width: 16),
           Flexible(
-            child: Wrap(
-              alignment: WrapAlignment.center,
-              crossAxisAlignment: WrapCrossAlignment.center,
-              spacing: 8,
-              runSpacing: 4,
-              children: [
-                Text(
-                  '诶？还没有在播放的视频！',
-                  locale: const Locale("zh-Hans", "zh"),
-                  style: TextStyle(
-                    color: textColor,
-                    fontSize: 18,
-                    fontWeight: FontWeight.normal,
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 620),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '诶？还没有在播放的视频！',
+                    locale: const Locale("zh-Hans", "zh"),
+                    style: TextStyle(
+                      color: textColor,
+                      fontSize: 18,
+                      fontWeight: FontWeight.normal,
+                    ),
                   ),
-                ),
-                MouseRegion(
-                  cursor: SystemMouseCursors.click,
-                  onEnter: (_) => setState(() => _isHovered = true),
-                  onExit: (_) => setState(() => _isHovered = false),
-                  child: GestureDetector(
-                    onTap: _handleUploadVideo,
-                    child: AnimatedScale(
-                      duration: const Duration(milliseconds: 200),
-                      scale: _isHovered ? 1.2 : 1.0, // 悬浮时放大 1.2 倍
-                      child: Text(
-                        '选择文件',
-                        locale: const Locale("zh-Hans", "zh"),
-                        style: TextStyle(
-                          color:
-                              _isHovered ? const Color(0xFFFF2E55) : textColor,
-                          fontSize: 32, // 大号字体
-                          fontWeight: FontWeight.bold,
+                  const SizedBox(height: 18),
+                  MouseRegion(
+                    cursor: SystemMouseCursors.click,
+                    onEnter: (_) => setState(() => _isHovered = true),
+                    onExit: (_) => setState(() => _isHovered = false),
+                    child: GestureDetector(
+                      onTap: _handleUploadVideo,
+                      child: AnimatedScale(
+                        duration: const Duration(milliseconds: 200),
+                        scale: _isHovered ? 1.06 : 1.0,
+                        alignment: Alignment.centerLeft,
+                        child: Text(
+                          '选择文件',
+                          locale: const Locale("zh-Hans", "zh"),
+                          style: TextStyle(
+                            color: _isHovered
+                                ? const Color(0xFFFF2E55)
+                                : textColor,
+                            fontSize: 32,
+                            fontWeight: FontWeight.bold,
+                          ),
                         ),
                       ),
                     ),
                   ),
-                ),
-              ],
+                  const SizedBox(height: 8),
+                  Text(
+                    '从本地文件、相册或文件管理器中打开视频',
+                    style: TextStyle(
+                      color: textColor.withOpacity(0.68),
+                      fontSize: 14,
+                    ),
+                  ),
+                  const SizedBox(height: 18),
+                  _buildChoiceDivider(textColor),
+                  const SizedBox(height: 18),
+                  MouseRegion(
+                    cursor: SystemMouseCursors.click,
+                    onEnter: (_) => setState(() => _isUrlActionHovered = true),
+                    onExit: (_) => setState(() => _isUrlActionHovered = false),
+                    child: GestureDetector(
+                      onTap: _toggleUrlInput,
+                      child: AnimatedScale(
+                        duration: const Duration(milliseconds: 200),
+                        scale: _isUrlActionHovered ? 1.04 : 1.0,
+                        alignment: Alignment.centerLeft,
+                        child: Text(
+                          '输入链接',
+                          locale: const Locale("zh-Hans", "zh"),
+                          style: TextStyle(
+                            color: _isUrlActionHovered
+                                ? const Color(0xFFFF2E55)
+                                : textColor.withOpacity(0.9),
+                            fontSize: 24,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    '粘贴 http/https 串流直链后直接播放',
+                    style: TextStyle(
+                      color: textColor.withOpacity(0.68),
+                      fontSize: 14,
+                    ),
+                  ),
+                  if (_showUrlInput) ...[
+                    const SizedBox(height: 14),
+                    _buildUrlInputCard(context, textColor),
+                  ],
+                ],
+              ),
             ),
           ),
         ],
       ),
     );
+  }
+
+  Widget _buildChoiceDivider(Color textColor) {
+    return Row(
+      children: [
+        Expanded(
+          child: Container(
+            height: 1,
+            color: textColor.withOpacity(0.14),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 10),
+          child: Text(
+            '或',
+            style: TextStyle(
+              color: textColor.withOpacity(0.56),
+              fontSize: 13,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+        Expanded(
+          child: Container(
+            height: 1,
+            color: textColor.withOpacity(0.14),
+          ),
+        ),
+      ],
+    );
+  }
+
+  void _toggleUrlInput() {
+    setState(() {
+      _showUrlInput = !_showUrlInput;
+    });
+
+    if (_showUrlInput) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        _urlFocusNode.requestFocus();
+      });
+    }
+  }
+
+  Widget _buildUrlInputCard(BuildContext context, Color textColor) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final isDarkMode = theme.brightness == Brightness.dark;
+
+    return Container(
+      constraints: const BoxConstraints(maxWidth: 560),
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: colorScheme.surface.withOpacity(isDarkMode ? 0.36 : 0.72),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: textColor.withOpacity(0.12)),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            '支持 http/https 串流直链，建议使用 Media Kit 或 MDK 内核。',
+            style: TextStyle(
+              color: textColor.withOpacity(0.72),
+              fontSize: 13,
+              height: 1.4,
+            ),
+          ),
+          const SizedBox(height: 10),
+          TextField(
+            controller: _urlController,
+            focusNode: _urlFocusNode,
+            keyboardType: TextInputType.url,
+            textInputAction: TextInputAction.go,
+            autocorrect: false,
+            enableSuggestions: false,
+            onSubmitted: (_) => _handlePlayFromUrl(),
+            decoration: InputDecoration(
+              hintText: 'https://example.com/video.mp4 或签名下载直链',
+              filled: true,
+              fillColor: colorScheme.surface.withOpacity(
+                isDarkMode ? 0.58 : 0.94,
+              ),
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: BorderSide.none,
+              ),
+              contentPadding: const EdgeInsets.symmetric(
+                horizontal: 14,
+                vertical: 14,
+              ),
+            ),
+          ),
+          const SizedBox(height: 10),
+          Wrap(
+            alignment: WrapAlignment.end,
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              HoverScaleTextButton(
+                onPressed: _isSubmittingUrl ? null : _pasteUrlFromClipboard,
+                child: Text('粘贴', style: TextStyle(color: textColor)),
+              ),
+              HoverScaleTextButton(
+                onPressed: _isSubmittingUrl ? null : _handlePlayFromUrl,
+                child: Text(
+                  _isSubmittingUrl ? '处理中...' : '播放链接',
+                  style: const TextStyle(
+                    color: Color(0xFFFF2E55),
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _pasteUrlFromClipboard() async {
+    try {
+      final data = await Clipboard.getData('text/plain');
+      final text = data?.text?.trim() ?? '';
+      if (text.isEmpty) {
+        if (!mounted) return;
+        BlurSnackBar.show(context, '剪贴板里没有可用链接');
+        return;
+      }
+      _urlController.text = text;
+      _urlController.selection = TextSelection.fromPosition(
+        TextPosition(offset: _urlController.text.length),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      BlurSnackBar.show(context, '读取剪贴板失败: $e');
+    }
+  }
+
+  Future<void> _handlePlayFromUrl() async {
+    if (_isSubmittingUrl) return;
+
+    final rawInput = _urlController.text.trim();
+    final uri = Uri.tryParse(rawInput);
+    final isValidHttpUrl = uri != null &&
+        uri.hasScheme &&
+        (uri.scheme == 'http' || uri.scheme == 'https') &&
+        uri.host.isNotEmpty;
+
+    if (!isValidHttpUrl) {
+      BlurSnackBar.show(context, '请输入有效的 http/https 视频链接');
+      _urlFocusNode.requestFocus();
+      return;
+    }
+
+    setState(() {
+      _isSubmittingUrl = true;
+    });
+
+    final videoState = context.read<VideoPlayerState>();
+    videoState.setPreInitLoadingState('正在准备串流链接...');
+
+    try {
+      final playableItem = PlayableItem(videoPath: rawInput);
+      if (await ExternalPlayerService.tryHandlePlayback(
+        context,
+        playableItem,
+      )) {
+        videoState.resetPlayer();
+        return;
+      }
+
+      await videoState.initializePlayer(rawInput);
+    } catch (e) {
+      if (!mounted) return;
+      BlurSnackBar.show(context, '播放链接失败: $e');
+      await videoState.resetPlayer();
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isSubmittingUrl = false;
+        });
+      }
+    }
   }
 
   Future<void> _handleUploadVideo() async {
@@ -159,16 +410,15 @@ class _VideoUploadUIState extends State<VideoUploadUI>
           actualPlayUrl: url,
         );
         if (await ExternalPlayerService.tryHandlePlayback(
-            context, playableItem)) {
+          context,
+          playableItem,
+        )) {
           videoState.resetPlayer();
           return;
         }
 
         Future.microtask(() async {
-          await videoState.initializePlayer(
-            fileName,
-            actualPlayUrl: url,
-          );
+          await videoState.initializePlayer(fileName, actualPlayUrl: url);
         });
       } else if (globals.isPhone) {
         // 手机端弹窗选择来源
@@ -181,19 +431,13 @@ class _VideoUploadUIState extends State<VideoUploadUI>
               onPressed: () {
                 Navigator.of(context).pop('album');
               },
-              child: const Text(
-                '相册',
-                style: TextStyle(color: Colors.white),
-              ),
+              child: const Text('相册', style: TextStyle(color: Colors.white)),
             ),
             HoverScaleTextButton(
               onPressed: () {
                 Navigator.of(context).pop('file'); // 先 pop
               },
-              child: const Text(
-                '文件管理器',
-                style: TextStyle(color: Colors.white),
-              ),
+              child: const Text('文件管理器', style: TextStyle(color: Colors.white)),
             ),
           ],
         );
@@ -210,7 +454,8 @@ class _VideoUploadUIState extends State<VideoUploadUI>
             photoStatus = await Permission.photos.request();
             videoStatus = await Permission.videos.request();
             print(
-                "Android permissions status: Photos=$photoStatus, Videos=$videoStatus");
+              "Android permissions status: Photos=$photoStatus, Videos=$videoStatus",
+            );
 
             if (!mounted) return;
             if (photoStatus.isGranted && videoStatus.isGranted) {
@@ -220,7 +465,8 @@ class _VideoUploadUIState extends State<VideoUploadUI>
               // Android 权限被拒绝
               if (!mounted) return;
               print(
-                  "Android permissions not granted. Photo status: $photoStatus, Video status: $videoStatus");
+                "Android permissions not granted. Photo status: $photoStatus, Video status: $videoStatus",
+              );
               if (photoStatus.isPermanentlyDenied ||
                   videoStatus.isPermanentlyDenied) {
                 BlurDialog.show<void>(
@@ -248,12 +494,14 @@ class _VideoUploadUIState extends State<VideoUploadUI>
           } else if (io.Platform.isIOS) {
             // 在 iOS 上直接尝试选择
             print(
-                "iOS: Bypassing permission_handler, directly calling ImagePicker.");
+              "iOS: Bypassing permission_handler, directly calling ImagePicker.",
+            );
             await _pickMediaFromGallery();
           } else {
             // 其他平台 (如果支持，也直接尝试)
             print(
-                "Other platform: Bypassing permission_handler, directly calling ImagePicker/FilePicker.");
+              "Other platform: Bypassing permission_handler, directly calling ImagePicker/FilePicker.",
+            );
             await _pickMediaFromGallery(); // 或者根据平台选择不同的picker逻辑
           }
         } else if (source == 'file') {
@@ -262,8 +510,10 @@ class _VideoUploadUIState extends State<VideoUploadUI>
             if (!mounted) return; // 在延迟后再次检查 mounted
             try {
               // 先显示加载界面，然后再选择文件
-              final videoState =
-                  Provider.of<VideoPlayerState>(context, listen: false);
+              final videoState = Provider.of<VideoPlayerState>(
+                context,
+                listen: false,
+              );
               videoState.setPreInitLoadingState('正在准备视频文件...');
 
               // 使用FilePickerService选择视频文件
@@ -277,7 +527,9 @@ class _VideoUploadUIState extends State<VideoUploadUI>
 
                 final playableItem = PlayableItem(videoPath: filePath);
                 if (await ExternalPlayerService.tryHandlePlayback(
-                    context, playableItem)) {
+                  context,
+                  playableItem,
+                )) {
                   videoState.resetPlayer();
                   return;
                 }
@@ -285,8 +537,10 @@ class _VideoUploadUIState extends State<VideoUploadUI>
                 // 然后在下一帧初始化播放器
                 Future.microtask(() async {
                   if (context.mounted) {
-                    await Provider.of<VideoPlayerState>(context, listen: false)
-                        .initializePlayer(filePath);
+                    await Provider.of<VideoPlayerState>(
+                      context,
+                      listen: false,
+                    ).initializePlayer(filePath);
                   }
                 });
               } else {
@@ -299,8 +553,10 @@ class _VideoUploadUIState extends State<VideoUploadUI>
                 // 确保 mounted
                 BlurSnackBar.show(context, '选择文件出错: $e');
                 // 发生错误时清除加载状态
-                Provider.of<VideoPlayerState>(context, listen: false)
-                    .resetPlayer();
+                Provider.of<VideoPlayerState>(
+                  context,
+                  listen: false,
+                ).resetPlayer();
               } else {
                 print('选择文件出错但 widget 已 unmounted: $e');
               }
@@ -321,7 +577,9 @@ class _VideoUploadUIState extends State<VideoUploadUI>
 
           final playableItem = PlayableItem(videoPath: filePath);
           if (await ExternalPlayerService.tryHandlePlayback(
-              context, playableItem)) {
+            context,
+            playableItem,
+          )) {
             videoState.resetPlayer();
             return;
           }
@@ -362,7 +620,9 @@ class _VideoUploadUIState extends State<VideoUploadUI>
 
         final playableItem = PlayableItem(videoPath: picked.path);
         if (await ExternalPlayerService.tryHandlePlayback(
-            context, playableItem)) {
+          context,
+          playableItem,
+        )) {
           videoState.resetPlayer();
           return;
         }
@@ -376,7 +636,8 @@ class _VideoUploadUIState extends State<VideoUploadUI>
       } else {
         // 用户可能取消了选择，或者 image_picker 因为权限问题返回了 null
         print(
-            "Media picking cancelled or failed (possibly due to permissions).");
+          "Media picking cancelled or failed (possibly due to permissions).",
+        );
         videoState.resetPlayer(); // 清除加载状态
       }
     } catch (e) {


### PR DESCRIPTION
## Summary
- add an http/https direct URL playback entry to the empty player state
- make the empty-state actions read as a clear either/or choice by moving link input below file selection
- keep existing local file playback flow intact while reusing the current player initialization path

## Testing
- flutter analyze lib/themes/nipaplay/widgets/video_upload_ui.dart
- flutter build macos
- manually launched the macOS app and verified the new empty-state entry is available