### PR TITLE
添加自动全屏功能，在视频载入后自动触发全屏行为

### DIFF
--- a/lib/themes/nipaplay/pages/settings/player_settings_page.dart
+++ b/lib/themes/nipaplay/pages/settings/player_settings_page.dart
@@ -729,6 +729,26 @@ class _PlayerSettingsPageState extends State<PlayerSettingsPage> {
             },
           ),
           Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
+          Consumer<VideoPlayerState>(
+            builder: (context, videoState, child) {
+              // notice: 不清楚移动端是否需要该功能，选项暂时只向桌面端开放
+              return SettingsItem.toggle(
+                title: '自动全屏',
+                subtitle: '在加载视频后自动全屏',
+                icon: Icons.fullscreen_rounded,
+                value: videoState.autoFullscreenEnabled,
+                onChanged: (bool value) async {
+                  await videoState.setAutoFullscreenEnabled(value);
+                  if (!context.mounted) return;
+                  BlurSnackBar.show(
+                    context,
+                    value ? '已开启自动全屏' : '已关闭自动全屏',
+                  );
+                },
+              );
+            },
+          ),
+          Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
         ],
         Consumer<VideoPlayerState>(
           builder: (context, videoState, child) {

--- a/lib/utils/video_player_state.dart
+++ b/lib/utils/video_player_state.dart
@@ -595,6 +595,10 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
   double? _pendingSystemVolume;
   bool _isDrainingSystemVolumeQueue = false;
 
+  // 播放自动全屏
+  final String _autoFullscreenEnabledKey = 'auto_fullscreen_enable';
+  bool _autoFullscreenEnabled = false;
+
   bool get _useSystemVolume => globals.isMobilePlatform && !kIsWeb;
 
   void _queueSystemVolumeUpdate(double volume) {
@@ -818,6 +822,7 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
   }
 
   bool get hasSubtitleDelayDurationLimit => _duration.inMilliseconds > 0;
+  bool get autoFullscreenEnabled => _autoFullscreenEnabled;
 
   double _resolveSubtitleDelaySecondsForCurrentVideo(double value) {
     final limit = subtitleDelayCustomLimitSeconds;

--- a/lib/utils/video_player_state/video_player_state_initialization.dart
+++ b/lib/utils/video_player_state/video_player_state_initialization.dart
@@ -33,6 +33,7 @@ extension VideoPlayerStateInitialization on VideoPlayerState {
     _focusNode.requestFocus();
     await _loadLastVideo();
     await _loadVideoEnhancementSettingsEarly();
+    await _loadAutoFullScreenEnabled();
     await _loadMinimalProgressBarSettings(); // 加载最小化进度条设置
     await _loadPrecacheBufferSize(); // 加载播放预缓存大小
     await _loadPrecacheBufferDuration(); // 加载播放预缓存时长

--- a/lib/utils/video_player_state/video_player_state_player_setup.dart
+++ b/lib/utils/video_player_state/video_player_state_player_setup.dart
@@ -546,7 +546,7 @@ extension VideoPlayerStatePlayerSetup on VideoPlayerState {
         player.seek(position: 0);
       }
 
-      //debugPrint('9. 检查播放器实际状态...');
+      // debugPrint('9. 检查播放器实际状态...');
       // 检查播放器实际状态
       // if (player.state == PlaybackState.playing) {
       //   _setStatus(PlayerStatus.playing, message: '正在播放');
@@ -670,6 +670,10 @@ extension VideoPlayerStatePlayerSetup on VideoPlayerState {
           // debugPrint('VideoPlayerState: Resuming playback (player was not auto-playing), calling play().'); // <--- REMOVED PRINT
           play(); // Call our central play method
         }
+      }
+
+      if (!isFullscreen && autoFullscreenEnabled) {
+        await toggleFullscreen();
       }
 
       // 尝试自动检测和加载字幕

--- a/lib/utils/video_player_state/video_player_state_preferences.dart
+++ b/lib/utils/video_player_state/video_player_state_preferences.dart
@@ -2075,4 +2075,42 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     _screenshotSaveDirectory = resolvedPath;
     notifyListeners();
   }
+
+  Future<void> _loadAutoFullScreenEnabled() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final bool stored = _readCompatibleBool(
+        prefs,
+        _autoFullscreenEnabledKey,
+        defaultValue: false,
+      );
+      _autoFullscreenEnabled = stored;
+    } catch (e) {
+      debugPrint('[VideoPlayerState] 读取 AutoFullscreen 设置失败: $e');
+      _autoFullscreenEnabled = false;
+    }
+
+    notifyListeners();
+  }
+
+  Future<void> setAutoFullscreenEnabled(bool value) async {
+    if (_autoFullscreenEnabled == value) {
+      return;
+    }
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await _persistBoolWithRetry(
+        prefs,
+        _autoFullscreenEnabledKey,
+        value,
+        settingName: '自动全屏',
+      );
+      _autoFullscreenEnabled = value;
+    } catch (e) {
+      debugPrint('[VideoPlayerState] 保存 AutoFullscreen 设置失败: $e');
+    }
+
+    notifyListeners();
+  }
 }


### PR DESCRIPTION
## Summary

- 在使用时，`选择文件`后视频以自动播放，但视频没有全屏，仍然需要用户手动点击全屏，使用起来不太方便。
- 添加自动全屏功能，在启动该功能后，'选择文件'后视频以自动播放并同时全屏，用户省去一步操作。

## Related Issue

- 无

## What Changed

- 在`设置`->`播放器`中新增`自动全屏`选项（暂时只向桌面端开放该选项）。
<img width="1810" height="840" alt="Screenshot 2026-04-17 at 13 22 36" src="https://github.com/user-attachments/assets/218bf766-b077-49f9-bf18-e5c0628e4d23" />

- 在`initializePlayer`函数中根据用户设置触发全屏行为。

- 该选项在`SharedPreferences`持续化存储。

## Other

- 在 Mac 中全屏后，`视频播放`页面的`返回`按钮就会消失。我有时想连着看几部不是同一系列的视频，但是每次都需要退出全面，然后才能点击`返回`按钮，继续点击`选择文件`，再继续点击全屏，甚是麻烦。
<img width="1470" height="956" alt="Screenshot 2026-04-17 at 13 38 04" src="https://github.com/user-attachments/assets/ca4755d4-4ab8-4e72-9e52-2d6ac24b41f9" />
<img width="1470" height="956" alt="Screenshot 2026-04-17 at 13 37 03" src="https://github.com/user-attachments/assets/682f782a-74c6-4bf3-985d-281fcb5eacbf" />

- 我在想能否全屏时也显示`返回`按钮，同时新增`选择文件`按钮（像`返回`按钮）在视频的 Overlay 上。