### PR TITLE
修复了设置页面中通用子页面在更改选项时页面闪烁的问题；修复了在播放新视频时LoadingOverlay仍然显示上一个视频的封面的问题。

### DIFF
--- a/lib/themes/nipaplay/pages/settings/general_page.dart
+++ b/lib/themes/nipaplay/pages/settings/general_page.dart
@@ -60,12 +60,16 @@ class _GeneralPageState extends State<GeneralPage> {
   // 生成默认页面选项
   List<DropdownMenuItemData<int>> _getDefaultPageItems() {
     List<DropdownMenuItemData<int>> items = [
-      DropdownMenuItemData(title: "主页", value: 0, isSelected: _defaultPageIndex == 0),
-      DropdownMenuItemData(title: "视频播放", value: 1, isSelected: _defaultPageIndex == 1),
-      DropdownMenuItemData(title: "媒体库", value: 2, isSelected: _defaultPageIndex == 2),
+      DropdownMenuItemData(
+          title: "主页", value: 0, isSelected: _defaultPageIndex == 0),
+      DropdownMenuItemData(
+          title: "视频播放", value: 1, isSelected: _defaultPageIndex == 1),
+      DropdownMenuItemData(
+          title: "媒体库", value: 2, isSelected: _defaultPageIndex == 2),
     ];
 
-    items.add(DropdownMenuItemData(title: "个人中心", value: 3, isSelected: _defaultPageIndex == 3));
+    items.add(DropdownMenuItemData(
+        title: "个人中心", value: 3, isSelected: _defaultPageIndex == 3));
 
     return items;
   }
@@ -243,8 +247,7 @@ class _GeneralPageState extends State<GeneralPage> {
     return null;
   }
 
-  Future<void> _saveStartupWindowState(
-      DesktopStartupWindowState state) async {
+  Future<void> _saveStartupWindowState(DesktopStartupWindowState state) async {
     await DesktopStartupWindowPreferences.saveState(state);
   }
 
@@ -297,14 +300,14 @@ class _GeneralPageState extends State<GeneralPage> {
                   cursorColor: const Color(0xFFFF2E55),
                   decoration: InputDecoration(
                     labelText: '宽度 (px)',
-                    labelStyle:
-                        TextStyle(color: colorScheme.onSurface.withOpacity(0.7)),
+                    labelStyle: TextStyle(
+                        color: colorScheme.onSurface.withOpacity(0.7)),
                     focusedBorder: UnderlineInputBorder(
                       borderSide: BorderSide(color: colorScheme.onSurface),
                     ),
                     enabledBorder: UnderlineInputBorder(
-                      borderSide:
-                          BorderSide(color: colorScheme.onSurface.withOpacity(0.38)),
+                      borderSide: BorderSide(
+                          color: colorScheme.onSurface.withOpacity(0.38)),
                     ),
                   ),
                   style: const TextStyle(color: Color(0xFFFF2E55)),
@@ -319,14 +322,14 @@ class _GeneralPageState extends State<GeneralPage> {
                   cursorColor: const Color(0xFFFF2E55),
                   decoration: InputDecoration(
                     labelText: '高度 (px)',
-                    labelStyle:
-                        TextStyle(color: colorScheme.onSurface.withOpacity(0.7)),
+                    labelStyle: TextStyle(
+                        color: colorScheme.onSurface.withOpacity(0.7)),
                     focusedBorder: UnderlineInputBorder(
                       borderSide: BorderSide(color: colorScheme.onSurface),
                     ),
                     enabledBorder: UnderlineInputBorder(
-                      borderSide:
-                          BorderSide(color: colorScheme.onSurface.withOpacity(0.38)),
+                      borderSide: BorderSide(
+                          color: colorScheme.onSurface.withOpacity(0.38)),
                     ),
                   ),
                   style: const TextStyle(color: Color(0xFFFF2E55)),
@@ -474,7 +477,9 @@ class _GeneralPageState extends State<GeneralPage> {
     return Container(
       key: ValueKey(section.storageKey),
       decoration: BoxDecoration(
-        border: showDivider ? Border(bottom: BorderSide(color: dividerColor)) : null,
+        border: showDivider
+            ? Border(bottom: BorderSide(color: dividerColor))
+            : null,
       ),
       child: ListTile(
         dense: true,
@@ -511,186 +516,159 @@ class _GeneralPageState extends State<GeneralPage> {
 
   @override
   Widget build(BuildContext context) {
-    return FutureBuilder<int>(
-      future: _loadDefaultPageIndex(),
-      builder: (context, snapshot) {
-        if (snapshot.connectionState == ConnectionState.waiting) {
-          return const Center(child: CircularProgressIndicator());
-        }
+    final colorScheme = Theme.of(context).colorScheme;
+    final l10n = context.l10n;
 
-        if (snapshot.hasError) {
-          return Center(child: Text('Error: ${snapshot.error}'));
-        }
+    final List<Widget> items = [];
 
-        _defaultPageIndex = snapshot.data ?? 0;
+    if (globals.isDesktop) {
+      items.add(
+        SettingsItem.dropdown(
+          title: "关闭窗口时",
+          subtitle: "设置关闭按钮的默认行为，可随时修改“记住我的选择”",
+          icon: Ionicons.close_outline,
+          items: _getDesktopExitItems(),
+          onChanged: (behavior) {
+            setState(() {
+              _desktopExitBehavior = behavior as DesktopExitBehavior;
+            });
+            _saveDesktopExitBehavior(behavior as DesktopExitBehavior);
+          },
+          dropdownKey: _desktopExitBehaviorDropdownKey,
+        ),
+      );
+      items.add(
+        Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
+      );
+      items.add(
+        SettingsItem.dropdown(
+          title: "播放器启动时状态",
+          subtitle: "设置启动时窗口状态",
+          icon: Ionicons.expand_outline,
+          items: _getStartupWindowStateItems(),
+          onChanged: (state) {
+            setState(() {
+              _startupWindowState = state as DesktopStartupWindowState;
+            });
+            _saveStartupWindowState(state as DesktopStartupWindowState);
+            if (_startupWindowState != DesktopStartupWindowState.windowed) {
+              BlurSnackBar.show(context, "启动时窗口状态已更新");
+            }
+          },
+          dropdownKey: _startupWindowStateDropdownKey,
+        ),
+      );
 
-        final colorScheme = Theme.of(context).colorScheme;
-        final l10n = context.l10n;
-
-        final List<Widget> items = [];
-
-        if (globals.isDesktop) {
-          items.add(
-            SettingsItem.dropdown(
-              title: "关闭窗口时",
-              subtitle: "设置关闭按钮的默认行为，可随时修改“记住我的选择”",
-              icon: Ionicons.close_outline,
-              items: _getDesktopExitItems(),
-              onChanged: (behavior) {
-                setState(() {
-                  _desktopExitBehavior = behavior as DesktopExitBehavior;
-                });
-                _saveDesktopExitBehavior(behavior as DesktopExitBehavior);
-              },
-              dropdownKey: _desktopExitBehaviorDropdownKey,
-            ),
-          );
-          items.add(
-            Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
-          );
-          items.add(
-            SettingsItem.dropdown(
-              title: "播放器启动时状态",
-              subtitle: "设置启动时窗口状态",
-              icon: Ionicons.expand_outline,
-              items: _getStartupWindowStateItems(),
-              onChanged: (state) {
-                setState(() {
-                  _startupWindowState = state as DesktopStartupWindowState;
-                });
-                _saveStartupWindowState(state as DesktopStartupWindowState);
-                if (_startupWindowState != DesktopStartupWindowState.windowed) {
-                  BlurSnackBar.show(context, "启动时窗口状态已更新");
-                }
-              },
-              dropdownKey: _startupWindowStateDropdownKey,
-            ),
-          );
-
-          if (_startupWindowState == DesktopStartupWindowState.windowed) {
-            items.add(
-              Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
-            );
-            items.add(
-              SettingsItem.dropdown(
-                title: "播放器启动时窗口位置",
-                subtitle: "窗口化启动时的位置",
-                icon: Ionicons.move_outline,
-                items: _getStartupWindowPositionItems(),
-                onChanged: (position) {
-                  setState(() {
-                    _startupWindowPosition =
-                        position as DesktopStartupWindowPosition;
-                  });
-                  _saveStartupWindowPosition(
-                      position as DesktopStartupWindowPosition);
-                  BlurSnackBar.show(context, "启动窗口位置已保存");
-                },
-                dropdownKey: _startupWindowPositionDropdownKey,
-              ),
-            );
-            items.add(
-              Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
-            );
-            items.add(
-              SettingsItem.dropdown(
-                title: "播放器启动时窗口尺寸",
-                subtitle: "支持预设与自定义尺寸",
-                icon: Ionicons.resize_outline,
-                items: _getStartupWindowSizeItems(),
-                onChanged: (value) {
-                  if (value is! String) return;
-                  if (value == 'custom') {
-                    _showCustomWindowSizeDialog();
-                    return;
-                  }
-                  final preset = _findWindowSizePreset(value);
-                  if (preset == null) return;
-                  _saveStartupWindowSize(preset.size).then((_) {
-                    if (!mounted) return;
-                    BlurSnackBar.show(context, "启动窗口尺寸已保存");
-                  });
-                },
-                dropdownKey: _startupWindowSizeDropdownKey,
-              ),
-            );
-            items.add(
-              Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
-            );
-            items.add(
-              SettingsItem.button(
-                title: "恢复默认窗口尺寸",
-                subtitle: "重置为默认的启动窗口大小",
-                icon: Ionicons.refresh_outline,
-                onTap: _resetStartupWindowSize,
-              ),
-            );
-          }
-
-          items.add(
-            Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
-          );
-        }
-
+      if (_startupWindowState == DesktopStartupWindowState.windowed) {
+        items.add(
+          Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
+        );
         items.add(
           SettingsItem.dropdown(
-            title: "默认展示页面",
-            subtitle: "选择应用启动后默认显示的页面",
-            icon: Ionicons.home_outline,
-            items: _getDefaultPageItems(),
-            onChanged: (index) {
+            title: "播放器启动时窗口位置",
+            subtitle: "窗口化启动时的位置",
+            icon: Ionicons.move_outline,
+            items: _getStartupWindowPositionItems(),
+            onChanged: (position) {
               setState(() {
-                _defaultPageIndex = index;
+                _startupWindowPosition =
+                    position as DesktopStartupWindowPosition;
               });
-              _saveDefaultPagePreference(index);
+              _saveStartupWindowPosition(
+                  position as DesktopStartupWindowPosition);
+              BlurSnackBar.show(context, "启动窗口位置已保存");
             },
-            dropdownKey: _defaultPageDropdownKey,
+            dropdownKey: _startupWindowPositionDropdownKey,
           ),
         );
         items.add(
           Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
         );
         items.add(
-          SettingsItem.toggle(
-            title: l10n.aboutAutoCheckUpdates,
-            subtitle: l10n.aboutManualOnlyWhenDisabled,
-            icon: Ionicons.cloud_outline,
-            value: _autoCheckUpdatesEnabled,
-            onChanged: _setAutoCheckUpdatesEnabled,
+          SettingsItem.dropdown(
+            title: "播放器启动时窗口尺寸",
+            subtitle: "支持预设与自定义尺寸",
+            icon: Ionicons.resize_outline,
+            items: _getStartupWindowSizeItems(),
+            onChanged: (value) {
+              if (value is! String) return;
+              if (value == 'custom') {
+                _showCustomWindowSizeDialog();
+                return;
+              }
+              final preset = _findWindowSizePreset(value);
+              if (preset == null) return;
+              _saveStartupWindowSize(preset.size).then((_) {
+                if (!mounted) return;
+                BlurSnackBar.show(context, "启动窗口尺寸已保存");
+              });
+            },
+            dropdownKey: _startupWindowSizeDropdownKey,
           ),
         );
         items.add(
           Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
         );
         items.add(
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-            child: Consumer<HomeSectionsSettingsProvider>(
-              builder: (context, provider, child) {
-                return _buildHomeSectionSettingsCard(context, provider);
-              },
-            ),
+          SettingsItem.button(
+            title: "恢复默认窗口尺寸",
+            subtitle: "重置为默认的启动窗口大小",
+            icon: Ionicons.refresh_outline,
+            onTap: _resetStartupWindowSize,
           ),
         );
+      }
 
-        return ListView(children: items);
-      },
+      items.add(
+        Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
+      );
+    }
+
+    items.add(
+      SettingsItem.dropdown(
+        title: "默认展示页面",
+        subtitle: "选择应用启动后默认显示的页面",
+        icon: Ionicons.home_outline,
+        items: _getDefaultPageItems(),
+        onChanged: (index) {
+          setState(() {
+            _defaultPageIndex = index;
+          });
+          _saveDefaultPagePreference(index);
+        },
+        dropdownKey: _defaultPageDropdownKey,
+      ),
     );
+    items.add(
+      Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
+    );
+    items.add(
+      SettingsItem.toggle(
+        title: l10n.aboutAutoCheckUpdates,
+        subtitle: l10n.aboutManualOnlyWhenDisabled,
+        icon: Ionicons.cloud_outline,
+        value: _autoCheckUpdatesEnabled,
+        onChanged: _setAutoCheckUpdatesEnabled,
+      ),
+    );
+    items.add(
+      Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
+    );
+    items.add(
+      Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Consumer<HomeSectionsSettingsProvider>(
+          builder: (context, provider, child) {
+            return _buildHomeSectionSettingsCard(context, provider);
+          },
+        ),
+      ),
+    );
+
+    return ListView(children: items);
   }
 }
 
-Future<int> _loadDefaultPageIndex() async {
-  final prefs = await SharedPreferences.getInstance();
-  final index = prefs.getInt(defaultPageIndexKey) ?? 0;
-  if (index < 0) {
-    return 0;
-  }
-  if (index > 3) {
-    return 3;
-  }
-  return index;
-}
- 
 class _HoverScaleActionButton extends StatefulWidget {
   final IconData icon;
   final String label;
@@ -717,7 +695,8 @@ class _HoverScaleActionButton extends StatefulWidget {
   });
 
   @override
-  State<_HoverScaleActionButton> createState() => _HoverScaleActionButtonState();
+  State<_HoverScaleActionButton> createState() =>
+      _HoverScaleActionButtonState();
 }
 
 class _HoverScaleActionButtonState extends State<_HoverScaleActionButton> {

--- a/lib/themes/nipaplay/widgets/loading_overlay.dart
+++ b/lib/themes/nipaplay/widgets/loading_overlay.dart
@@ -5,6 +5,7 @@ import 'dart:ui' as ui;
 import 'package:flutter/material.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/cached_network_image_widget.dart';
 import 'package:nipaplay/utils/globals.dart' as globals;
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'typing_text.dart';
 
@@ -22,12 +23,12 @@ class LoadingOverlay extends StatefulWidget {
   final double fontSize;
   final bool isBold;
   final bool highPriorityAnimation;
-  
+
   // 新增：媒体信息参数
   final String? animeTitle;
   final String? episodeTitle;
   final String? fileName;
-  final String? coverImageUrl;
+  final int? animeId;
 
   const LoadingOverlay({
     super.key,
@@ -47,17 +48,19 @@ class LoadingOverlay extends StatefulWidget {
     this.animeTitle,
     this.episodeTitle,
     this.fileName,
-    this.coverImageUrl,
+    this.animeId,
   });
 
   @override
   State<LoadingOverlay> createState() => _LoadingOverlayState();
 }
 
-class _LoadingOverlayState extends State<LoadingOverlay> with SingleTickerProviderStateMixin {
+class _LoadingOverlayState extends State<LoadingOverlay>
+    with SingleTickerProviderStateMixin {
   final ScrollController _scrollController = ScrollController();
   late AnimationController _cursorController;
   late Animation<double> _cursorAnimation;
+  String? _coverImageUrl;
 
   // 滚动到底部的通用方法
   void _scrollToBottom() {
@@ -82,8 +85,10 @@ class _LoadingOverlayState extends State<LoadingOverlay> with SingleTickerProvid
       vsync: this,
       duration: const Duration(milliseconds: 500), // 闪烁频率
     )..repeat(reverse: true); // 重复执行并反向（产生闪烁效果）
-    
-    _cursorAnimation = Tween<double>(begin: 0.0, end: 1.0).animate(_cursorController);
+
+    _cursorAnimation =
+        Tween<double>(begin: 0.0, end: 1.0).animate(_cursorController);
+    _updateAnimeCoverUrl();
   }
 
   @override
@@ -107,6 +112,10 @@ class _LoadingOverlayState extends State<LoadingOverlay> with SingleTickerProvid
         }
       });
     }
+    if (oldWidget.animeId != widget.animeId) {
+      _coverImageUrl = null; // 清空前URL 避免显示上一部视频的封面
+      _updateAnimeCoverUrl();
+    }
   }
 
   @override
@@ -122,26 +131,31 @@ class _LoadingOverlayState extends State<LoadingOverlay> with SingleTickerProvid
     final colorScheme = theme.colorScheme;
     final bool isDark = theme.brightness == Brightness.dark;
     final bool hasCoverImage =
-        widget.coverImageUrl != null && widget.coverImageUrl!.isNotEmpty;
+        _coverImageUrl != null && _coverImageUrl!.isNotEmpty;
 
     // 计算比例尺寸时考虑屏幕大小，修复clamp参数顺序问题
     final screenWidth = MediaQuery.of(context).size.width;
     final screenHeight = MediaQuery.of(context).size.height;
-    
+
     // 手机使用较小的宽度，平板和桌面使用较大的宽度
-    final targetWidth = globals.isPhone && !globals.isTablet 
+    final targetWidth = globals.isPhone && !globals.isTablet
         ? math.min(screenWidth * 0.9, 400.0) // 手机上较小宽度
-        : math.min(screenWidth * 0.9, (widget.width * 2.5).clamp(300.0, 800.0)); // 平板/桌面较大宽度
-    
+        : math.min(screenWidth * 0.9,
+            (widget.width * 2.5).clamp(300.0, 800.0)); // 平板/桌面较大宽度
+
     final effectiveWidth = math.max(300.0, targetWidth);
-    final effectiveHeight = math.max(200.0, math.min(screenHeight * 0.5, widget.height ?? 300));
+    final effectiveHeight =
+        math.max(200.0, math.min(screenHeight * 0.5, widget.height ?? 300));
 
     final Color fallbackBackgroundColor =
         isDark ? const Color(0xFF1E1E1E) : const Color(0xFFF2F2F2);
     final Color effectiveBackgroundColor =
-        widget.backgroundColor == Colors.black ? fallbackBackgroundColor : widget.backgroundColor;
-    final Color effectiveTextColor =
-        widget.textColor == Colors.white ? (isDark ? Colors.white : Colors.black87) : widget.textColor;
+        widget.backgroundColor == Colors.black
+            ? fallbackBackgroundColor
+            : widget.backgroundColor;
+    final Color effectiveTextColor = widget.textColor == Colors.white
+        ? (isDark ? Colors.white : Colors.black87)
+        : widget.textColor;
     final Color baseSurface = Color.lerp(
       colorScheme.surface,
       colorScheme.onSurface,
@@ -152,8 +166,9 @@ class _LoadingOverlayState extends State<LoadingOverlay> with SingleTickerProvid
         colorScheme.onSurface.withOpacity(isDark ? 0.2 : 0.12);
     final Color cardShadowColor =
         Colors.black.withOpacity(isDark ? 0.45 : 0.16);
-    final Color cursorColor = effectiveTextColor.withOpacity(widget.textOpacity);
-    
+    final Color cursorColor =
+        effectiveTextColor.withOpacity(widget.textOpacity);
+
     // 获取文本样式
     final textStyle = TextStyle(
       color: effectiveTextColor.withOpacity(widget.textOpacity),
@@ -161,21 +176,21 @@ class _LoadingOverlayState extends State<LoadingOverlay> with SingleTickerProvid
       fontWeight: widget.isBold ? FontWeight.w600 : FontWeight.normal,
       letterSpacing: 0.5,
     );
-    
+
     final titleStyle = TextStyle(
       color: effectiveTextColor.withOpacity(widget.textOpacity * 0.9),
       fontSize: widget.fontSize + 2,
       fontWeight: FontWeight.w700,
       letterSpacing: 0.3,
     );
-    
+
     final subtitleStyle = TextStyle(
       color: effectiveTextColor.withOpacity(widget.textOpacity * 0.8),
       fontSize: widget.fontSize - 2,
       fontWeight: FontWeight.w500,
       letterSpacing: 0.2,
     );
-    
+
     return Stack(
       fit: StackFit.expand,
       children: [
@@ -191,7 +206,7 @@ class _LoadingOverlayState extends State<LoadingOverlay> with SingleTickerProvid
                   child: Opacity(
                     opacity: isDark ? 0.25 : 0.35,
                     child: CachedNetworkImageWidget(
-                      imageUrl: widget.coverImageUrl!,
+                      imageUrl: _coverImageUrl!,
                       fit: BoxFit.cover,
                       shouldCompress: false,
                       loadMode: CachedImageLoadMode.hybrid,
@@ -219,7 +234,8 @@ class _LoadingOverlayState extends State<LoadingOverlay> with SingleTickerProvid
           )
         else
           Container(
-            color: effectiveBackgroundColor.withOpacity(widget.backgroundOpacity),
+            color:
+                effectiveBackgroundColor.withOpacity(widget.backgroundOpacity),
           ),
         // 加载界面
         Center(
@@ -246,8 +262,9 @@ class _LoadingOverlayState extends State<LoadingOverlay> with SingleTickerProvid
               ),
               child: Padding(
                 padding: const EdgeInsets.all(20.0),
-                child: globals.isPhone && !globals.isTablet 
-                    ? Column( // 手机上使用上下双行布局
+                child: globals.isPhone && !globals.isTablet
+                    ? Column(
+                        // 手机上使用上下双行布局
                         mainAxisAlignment: MainAxisAlignment.center,
                         crossAxisAlignment: CrossAxisAlignment.center,
                         children: [
@@ -283,7 +300,8 @@ class _LoadingOverlayState extends State<LoadingOverlay> with SingleTickerProvid
                           ),
                         ],
                       )
-                    : Row( // 平板和桌面保持双栏布局
+                    : Row(
+                        // 平板和桌面保持双栏布局
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
                           // 左侧：媒体信息区域 (1/3 宽度)
@@ -298,7 +316,8 @@ class _LoadingOverlayState extends State<LoadingOverlay> with SingleTickerProvid
                           // 分隔线
                           Container(
                             width: 1,
-                            margin: const EdgeInsets.symmetric(horizontal: 16.0),
+                            margin:
+                                const EdgeInsets.symmetric(horizontal: 16.0),
                             decoration: BoxDecoration(
                               gradient: LinearGradient(
                                 begin: Alignment.topCenter,
@@ -373,11 +392,11 @@ class _LoadingOverlayState extends State<LoadingOverlay> with SingleTickerProvid
         borderRadius: BorderRadius.circular(8),
         color: accentColor.withOpacity(0.1),
       ),
-      child: widget.coverImageUrl != null
+      child: _coverImageUrl != null
           ? ClipRRect(
               borderRadius: BorderRadius.circular(8),
               child: Image.network(
-                widget.coverImageUrl!,
+                _coverImageUrl!,
                 fit: BoxFit.cover,
                 errorBuilder: (context, error, stackTrace) {
                   return Container(
@@ -419,7 +438,7 @@ class _LoadingOverlayState extends State<LoadingOverlay> with SingleTickerProvid
               overflow: TextOverflow.ellipsis,
             ),
           ),
-        
+
         // 集数标题
         if (widget.episodeTitle != null && widget.episodeTitle!.isNotEmpty)
           Padding(
@@ -431,10 +450,11 @@ class _LoadingOverlayState extends State<LoadingOverlay> with SingleTickerProvid
               overflow: TextOverflow.ellipsis,
             ),
           ),
-        
+
         // 文件名（如果没有动画名时显示）
-        if ((widget.animeTitle == null || widget.animeTitle!.isEmpty) && 
-            widget.fileName != null && widget.fileName!.isNotEmpty)
+        if ((widget.animeTitle == null || widget.animeTitle!.isEmpty) &&
+            widget.fileName != null &&
+            widget.fileName!.isNotEmpty)
           Padding(
             padding: const EdgeInsets.only(bottom: 6),
             child: Text(
@@ -458,7 +478,7 @@ class _LoadingOverlayState extends State<LoadingOverlay> with SingleTickerProvid
       behavior: ScrollConfiguration.of(context).copyWith(
         scrollbars: false,
       ),
-      child: widget.messages.isEmpty 
+      child: widget.messages.isEmpty
           ? Center(
               child: Text(
                 '正在加载...',
@@ -510,6 +530,30 @@ class _LoadingOverlayState extends State<LoadingOverlay> with SingleTickerProvid
               },
             ),
     );
+  }
+
+  // 获取番剧封面URL
+  Future<String?> _getAnimeCoverUrl(int? animeId) async {
+    if (animeId == null) return null;
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      const prefsKeyPrefix = 'media_library_image_url_';
+      return prefs.getString('$prefsKeyPrefix$animeId');
+    } catch (e) {
+      debugPrint('获取番剧封面失败: $e');
+      return null;
+    }
+  }
+
+  Future<void> _updateAnimeCoverUrl() async {
+    final animeId = widget.animeId;
+    final url = await _getAnimeCoverUrl(animeId);
+    if (mounted && widget.animeId == animeId && _coverImageUrl != url) {
+      setState(() {
+        _coverImageUrl = url;
+      });
+    }
   }
 }
 
@@ -586,20 +630,20 @@ class _TypingTextCursorState extends State<TypingTextCursor> {
       textDirection: TextDirection.ltr,
     );
     textPainter.layout();
-    
+
     return Stack(
       children: [
-                 Positioned(
-           left: textPainter.width,
-           bottom: 5, // 绝对贴于底部
-           child: FadeTransition(
-             opacity: widget.cursorAnimation,
-             child: Container(
-               width: 10, // 光标宽度
-               height: 3, // 光标高度（下划线厚度）
-               color: widget.cursorColor,
-             ),
-           ),
+        Positioned(
+          left: textPainter.width,
+          bottom: 5, // 绝对贴于底部
+          child: FadeTransition(
+            opacity: widget.cursorAnimation,
+            child: Container(
+              width: 10, // 光标宽度
+              height: 3, // 光标高度（下划线厚度）
+              color: widget.cursorColor,
+            ),
+          ),
         ),
       ],
     );

--- a/lib/themes/nipaplay/widgets/video_player_ui.dart
+++ b/lib/themes/nipaplay/widgets/video_player_ui.dart
@@ -22,7 +22,6 @@ import 'right_edge_hover_menu.dart';
 import 'minimal_progress_bar.dart';
 import 'danmaku_density_bar.dart';
 import 'speed_boost_indicator.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'loading_overlay.dart';
 import 'macos_hdr_probe_overlay.dart';
 import 'vertical_indicator.dart';
@@ -71,8 +70,6 @@ class _VideoPlayerUIState extends State<VideoPlayerUI>
 
   // <<< ADDED: Hold a reference to VideoPlayerState for managing the callback
   VideoPlayerState? _videoPlayerStateInstance;
-  String? _currentAnimeCoverUrl; // 当前番剧封面URL
-  int? _lastAnimeId; // 上次获取封面的番剧ID，用于避免重复请求
   int? _macosNativeVideoViewId;
 
   bool _isRepeatableShortcut(LogicalKeyboardKey key) {
@@ -179,33 +176,6 @@ class _VideoPlayerUIState extends State<VideoPlayerUI>
         defaultTargetPlatform == TargetPlatform.macOS &&
         Platform.environment['NIPAPLAY_MACOS_HDR_USE_APPKIT_VIEW'] != '1' &&
         Platform.environment['NIPAPLAY_DISABLE_MACOS_WINDOW_OVERLAY'] != '1';
-  }
-
-  // 获取番剧封面URL
-  Future<String?> _getAnimeCoverUrl(int? animeId) async {
-    if (animeId == null) return null;
-
-    try {
-      final prefs = await SharedPreferences.getInstance();
-      const prefsKeyPrefix = 'media_library_image_url_';
-      return prefs.getString('$prefsKeyPrefix$animeId');
-    } catch (e) {
-      debugPrint('获取番剧封面失败: $e');
-      return null;
-    }
-  }
-
-  // 更新封面URL（如果番剧ID变化）
-  void _updateAnimeCoverUrl(int? animeId) async {
-    if (animeId != _lastAnimeId) {
-      _lastAnimeId = animeId;
-      final coverUrl = await _getAnimeCoverUrl(animeId);
-      if (mounted && coverUrl != _currentAnimeCoverUrl) {
-        setState(() {
-          _currentAnimeCoverUrl = coverUrl;
-        });
-      }
-    }
   }
 
   double getFontSize(VideoPlayerState videoState) {
@@ -319,8 +289,8 @@ class _VideoPlayerUIState extends State<VideoPlayerUI>
           context,
           listen: false,
         );
-        _videoPlayerStateInstance
-            ?.onSeriousPlaybackErrorAndShouldPop = () async {
+        _videoPlayerStateInstance?.onSeriousPlaybackErrorAndShouldPop =
+            () async {
           if (mounted && _videoPlayerStateInstance != null) {
             // 获取当前的错误信息用于显示
             final String errorMessage =
@@ -419,8 +389,7 @@ class _VideoPlayerUIState extends State<VideoPlayerUI>
   void _resetMouseHideTimer() {
     _mouseMoveTimer?.cancel();
     if (!globals.isMobilePlatform) {
-      final videoState =
-          _videoPlayerStateInstance ??
+      final videoState = _videoPlayerStateInstance ??
           Provider.of<VideoPlayerState>(context, listen: false);
       final hideDelay = videoState.instantHidePlayerUiEnabled
           ? _instantMouseHideDelay
@@ -806,13 +775,9 @@ class _VideoPlayerUIState extends State<VideoPlayerUI>
     return Consumer<VideoPlayerState>(
       builder: (context, videoState, child) {
         final textureId = videoState.player.textureId.value;
-        final hasRenderableVideoSurface =
-            kIsWeb ||
+        final hasRenderableVideoSurface = kIsWeb ||
             videoState.player.prefersPlatformVideoSurface ||
             (textureId != null && textureId >= 0);
-
-        // 更新番剧封面URL（如果有番剧ID）
-        _updateAnimeCoverUrl(videoState.animeId);
 
         final shouldKeepNativeSurface = _shouldKeepMacOSNativeVideoSurface(
           videoState,
@@ -832,7 +797,7 @@ class _VideoPlayerUIState extends State<VideoPlayerUI>
                   animeTitle: videoState.animeTitle,
                   episodeTitle: videoState.episodeTitle,
                   fileName: videoState.currentVideoPath?.split('/').last,
-                  coverImageUrl: _currentAnimeCoverUrl,
+                  animeId: videoState.animeId,
                 ),
             ],
           );
@@ -882,11 +847,11 @@ class _VideoPlayerUIState extends State<VideoPlayerUI>
                       : null,
                   onHorizontalDragStart: videoState.hasVideo
                       ? (details) =>
-                            _handleHorizontalDragStart(context, details)
+                          _handleHorizontalDragStart(context, details)
                       : null,
                   onHorizontalDragUpdate: videoState.hasVideo
                       ? (details) =>
-                            _handleHorizontalDragUpdate(context, details)
+                          _handleHorizontalDragUpdate(context, details)
                       : null,
                   onHorizontalDragEnd: videoState.hasVideo
                       ? (details) => _handleHorizontalDragEnd(context, details)
@@ -928,8 +893,7 @@ class _VideoPlayerUIState extends State<VideoPlayerUI>
                                                     .videoDuration
                                                     .inMilliseconds
                                                     .toDouble(),
-                                                isPlaying:
-                                                    videoState.status ==
+                                                isPlaying: videoState.status ==
                                                     PlayerStatus.playing,
                                                 fontSize: getFontSize(
                                                   videoState,
@@ -975,7 +939,7 @@ class _VideoPlayerUIState extends State<VideoPlayerUI>
                                       fileName: videoState.currentVideoPath
                                           ?.split('/')
                                           .last,
-                                      coverImageUrl: _currentAnimeCoverUrl,
+                                      animeId: videoState.animeId,
                                     ),
                                   ),
                                 if (videoState.hasVideo)
@@ -1020,8 +984,7 @@ class _VideoPlayerUIState extends State<VideoPlayerUI>
                                           builder: (context, videoState, _) {
                                             // 使用高频时间轴驱动弹幕帧率
                                             return ValueListenableBuilder<
-                                              double
-                                            >(
+                                                double>(
                                               valueListenable:
                                                   videoState.playbackTimeMs,
                                               builder: (context, posMs, __) {
@@ -1036,7 +999,7 @@ class _VideoPlayerUIState extends State<VideoPlayerUI>
                                                       .toDouble(),
                                                   isPlaying:
                                                       videoState.status ==
-                                                      PlayerStatus.playing,
+                                                          PlayerStatus.playing,
                                                   fontSize: getFontSize(
                                                     videoState,
                                                   ),
@@ -1081,7 +1044,7 @@ class _VideoPlayerUIState extends State<VideoPlayerUI>
                                         fileName: videoState.currentVideoPath
                                             ?.split('/')
                                             .last,
-                                        coverImageUrl: _currentAnimeCoverUrl,
+                                        animeId: videoState.animeId,
                                       ),
                                     ),
                                   if (videoState.hasVideo)

--- a/lib/utils/video_player_state/video_player_state_playback_controls.dart
+++ b/lib/utils/video_player_state/video_player_state_playback_controls.dart
@@ -249,6 +249,13 @@ extension VideoPlayerStatePlaybackControls on VideoPlayerState {
     String? message,
     bool clearPreviousMessages = false,
   }) {
+    switch (newStatus) {
+      case PlayerStatus.idle:
+      case PlayerStatus.loading:
+        _resetVideoState();
+        break;
+      default:
+    }
     // 在状态即将从loading或recognizing变为ready或playing时，设置最终加载阶段标志
     if ((_status == PlayerStatus.loading ||
             _status == PlayerStatus.recognizing) &&
@@ -387,8 +394,7 @@ extension VideoPlayerStatePlaybackControls on VideoPlayerState {
 
   void pause() {
     if (_status == PlayerStatus.playing) {
-      final bool isWindowsMediaKit =
-          !kIsWeb &&
+      final bool isWindowsMediaKit = !kIsWeb &&
           Platform.isWindows &&
           player.getPlayerKernelName() == 'Media Kit';
       if (isWindowsMediaKit) {
@@ -399,18 +405,15 @@ extension VideoPlayerStatePlaybackControls on VideoPlayerState {
       }
 
       // 使用直接暂停方法，确保VideoPlayer插件能够暂停视频
-      player
-          .pauseDirectly()
-          .then((_) {
-            //debugPrint('[VideoPlayerState] pauseDirectly() 调用成功');
-            _setStatus(PlayerStatus.paused, message: '已暂停');
-          })
-          .catchError((e) {
-            debugPrint('[VideoPlayerState] pauseDirectly() 调用失败: $e');
-            // 尝试使用传统方法
-            player.state = PlaybackState.paused;
-            _setStatus(PlayerStatus.paused, message: '已暂停');
-          });
+      player.pauseDirectly().then((_) {
+        //debugPrint('[VideoPlayerState] pauseDirectly() 调用成功');
+        _setStatus(PlayerStatus.paused, message: '已暂停');
+      }).catchError((e) {
+        debugPrint('[VideoPlayerState] pauseDirectly() 调用失败: $e');
+        // 尝试使用传统方法
+        player.state = PlaybackState.paused;
+        _setStatus(PlayerStatus.paused, message: '已暂停');
+      });
 
       // Jellyfin同步：如果是Jellyfin流媒体，报告暂停状态
       if (_currentVideoPath != null &&
@@ -456,8 +459,7 @@ extension VideoPlayerStatePlaybackControls on VideoPlayerState {
     debugPrint(
       '[VideoPlayerState] play() called. hasVideo: $hasVideo, _status: $_status, currentMedia: ${player.media}',
     );
-    final bool isWindowsMediaKit =
-        !kIsWeb &&
+    final bool isWindowsMediaKit = !kIsWeb &&
         Platform.isWindows &&
         player.getPlayerKernelName() == 'Media Kit';
     if (isWindowsMediaKit) {
@@ -471,25 +473,22 @@ extension VideoPlayerStatePlaybackControls on VideoPlayerState {
         (_status == PlayerStatus.paused || _status == PlayerStatus.ready)) {
       _lastPlaybackStartMs = DateTime.now().millisecondsSinceEpoch;
       // 使用直接播放方法，确保VideoPlayer插件能够播放视频
-      player
-          .playDirectly()
-          .then((_) {
-            //debugPrint('[VideoPlayerState] playDirectly() 调用成功');
-            // 设置状态
-            _setStatus(PlayerStatus.playing, message: '开始播放');
+      player.playDirectly().then((_) {
+        //debugPrint('[VideoPlayerState] playDirectly() 调用成功');
+        // 设置状态
+        _setStatus(PlayerStatus.playing, message: '开始播放');
 
-            // 播放开始时提交观看记录到弹弹play
-            _submitWatchHistoryToDandanplay();
-          })
-          .catchError((e) {
-            debugPrint('[VideoPlayerState] playDirectly() 调用失败: $e');
-            // 尝试使用传统方法
-            player.state = PlaybackState.playing;
-            _setStatus(PlayerStatus.playing, message: '开始播放');
+        // 播放开始时提交观看记录到弹弹play
+        _submitWatchHistoryToDandanplay();
+      }).catchError((e) {
+        debugPrint('[VideoPlayerState] playDirectly() 调用失败: $e');
+        // 尝试使用传统方法
+        player.state = PlaybackState.playing;
+        _setStatus(PlayerStatus.playing, message: '开始播放');
 
-            // 播放开始时提交观看记录到弹弹play
-            _submitWatchHistoryToDandanplay();
-          });
+        // 播放开始时提交观看记录到弹弹play
+        _submitWatchHistoryToDandanplay();
+      });
 
       // <<< ADDED DEBUG LOG >>>
       debugPrint(

--- a/lib/utils/video_player_state/video_player_state_player_setup.dart
+++ b/lib/utils/video_player_state/video_player_state_player_setup.dart
@@ -141,8 +141,7 @@ extension VideoPlayerStatePlayerSetup on VideoPlayerState {
           !videoPath.startsWith('blob:')) {
         final existingUrl = filePickerService.getWebObjectUrl(videoPath);
         if (existingUrl == null || existingUrl.isEmpty) {
-          final mimeType =
-              filePickerService.getWebMimeType(videoPath) ??
+          final mimeType = filePickerService.getWebMimeType(videoPath) ??
               filePickerService.resolveWebMimeType(fileName: videoPath);
           filePickerService.registerWebObjectUrl(
             videoPath,
@@ -152,8 +151,7 @@ extension VideoPlayerStatePlayerSetup on VideoPlayerState {
         }
       }
 
-      final webMimeType =
-          filePickerService.getWebMimeType(videoPath) ??
+      final webMimeType = filePickerService.getWebMimeType(videoPath) ??
           filePickerService.resolveWebMimeType(fileName: videoPath);
       if (webMimeType != null &&
           webMimeType.isNotEmpty &&
@@ -307,7 +305,8 @@ extension VideoPlayerStatePlayerSetup on VideoPlayerState {
         _setStatus(PlayerStatus.loading, message: '正在初始化播放器...');
         await Future.delayed(const Duration(milliseconds: 150));
       } else {
-        _setStatus(PlayerStatus.idle);
+        // _setStatus(PlayerStatus.idle);
+        // notice:
       }
 
       //debugPrint('3. 设置媒体源...');
@@ -322,9 +321,8 @@ extension VideoPlayerStatePlayerSetup on VideoPlayerState {
       // 针对Jellyfin流媒体，给予更长的初始化时间
       final bool isJellyfinStreaming =
           videoPath.contains('jellyfin://') || videoPath.contains('emby://');
-      final int initializationTimeout = isJellyfinStreaming
-          ? 30000
-          : 15000; // Jellyfin: 30秒, 其他: 15秒
+      final int initializationTimeout =
+          isJellyfinStreaming ? 30000 : 15000; // Jellyfin: 30秒, 其他: 15秒
 
       debugPrint(
         'VideoPlayerState: 播放器初始化超时设置: ${initializationTimeout}ms (${isJellyfinStreaming ? 'Jellyfin流媒体' : '本地文件'})',
@@ -758,8 +756,7 @@ extension VideoPlayerStatePlayerSetup on VideoPlayerState {
       //debugPrint('初始化视频播放器时出错: $e');
       if (kIsWeb) {
         final errorText = e.toString();
-        final bool isUnsupportedFormat =
-            e is PlatformException &&
+        final bool isUnsupportedFormat = e is PlatformException &&
                 (e.code == 'MEDIA_ERR_SRC_NOT_SUPPORTED' ||
                     e.message?.contains('MEDIA_ERR_SRC_NOT_SUPPORTED') ==
                         true ||
@@ -831,8 +828,8 @@ extension VideoPlayerStatePlayerSetup on VideoPlayerState {
       );
       final sharedEpisodeHistories =
           await SharedRemoteHistoryHelper.loadHistoriesBySharedEpisodeId(
-            sharedEpisodeId,
-          );
+        sharedEpisodeId,
+      );
 
       WatchHistoryItem? existingHistory =
           await WatchHistoryManager.getHistoryItem(path);
@@ -874,22 +871,22 @@ extension VideoPlayerStatePlayerSetup on VideoPlayerState {
         if (isJellyfinStream || isEmbyStream || isSharedRemoteStream) {
           final animeNameCandidate =
               SharedRemoteHistoryHelper.firstNonEmptyString([
-                SharedRemoteHistoryHelper.normalizeHistoryName(_animeTitle),
-                SharedRemoteHistoryHelper.normalizeHistoryName(
-                  _initialHistoryItem?.animeName,
-                ),
-                SharedRemoteHistoryHelper.normalizeHistoryName(finalAnimeName),
-              ]);
+            SharedRemoteHistoryHelper.normalizeHistoryName(_animeTitle),
+            SharedRemoteHistoryHelper.normalizeHistoryName(
+              _initialHistoryItem?.animeName,
+            ),
+            SharedRemoteHistoryHelper.normalizeHistoryName(finalAnimeName),
+          ]);
           if (animeNameCandidate != null) {
             finalAnimeName = animeNameCandidate;
           }
 
           final episodeTitleCandidate =
               SharedRemoteHistoryHelper.firstNonEmptyString([
-                _episodeTitle,
-                _initialHistoryItem?.episodeTitle,
-                finalEpisodeTitle,
-              ]);
+            _episodeTitle,
+            _initialHistoryItem?.episodeTitle,
+            finalEpisodeTitle,
+          ]);
           if (episodeTitleCandidate != null) {
             finalEpisodeTitle = episodeTitleCandidate;
           }
@@ -907,20 +904,17 @@ extension VideoPlayerStatePlayerSetup on VideoPlayerState {
           filePath: path,
           animeName: finalAnimeName,
           episodeTitle: finalEpisodeTitle,
-          episodeId:
-              _episodeId ??
+          episodeId: _episodeId ??
               existingHistory.episodeId ??
               _initialHistoryItem?.episodeId,
-          animeId:
-              _animeId ??
+          animeId: _animeId ??
               existingHistory.animeId ??
               _initialHistoryItem?.animeId,
           watchProgress: existingHistory.watchProgress,
           lastPosition: existingHistory.lastPosition,
           duration: existingHistory.duration,
           lastWatchTime: DateTime.now(),
-          thumbnailPath:
-              existingHistory.thumbnailPath ??
+          thumbnailPath: existingHistory.thumbnailPath ??
               _initialHistoryItem?.thumbnailPath,
           isFromScan: existingHistory.isFromScan,
         );
@@ -1007,8 +1001,7 @@ extension VideoPlayerStatePlayerSetup on VideoPlayerState {
           .replaceAll(RegExp(r'[_\.-]'), ' ')
           .trim();
 
-      final initialAnimeName =
-          SharedRemoteHistoryHelper.firstNonEmptyString([
+      final initialAnimeName = SharedRemoteHistoryHelper.firstNonEmptyString([
             SharedRemoteHistoryHelper.normalizeHistoryName(_animeTitle),
             SharedRemoteHistoryHelper.normalizeHistoryName(
               _initialHistoryItem?.animeName,


### PR DESCRIPTION
## Summary

- 修复了设置页面中通用子页面在更改选项时页面闪烁的问题
- 修复了在播放新的视频时 LoadingOverlay 仍然显示上一个视频的封面的问题

## Related Issue

- 无

## What Changed

- 移除了 GeneralPage 中无效的 FutureBuilder (不正确的 FutureBuilder 使用会使得内部的 snapshot 状态不停地改变)
- 在 videoState 为 idle 或 loading 时，清除状态 _resetVideoState；在无 animeId 时，LoadingOverlay 清除对应的封面 url
