### PR TITLE
chore: reduce state analyzer noise

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1311,7 +1311,8 @@ class MainPageState extends State<MainPage>
     _tabChangeNotifier?.addListener(_onTabChangeRequested);
 
     // 添加VideoPlayerState监听
-    final newVideoPlayerState = Provider.of<VideoPlayerState>(context);
+    final newVideoPlayerState =
+        Provider.of<VideoPlayerState>(context, listen: false);
     if (newVideoPlayerState != _videoPlayerState) {
       _videoPlayerState?.removeListener(_manageHotkeys);
       _videoPlayerState = newVideoPlayerState;

--- a/lib/utils/hotkey_service.dart
+++ b/lib/utils/hotkey_service.dart
@@ -788,6 +788,7 @@ class HotkeyService extends ChangeNotifier {
       await hotKeyManager.unregisterAll();
     }
     _registeredHotkeys.clear();
+    super.dispose();
   }
 }
 

--- a/lib/utils/video_player_state.dart
+++ b/lib/utils/video_player_state.dart
@@ -233,6 +233,11 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
   late Player player; // 改为 late 修饰，使用 Player.create() 方法创建
   BuildContext? _context;
   bool _isDisposed = false;
+
+  void _notifyListeners() {
+    notifyListeners();
+  }
+
   StreamSubscription? _playerKernelChangeSubscription; // 播放器内核切换事件订阅
   StreamSubscription? _danmakuKernelChangeSubscription; // 弹幕内核切换事件订阅
   PlayerStatus _status = PlayerStatus.idle;

--- a/lib/utils/video_player_state/video_player_state_danmaku.dart
+++ b/lib/utils/video_player_state/video_player_state_danmaku.dart
@@ -226,7 +226,7 @@ extension VideoPlayerStateDanmaku on VideoPlayerState {
       _danmakuList.clear();
       danmakuController?.clearDanmaku();
       if (canContinue()) {
-        notifyListeners();
+        _notifyListeners();
       } else {
         return;
       }
@@ -252,7 +252,7 @@ extension VideoPlayerStateDanmaku on VideoPlayerState {
         // 设置最终加载阶段标志，减少动画性能消耗
         _isInFinalLoadingPhase = true;
         if (canContinue()) {
-          notifyListeners();
+          _notifyListeners();
         } else {
           return;
         }
@@ -285,7 +285,7 @@ extension VideoPlayerStateDanmaku on VideoPlayerState {
         // await _prebuildGPUDanmakuCharsetIfNeeded();
 
         if (canContinue()) {
-          notifyListeners();
+          _notifyListeners();
         }
         return;
       }
@@ -297,7 +297,7 @@ extension VideoPlayerStateDanmaku on VideoPlayerState {
       // 设置最终加载阶段标志，减少动画性能消耗
       _isInFinalLoadingPhase = true;
       if (canContinue()) {
-        notifyListeners();
+        _notifyListeners();
       } else {
         return;
       }
@@ -346,7 +346,7 @@ extension VideoPlayerStateDanmaku on VideoPlayerState {
         _setStatus(PlayerStatus.playing,
             message: '弹幕加载完成 (${danmakuData['count']}条)');
         if (canContinue()) {
-          notifyListeners();
+          _notifyListeners();
         }
       } else {
         debugPrint('网络返回的弹幕数据无效');
@@ -443,7 +443,7 @@ extension VideoPlayerStateDanmaku on VideoPlayerState {
         } else {
           _addStatusMessage('已自动加载本地弹幕 (${comments.length}条)');
         }
-        notifyListeners();
+        _notifyListeners();
       }
     } catch (e, st) {
       if (!canContinue()) return;
@@ -494,7 +494,7 @@ extension VideoPlayerStateDanmaku on VideoPlayerState {
     _danmakuOverlayKey = 'danmaku_${DateTime.now().millisecondsSinceEpoch}';
 
     debugPrint('弹幕轨道合并及过滤完成，显示${_danmakuList.length}条，总计${mergedList.length}条');
-    notifyListeners(); // 确保通知UI更新
+    _notifyListeners(); // 确保通知UI更新
   }
 
   List<Map<String, dynamic>> collectDanmakuForExport({
@@ -956,7 +956,7 @@ extension VideoPlayerStateDanmaku on VideoPlayerState {
     if (_danmakuTracks.containsKey(trackId)) {
       _danmakuTrackEnabled[trackId] = enabled;
       _updateMergedDanmakuList();
-      notifyListeners();
+      _notifyListeners();
       debugPrint('弹幕轨道 $trackId ${enabled ? "启用" : "禁用"}');
     }
   }
@@ -972,7 +972,7 @@ extension VideoPlayerStateDanmaku on VideoPlayerState {
       _danmakuTracks.remove(trackId);
       _danmakuTrackEnabled.remove(trackId);
       _updateMergedDanmakuList();
-      notifyListeners();
+      _notifyListeners();
       debugPrint('删除弹幕轨道: $trackId');
     }
   }
@@ -980,7 +980,7 @@ extension VideoPlayerStateDanmaku on VideoPlayerState {
   // 在设置视频时长时更新状态
   void setVideoDuration(Duration duration) {
     _videoDuration = duration;
-    notifyListeners();
+    _notifyListeners();
   }
 
   // 更新观看记录
@@ -1262,7 +1262,7 @@ extension VideoPlayerStateDanmaku on VideoPlayerState {
         final timeB = (b['time'] as double?) ?? 0.0;
         return timeA.compareTo(timeB);
       });
-      notifyListeners();
+      _notifyListeners();
       debugPrint('已添加新弹幕到列表: ${danmaku['content']}');
     }
   }
@@ -1415,6 +1415,6 @@ extension VideoPlayerStateDanmaku on VideoPlayerState {
 
     _applyTimelineDanmakuTrackForCurrentVideo();
     _updateMergedDanmakuList();
-    notifyListeners();
+    _notifyListeners();
   }
 }

--- a/lib/utils/video_player_state/video_player_state_initialization.dart
+++ b/lib/utils/video_player_state/video_player_state_initialization.dart
@@ -122,7 +122,7 @@ extension VideoPlayerStateInitialization on VideoPlayerState {
       //debugPrint("Failed to get initial screen brightness: $e");
       // Keep default _currentBrightness if error occurs
     }
-    notifyListeners();
+    _notifyListeners();
   }
 
   // Load initial system volume (placeholder)
@@ -157,7 +157,7 @@ extension VideoPlayerStateInitialization on VideoPlayerState {
       _currentVolume = 0.5; // Fallback
       _initialDragVolume = _currentVolume;
     }
-    notifyListeners();
+    _notifyListeners();
   }
 
   void startBrightnessDrag() {
@@ -190,7 +190,7 @@ extension VideoPlayerStateInitialization on VideoPlayerState {
       // 更新 _initialDragBrightness 为当前成功设置的亮度，以确保下次拖拽的起点是连贯的
       _initialDragBrightness = newBrightness;
       _showBrightnessIndicator();
-      notifyListeners();
+      _notifyListeners();
       ////debugPrint("[VideoPlayerState] Brightness updated. Current: $_currentBrightness, InitialDrag: $_initialDragBrightness");
     } catch (e) {
       //debugPrint("Failed to set screen brightness: $e");
@@ -256,13 +256,13 @@ extension VideoPlayerStateInitialization on VideoPlayerState {
       Overlay.of(_context!).insert(_brightnessOverlayEntry!);
     }
 
-    notifyListeners();
+    _notifyListeners();
 
     _brightnessIndicatorTimer?.cancel();
     _brightnessIndicatorTimer = Timer(const Duration(seconds: 2), () {
       _hideBrightnessIndicator();
     });
-    // The final notifyListeners() from the original method is already covered above.
+    // The final _notifyListeners() from the original method is already covered above.
   }
 
   void _hideBrightnessIndicator() {
@@ -271,7 +271,7 @@ extension VideoPlayerStateInitialization on VideoPlayerState {
 
     if (_isBrightnessIndicatorVisible) {
       _isBrightnessIndicatorVisible = false;
-      notifyListeners();
+      _notifyListeners();
 
       Future.delayed(const Duration(milliseconds: 150), () {
         if (_brightnessOverlayEntry != null) {
@@ -338,7 +338,7 @@ extension VideoPlayerStateInitialization on VideoPlayerState {
       );
       Overlay.of(_context!).insert(_volumeOverlayEntry!);
     }
-    notifyListeners();
+    _notifyListeners();
 
     _volumeIndicatorTimer?.cancel();
     _volumeIndicatorTimer = Timer(const Duration(seconds: 2), () {
@@ -352,7 +352,7 @@ extension VideoPlayerStateInitialization on VideoPlayerState {
 
     if (_isVolumeIndicatorVisible) {
       _isVolumeIndicatorVisible = false;
-      notifyListeners();
+      _notifyListeners();
 
       Future.delayed(const Duration(milliseconds: 150), () {
         if (_volumeOverlayEntry != null) {

--- a/lib/utils/video_player_state/video_player_state_metadata.dart
+++ b/lib/utils/video_player_state/video_player_state_metadata.dart
@@ -4,7 +4,7 @@ extension VideoPlayerStateMetadata on VideoPlayerState {
   // 添加setter方法以支持手动匹配后立即更新标题
   void setAnimeTitle(String? title) {
     _animeTitle = title;
-    notifyListeners();
+    _notifyListeners();
 
     // 立即更新历史记录，确保历史记录卡片显示正确的动画名称
     _updateHistoryWithNewTitles();
@@ -12,7 +12,7 @@ extension VideoPlayerStateMetadata on VideoPlayerState {
 
   void setEpisodeTitle(String? title) {
     _episodeTitle = title;
-    notifyListeners();
+    _notifyListeners();
 
     // 立即更新历史记录，确保历史记录卡片显示正确的动画名称
     _updateHistoryWithNewTitles();
@@ -96,13 +96,13 @@ extension VideoPlayerStateMetadata on VideoPlayerState {
       }
 
       final prefs = await SharedPreferences.getInstance();
-      final autoMatchEnabled = 
+      final autoMatchEnabled =
           prefs.getBool(SettingsKeys.autoMatchDanmakuOnPlay) ?? true;
       if (!autoMatchEnabled) {
         _danmakuList = [];
         _danmakuTracks.clear();
         _danmakuTrackEnabled.clear();
-        final handled = 
+        final handled =
             await _tryManualMatchDanmaku(videoPath, initialFileName: null);
         if (!handled) {
           _setStatus(PlayerStatus.recognizing, message: '已关闭自动匹配弹幕，跳过弹幕');
@@ -159,7 +159,7 @@ extension VideoPlayerStateMetadata on VideoPlayerState {
 
                   // 设置最终加载阶段标志，减少动画性能消耗
                   _isInFinalLoadingPhase = true;
-                  notifyListeners();
+                  _notifyListeners();
 
                   _danmakuList = await compute(
                     parseDanmakuListInBackground,
@@ -185,7 +185,7 @@ extension VideoPlayerStateMetadata on VideoPlayerState {
                   };
                   _danmakuTrackEnabled['dandanplay'] = true;
 
-                  notifyListeners();
+                  _notifyListeners();
                   _setStatus(PlayerStatus.recognizing,
                       message: '从缓存加载弹幕完成 (${_danmakuList.length}条)');
                   return; // Return early after loading from cache
@@ -202,7 +202,7 @@ extension VideoPlayerStateMetadata on VideoPlayerState {
 
                 // 设置最终加载阶段标志，减少动画性能消耗
                 _isInFinalLoadingPhase = true;
-                notifyListeners();
+                _notifyListeners();
 
                 _setStatus(PlayerStatus.recognizing, message: '正在解析网络弹幕...');
                 if (danmakuData['comments'] != null &&
@@ -237,7 +237,7 @@ extension VideoPlayerStateMetadata on VideoPlayerState {
                   _danmakuTrackEnabled.clear();
                 }
 
-                notifyListeners();
+                _notifyListeners();
                 _setStatus(PlayerStatus.recognizing,
                     message: '弹幕加载完成 (${_danmakuList.length}条)');
 
@@ -313,9 +313,7 @@ extension VideoPlayerStateMetadata on VideoPlayerState {
         initialVideoTitle: initialKeyword,
       );
 
-      if (result != null &&
-          !_isDisposed &&
-          _currentVideoPath == videoPath) {
+      if (result != null && !_isDisposed && _currentVideoPath == videoPath) {
         final episodeIdStr = result['episodeId']?.toString() ?? '';
         final animeIdStr = result['animeId']?.toString() ?? '';
 
@@ -445,7 +443,7 @@ extension VideoPlayerStateMetadata on VideoPlayerState {
       // 直接设置状态和消息，但不改变PlayerStatus本身
       _setStatus(_status, message: message);
 
-      notifyListeners();
+      _notifyListeners();
 
       // 创建更新后的观看记录
       final updatedHistory = WatchHistoryItem(
@@ -584,7 +582,8 @@ extension VideoPlayerStateMetadata on VideoPlayerState {
         // 尝试刷新已显示的缩略图
         _triggerImageCacheRefresh(thumbnailPath);
 
-        if (SharedRemoteHistoryHelper.isSharedRemoteStreamPath(_currentVideoPath!)) {
+        if (SharedRemoteHistoryHelper.isSharedRemoteStreamPath(
+            _currentVideoPath!)) {
           unawaited(
             SharedRemotePlaybackSyncService.instance.syncThumbnail(
               videoUrl: _currentVideoPath!,

--- a/lib/utils/video_player_state/video_player_state_navigation.dart
+++ b/lib/utils/video_player_state/video_player_state_navigation.dart
@@ -613,7 +613,7 @@ extension VideoPlayerStateNavigation on VideoPlayerState {
 
             if (shouldUiNotify) {
               _lastUiNotifyMs = nowTime;
-              notifyListeners();
+              _notifyListeners();
             }
           } else {
             // 错误处理逻辑（原来在10秒定时器中）
@@ -743,7 +743,7 @@ extension VideoPlayerStateNavigation on VideoPlayerState {
           }
           if (shouldUiNotify) {
             _lastUiNotifyMs = nowTime;
-            notifyListeners();
+            _notifyListeners();
           }
         }
       }

--- a/lib/utils/video_player_state/video_player_state_playback_controls.dart
+++ b/lib/utils/video_player_state/video_player_state_playback_controls.dart
@@ -53,7 +53,7 @@ extension VideoPlayerStatePlaybackControls on VideoPlayerState {
       }
       await _restoreSystemUiOverlayStyleIfNeeded();
 
-      notifyListeners();
+      _notifyListeners();
     }
   }
 
@@ -203,7 +203,7 @@ extension VideoPlayerStatePlaybackControls on VideoPlayerState {
         //debugPrint("Error disabling wakelock: $e");
       }
 
-      notifyListeners();
+      _notifyListeners();
       _logMacOSHdrResetTrace(
         'resetPlayer notifyListeners path=$_currentVideoPath status=$_status hasVideo=$hasVideo playerState=${player.state}',
       );
@@ -265,7 +265,7 @@ extension VideoPlayerStatePlaybackControls on VideoPlayerState {
 
       // 延迟通知UI刷新，给足够时间处理状态变更
       Future.microtask(() {
-        notifyListeners();
+        _notifyListeners();
       });
     }
 
@@ -299,7 +299,7 @@ extension VideoPlayerStatePlaybackControls on VideoPlayerState {
       // 在播放开始后一小段时间重置最终加载阶段标志
       Future.delayed(const Duration(milliseconds: 200), () {
         _isInFinalLoadingPhase = false;
-        notifyListeners();
+        _notifyListeners();
       });
     } else {
       // Disable for any other status (paused, error, idle, disposed, ready, loading, recognizing)
@@ -317,7 +317,7 @@ extension VideoPlayerStatePlaybackControls on VideoPlayerState {
       });
     }
 
-    notifyListeners();
+    _notifyListeners();
   }
 
   void togglePlayPause() {
@@ -380,7 +380,7 @@ extension VideoPlayerStatePlaybackControls on VideoPlayerState {
       _progress = 0.0;
       _bufferedPositionMs = 0;
       _playbackTimeMs.value = 0;
-      notifyListeners();
+      _notifyListeners();
       player.seek(position: 0);
       if (_status != PlayerStatus.playing) {
         play();
@@ -676,7 +676,7 @@ extension VideoPlayerStatePlaybackControls on VideoPlayerState {
       if (_duration.inMilliseconds > 0) {
         _progress = clampedPosition.inMilliseconds / _duration.inMilliseconds;
       }
-      notifyListeners();
+      _notifyListeners();
 
       // 更新播放器位置
       player.seek(position: clampedPosition.inMilliseconds);
@@ -788,12 +788,12 @@ extension VideoPlayerStatePlaybackControls on VideoPlayerState {
     } else {
       _autoHideTimer?.cancel();
     }
-    notifyListeners();
+    _notifyListeners();
   }
 
   void setShowRightMenu(bool value) {
     _showRightMenu = value;
-    notifyListeners();
+    _notifyListeners();
   }
 
   void setControlsVisibilityLocked(bool value) {
@@ -835,7 +835,7 @@ extension VideoPlayerStatePlaybackControls on VideoPlayerState {
       });
     }
 
-    notifyListeners();
+    _notifyListeners();
   }
 
   void _showHoverSettingsMenu() {
@@ -859,7 +859,7 @@ extension VideoPlayerStatePlaybackControls on VideoPlayerState {
     _hoverSettingsMenuOverlay?.remove();
     _hoverSettingsMenuOverlay = null;
     _isRightEdgeHovered = false;
-    notifyListeners();
+    _notifyListeners();
   }
 
   Widget _buildHoverSettingsMenu(BuildContext context) {
@@ -902,7 +902,7 @@ extension VideoPlayerStatePlaybackControls on VideoPlayerState {
         }
       }
 
-      notifyListeners();
+      _notifyListeners();
     } finally {
       _isFullscreenTransitioning = false;
     }
@@ -924,19 +924,19 @@ extension VideoPlayerStatePlaybackControls on VideoPlayerState {
   // 更新状态消息的方法
   void _updateStatusMessages(List<String> messages) {
     _statusMessages = messages;
-    notifyListeners();
+    _notifyListeners();
   }
 
   // 添加单个状态消息的方法
   void _addStatusMessage(String message) {
     _statusMessages.add(message);
-    notifyListeners();
+    _notifyListeners();
   }
 
   // 清除所有状态消息的方法
   void _clearStatusMessages() {
     _statusMessages.clear();
-    notifyListeners();
+    _notifyListeners();
   }
 
   // Volume Drag Methods
@@ -966,7 +966,7 @@ extension VideoPlayerStatePlaybackControls on VideoPlayerState {
     _initialDragVolume = newVolume;
     _showVolumeIndicator();
     _scheduleVolumePersistence();
-    notifyListeners();
+    _notifyListeners();
 
     try {
       if (_useSystemVolume) {
@@ -1000,7 +1000,7 @@ extension VideoPlayerStatePlaybackControls on VideoPlayerState {
       _initialDragVolume = newVolume;
       _showVolumeIndicator();
       _scheduleVolumePersistence(immediate: true);
-      notifyListeners();
+      _notifyListeners();
 
       if (_useSystemVolume) {
         _ensurePlayerVolumeMatchesPlatformPolicy();
@@ -1030,7 +1030,7 @@ extension VideoPlayerStatePlaybackControls on VideoPlayerState {
       _initialDragVolume = newVolume;
       _showVolumeIndicator();
       _scheduleVolumePersistence(immediate: true);
-      notifyListeners();
+      _notifyListeners();
 
       if (_useSystemVolume) {
         _ensurePlayerVolumeMatchesPlatformPolicy();
@@ -1060,7 +1060,7 @@ extension VideoPlayerStatePlaybackControls on VideoPlayerState {
     _dragSeekTargetPosition = _position;
     _showSeekIndicator(); // <<< CALL ADDED
     //debugPrint("Seek drag started. Start position: $_dragSeekStartPosition");
-    notifyListeners();
+    _notifyListeners();
   }
 
   void updateSeekDrag(double deltaDx, BuildContext context) {
@@ -1088,7 +1088,7 @@ extension VideoPlayerStatePlaybackControls on VideoPlayerState {
     // TODO: Update seek indicator UI with _dragSeekTargetPosition
     // For now, just print.
     // //debugPrint("Seek drag update. Target: $_dragSeekTargetPosition, DeltaDx: $deltaDx, AccumulatedDx: $_accumulatedDragDx");
-    notifyListeners(); // To update UI displaying _dragSeekTargetPosition
+    _notifyListeners(); // To update UI displaying _dragSeekTargetPosition
   }
 
   void endSeekDrag() {
@@ -1100,7 +1100,7 @@ extension VideoPlayerStatePlaybackControls on VideoPlayerState {
     _accumulatedDragDx = 0.0;
     _hideSeekIndicator(); // <<< CALL ADDED
     //debugPrint("Seek drag ended. Seeking to: $_dragSeekTargetPosition");
-    notifyListeners();
+    _notifyListeners();
   }
 
   // Seek Indicator Overlay Methods
@@ -1137,7 +1137,7 @@ extension VideoPlayerStatePlaybackControls on VideoPlayerState {
       );
       Overlay.of(_context!).insert(_seekOverlayEntry!);
     }
-    notifyListeners(); // To trigger opacity animation in SeekIndicator
+    _notifyListeners(); // To trigger opacity animation in SeekIndicator
 
     // Optional: Timer to auto-hide if drag ends abruptly or no more updates
     _seekIndicatorTimer?.cancel();
@@ -1152,7 +1152,7 @@ extension VideoPlayerStatePlaybackControls on VideoPlayerState {
 
     if (_isSeekIndicatorVisible) {
       _isSeekIndicatorVisible = false;
-      notifyListeners(); // Trigger fade-out animation
+      _notifyListeners(); // Trigger fade-out animation
 
       // Wait for fade-out animation to complete before removing
       Future.delayed(const Duration(milliseconds: 200), () {

--- a/lib/utils/video_player_state/video_player_state_player_setup.dart
+++ b/lib/utils/video_player_state/video_player_state_player_setup.dart
@@ -62,19 +62,19 @@ extension VideoPlayerStatePlayerSetup on VideoPlayerState {
     if (isNetworkUrl) {
       debugPrint('检测到流媒体URL: $videoPath');
       _statusMessages.add('正在准备流媒体播放...');
-      notifyListeners();
+      _notifyListeners();
     } else if (isJellyfinStream) {
       final infoUrl = playbackSession?.streamUrl ?? actualPlayUrl;
       debugPrint(
         '检测到Jellyfin流媒体: videoPath=$videoPath, actualPlayUrl=$infoUrl',
       );
       _statusMessages.add('正在准备Jellyfin流媒体播放...');
-      notifyListeners();
+      _notifyListeners();
     } else if (isEmbyStream) {
       final infoUrl = playbackSession?.streamUrl ?? actualPlayUrl;
       debugPrint('检测到Emby流媒体: videoPath=$videoPath, actualPlayUrl=$infoUrl');
       _statusMessages.add('正在准备Emby流媒体播放...');
-      notifyListeners();
+      _notifyListeners();
     }
 
     if (!kIsWeb && !isNetworkUrl && !isJellyfinStream && !isEmbyStream) {
@@ -400,7 +400,7 @@ extension VideoPlayerStatePlayerSetup on VideoPlayerState {
                   debugPrint(
                     'VideoPlayerState: 从snapshot设置视频宽高比: $_aspectRatio (${frame.width}x${frame.height})',
                   );
-                  notifyListeners(); // 通知UI更新
+                  _notifyListeners(); // 通知UI更新
                 }
               });
             } catch (e) {
@@ -648,7 +648,7 @@ extension VideoPlayerStatePlayerSetup on VideoPlayerState {
 
       // 设置进入最终加载阶段，以优化动画性能
       _isInFinalLoadingPhase = true;
-      notifyListeners();
+      _notifyListeners();
 
       //debugPrint('11. 设置准备就绪状态...');
       // 设置状态为准备就绪

--- a/lib/utils/video_player_state/video_player_state_preferences.dart
+++ b/lib/utils/video_player_state/video_player_state_preferences.dart
@@ -9,7 +9,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
 
     // 添加错误消息
     _statusMessages = ['播放出错，正在尝试恢复...'];
-    notifyListeners();
+    _notifyListeners();
 
     // 尝试恢复播放
     _tryRecoverFromError();
@@ -57,7 +57,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
         prefs.getInt(_minimalProgressBarColorKey) ?? 0xFFFF7274;
     _showDanmakuDensityChart =
         prefs.getBool(_showDanmakuDensityChartKey) ?? false;
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> _loadPlaybackEndAction() async {
@@ -70,7 +70,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
       action == PlaybackEndAction.autoNext,
     );
     if (changed) {
-      notifyListeners();
+      _notifyListeners();
     }
   }
 
@@ -87,7 +87,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     if (action != PlaybackEndAction.autoNext) {
       AutoNextEpisodeService.instance.cancelAutoNext();
     }
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> _loadAutoNextCountdownSeconds() async {
@@ -104,7 +104,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     _autoNextCountdownSeconds = resolved;
     AutoNextEpisodeService.instance.updateCountdownDuration(resolved);
     if (changed) {
-      notifyListeners();
+      _notifyListeners();
     }
   }
 
@@ -122,7 +122,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     await prefs.setInt(_autoNextCountdownSecondsKey, resolved);
     _autoNextCountdownSeconds = resolved;
     AutoNextEpisodeService.instance.updateCountdownDuration(resolved);
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> _loadPauseOnBackgroundSetting() async {
@@ -131,7 +131,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     final bool resolvedValue = storedValue ?? globals.isMobilePlatform;
     if (_pauseOnBackground != resolvedValue) {
       _pauseOnBackground = resolvedValue;
-      notifyListeners();
+      _notifyListeners();
     } else {
       _pauseOnBackground = resolvedValue;
     }
@@ -144,7 +144,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_pauseOnBackgroundKey, enabled);
     _pauseOnBackground = enabled;
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> _loadDesktopHoverSettingsMenuEnabled() async {
@@ -153,7 +153,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
         prefs.getBool(_desktopHoverSettingsMenuEnabledKey) ?? false;
     if (_desktopHoverSettingsMenuEnabled != resolved) {
       _desktopHoverSettingsMenuEnabled = resolved;
-      notifyListeners();
+      _notifyListeners();
     } else {
       _desktopHoverSettingsMenuEnabled = resolved;
     }
@@ -169,7 +169,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     if (!enabled) {
       setShowRightMenu(false);
     }
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> _loadInstantHidePlayerUiEnabled() async {
@@ -177,7 +177,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     final resolved = prefs.getBool(_instantHidePlayerUiEnabledKey) ?? false;
     if (_instantHidePlayerUiEnabled != resolved) {
       _instantHidePlayerUiEnabled = resolved;
-      notifyListeners();
+      _notifyListeners();
     } else {
       _instantHidePlayerUiEnabled = resolved;
     }
@@ -190,7 +190,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_instantHidePlayerUiEnabledKey, enabled);
     _instantHidePlayerUiEnabled = enabled;
-    notifyListeners();
+    _notifyListeners();
   }
 
   // 保存最小化进度条启用状态
@@ -198,7 +198,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     _minimalProgressBarEnabled = enabled;
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_minimalProgressBarEnabledKey, enabled);
-    notifyListeners();
+    _notifyListeners();
   }
 
   // 保存最小化进度条颜色
@@ -206,7 +206,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     _minimalProgressBarColor = color;
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(_minimalProgressBarColorKey, color);
-    notifyListeners();
+    _notifyListeners();
   }
 
   // 设置弹幕密度图显示状态
@@ -214,14 +214,14 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     _showDanmakuDensityChart = show;
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_showDanmakuDensityChartKey, show);
-    notifyListeners();
+    _notifyListeners();
   }
 
   // 加载弹幕不透明度
   Future<void> _loadDanmakuOpacity() async {
     final prefs = await SharedPreferences.getInstance();
     _danmakuOpacity = prefs.getDouble(_danmakuOpacityKey) ?? 1.0;
-    notifyListeners();
+    _notifyListeners();
   }
 
   // 保存弹幕不透明度
@@ -229,7 +229,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     _danmakuOpacity = opacity;
     final prefs = await SharedPreferences.getInstance();
     await prefs.setDouble(_danmakuOpacityKey, opacity);
-    notifyListeners();
+    _notifyListeners();
   }
 
   // 获取映射后的弹幕不透明度
@@ -242,7 +242,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
   Future<void> _loadDanmakuVisible() async {
     final prefs = await SharedPreferences.getInstance();
     _danmakuVisible = prefs.getBool(_danmakuVisibleKey) ?? true;
-    notifyListeners();
+    _notifyListeners();
   }
 
   void setDanmakuVisible(bool visible) async {
@@ -250,7 +250,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
       _danmakuVisible = visible;
       final prefs = await SharedPreferences.getInstance();
       await prefs.setBool(_danmakuVisibleKey, visible);
-      notifyListeners();
+      _notifyListeners();
     }
   }
 
@@ -262,7 +262,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
   Future<void> _loadMergeDanmaku() async {
     final prefs = await SharedPreferences.getInstance();
     _mergeDanmaku = prefs.getBool(_mergeDanmakuKey) ?? false;
-    notifyListeners();
+    _notifyListeners();
   }
 
   // 设置弹幕合并
@@ -271,7 +271,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
       _mergeDanmaku = merge;
       final prefs = await SharedPreferences.getInstance();
       await prefs.setBool(_mergeDanmakuKey, merge);
-      notifyListeners();
+      _notifyListeners();
     }
   }
 
@@ -284,7 +284,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
   Future<void> _loadDanmakuStacking() async {
     final prefs = await SharedPreferences.getInstance();
     _danmakuStacking = prefs.getBool(_danmakuStackingKey) ?? false;
-    notifyListeners();
+    _notifyListeners();
   }
 
   // 加载弹幕随机染色设置
@@ -292,7 +292,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     final prefs = await SharedPreferences.getInstance();
     _danmakuRandomColorEnabled =
         prefs.getBool(_danmakuRandomColorEnabledKey) ?? false;
-    notifyListeners();
+    _notifyListeners();
   }
 
   // 加载时间轴告知弹幕轨道开关
@@ -300,7 +300,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     final prefs = await SharedPreferences.getInstance();
     _isTimelineDanmakuEnabled =
         prefs.getBool(_timelineDanmakuEnabledKey) ?? true;
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> _loadHardwareDecoderSetting() async {
@@ -311,7 +311,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     _useHardwareDecoder = resolved;
     await applyHardwareDecoderPreference();
     if (changed) {
-      notifyListeners();
+      _notifyListeners();
     }
   }
 
@@ -321,7 +321,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
       _danmakuStacking = stacking;
       final prefs = await SharedPreferences.getInstance();
       await prefs.setBool(_danmakuStackingKey, stacking);
-      notifyListeners();
+      _notifyListeners();
     }
   }
 
@@ -346,13 +346,13 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     _statusMessages.clear(); // 清除之前的状态消息
     _setStatus(PlayerStatus.loading, message: message);
     // 确保状态变更立即生效
-    notifyListeners();
+    _notifyListeners();
   }
 
   // 更新解码器设置，代理到解码器管理器
   void updateDecoders(List<String> decoders) {
     _decoderManager.updateDecoders(decoders);
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> setHardwareDecoderEnabled(bool enabled) async {
@@ -363,7 +363,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_useHardwareDecoderKey, enabled);
     await applyHardwareDecoderPreference();
-    notifyListeners();
+    _notifyListeners();
   }
 
   String _resolveMpvHwdecValue() {
@@ -397,7 +397,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     ); // 默认1倍速
     _speedBoostRate = prefs.getDouble(_speedBoostRateKey) ?? 2.0; // 默认2倍速
     _normalPlaybackRate = 1.0; // 始终重置为1.0
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> _loadPrecacheBufferSize() async {
@@ -412,7 +412,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
             )
             .toInt();
     _precacheBufferSizeMb = resolved;
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> _loadPrecacheBufferDuration() async {
@@ -421,7 +421,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     final resolved =
         (storedValue ?? _precacheBufferDurationSeconds).clamp(1, 120).toInt();
     _precacheBufferDurationSeconds = resolved;
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> setPrecacheBufferSizeMb(int value) async {
@@ -436,7 +436,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     }
     _precacheBufferSizeMb = resolved;
     await PlayerFactory.savePrecacheBufferSizeMb(resolved);
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> setPrecacheBufferDurationSeconds(int value) async {
@@ -448,7 +448,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(_precacheBufferDurationSecondsKey, resolved);
     await applyPrecacheBufferSettings();
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> applyPrecacheBufferSettings() async {
@@ -478,7 +478,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
       player.setPlaybackRate(resolved);
       debugPrint('设置播放速度: ${resolved}x');
     }
-    notifyListeners();
+    _notifyListeners();
   }
 
   // 设置长按倍速播放的倍率
@@ -486,7 +486,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     _speedBoostRate = rate;
     final prefs = await SharedPreferences.getInstance();
     await prefs.setDouble(_speedBoostRateKey, rate);
-    notifyListeners();
+    _notifyListeners();
   }
 
   // 开始倍速播放（长按开始）
@@ -501,7 +501,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     player.setPlaybackRate(_speedBoostRate);
     debugPrint('开始长按倍速播放: ${_speedBoostRate}x (之前: ${_normalPlaybackRate}x)');
 
-    notifyListeners();
+    _notifyListeners();
   }
 
   // 结束倍速播放（长按结束）
@@ -513,7 +513,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     player.setPlaybackRate(_normalPlaybackRate);
     debugPrint('结束长按倍速播放，恢复到: ${_normalPlaybackRate}x');
 
-    notifyListeners();
+    _notifyListeners();
   }
 
   // 切换播放速度按钮功能
@@ -557,7 +557,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
         );
       }
     }
-    notifyListeners();
+    _notifyListeners();
   }
 
   // 保存快进快退时间设置
@@ -565,14 +565,14 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     _seekStepSeconds = clampSeekStepToCurrentVideoDuration(seconds);
     final prefs = await SharedPreferences.getInstance();
     await prefs.setDouble(_seekStepSecondsKey, _seekStepSeconds);
-    notifyListeners();
+    _notifyListeners();
   }
 
   // 加载跳过时间设置
   Future<void> _loadSkipSeconds() async {
     final prefs = await SharedPreferences.getInstance();
     _skipSeconds = prefs.getInt(_skipSecondsKey) ?? 90; // 默认90秒
-    notifyListeners();
+    _notifyListeners();
   }
 
   // 保存跳过时间设置
@@ -580,7 +580,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     _skipSeconds = seconds;
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(_skipSecondsKey, seconds);
-    notifyListeners();
+    _notifyListeners();
   }
 
   bool _readCompatibleBool(
@@ -676,7 +676,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     );
     if (_doubleResolutionPlaybackEnabled != resolved) {
       _doubleResolutionPlaybackEnabled = resolved;
-      notifyListeners();
+      _notifyListeners();
     } else {
       _doubleResolutionPlaybackEnabled = resolved;
     }
@@ -701,7 +701,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     if (!hasVideo) {
       await applyAnime4KProfileToCurrentPlayer();
     }
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> _loadAnime4KProfile() async {
@@ -723,7 +723,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     }
 
     await applyAnime4KProfileToCurrentPlayer();
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> setAnime4KProfile(Anime4KProfile profile) async {
@@ -751,7 +751,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     if (!hasVideo) {
       await applyAnime4KProfileToCurrentPlayer();
     }
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> _loadCrtProfile() async {
@@ -773,7 +773,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     }
 
     await applyAnime4KProfileToCurrentPlayer();
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> setCrtProfile(CrtProfile profile) async {
@@ -796,7 +796,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     }
 
     await applyAnime4KProfileToCurrentPlayer();
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> applyAnime4KProfileToCurrentPlayer() async {
@@ -1184,7 +1184,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
   Future<void> _loadDanmakuFontSize() async {
     final prefs = await SharedPreferences.getInstance();
     _danmakuFontSize = prefs.getDouble(_danmakuFontSizeKey) ?? 0.0;
-    notifyListeners();
+    _notifyListeners();
   }
 
   // 设置弹幕字体大小
@@ -1193,7 +1193,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
       _danmakuFontSize = fontSize;
       final prefs = await SharedPreferences.getInstance();
       await prefs.setDouble(_danmakuFontSizeKey, fontSize);
-      notifyListeners();
+      _notifyListeners();
     }
   }
 
@@ -1340,7 +1340,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     }
 
     if (changed) {
-      notifyListeners();
+      _notifyListeners();
     }
   }
 
@@ -1354,7 +1354,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_danmakuFontFilePathKey, '');
     await prefs.setString(_danmakuFontFamilyKey, normalized);
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<bool> importDanmakuFontFile(String sourcePath) async {
@@ -1379,7 +1379,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_danmakuFontFilePathKey, persistedPath);
     await prefs.setString(_danmakuFontFamilyKey, runtimeFamily);
-    notifyListeners();
+    _notifyListeners();
     return true;
   }
 
@@ -1392,7 +1392,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_danmakuFontFilePathKey, '');
     await prefs.setString(_danmakuFontFamilyKey, '');
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> setDanmakuOutlineStyle(DanmakuOutlineStyle style) async {
@@ -1402,7 +1402,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     _danmakuOutlineStyle = style;
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(_danmakuOutlineStyleKey, style.index);
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> setDanmakuShadowStyle(DanmakuShadowStyle style) async {
@@ -1412,7 +1412,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     _danmakuShadowStyle = style;
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(_danmakuShadowStyleKey, style.index);
-    notifyListeners();
+    _notifyListeners();
   }
 
   // 获取实际使用的弹幕字体大小
@@ -1557,7 +1557,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
             VideoPlayerState.defaultSubtitleOverrideMode.index)
         .clamp(0, SubtitleStyleOverrideMode.values.length - 1)];
     await applySubtitleStylePreference();
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> setSubtitleScale(double scale) async {
@@ -1569,7 +1569,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setDouble(_subtitleScaleKey, resolved);
     await applySubtitleStylePreference();
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> setSubtitleDelaySeconds(double seconds) async {
@@ -1580,7 +1580,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setDouble(_subtitleDelayKey, seconds);
     await applySubtitleStylePreference();
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> setSubtitlePosition(double position) async {
@@ -1592,7 +1592,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setDouble(_subtitlePositionKey, resolved);
     await applySubtitleStylePreference();
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> setSubtitleAlignX(SubtitleAlignX align) async {
@@ -1601,7 +1601,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(_subtitleAlignXKey, align.index);
     await applySubtitleStylePreference();
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> setSubtitleAlignY(SubtitleAlignY align) async {
@@ -1610,7 +1610,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(_subtitleAlignYKey, align.index);
     await applySubtitleStylePreference();
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> setSubtitleMarginX(double value) async {
@@ -1619,7 +1619,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setDouble(_subtitleMarginXKey, value);
     await applySubtitleStylePreference();
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> setSubtitleMarginY(double value) async {
@@ -1628,7 +1628,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setDouble(_subtitleMarginYKey, value);
     await applySubtitleStylePreference();
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> setSubtitleOpacity(double value) async {
@@ -1638,7 +1638,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setDouble(_subtitleOpacityKey, resolved);
     await applySubtitleStylePreference();
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> setSubtitleBorderSize(double value) async {
@@ -1648,7 +1648,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setDouble(_subtitleBorderSizeKey, resolved);
     await applySubtitleStylePreference();
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> setSubtitleShadowOffset(double value) async {
@@ -1658,7 +1658,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setDouble(_subtitleShadowOffsetKey, resolved);
     await applySubtitleStylePreference();
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> setSubtitleBold(bool value) async {
@@ -1667,7 +1667,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_subtitleBoldKey, value);
     await applySubtitleStylePreference();
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> setSubtitleItalic(bool value) async {
@@ -1676,7 +1676,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_subtitleItalicKey, value);
     await applySubtitleStylePreference();
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> setSubtitleColor(Color color) async {
@@ -1685,7 +1685,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(_subtitleColorKey, color.value);
     await applySubtitleStylePreference();
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> setSubtitleBorderColor(Color color) async {
@@ -1694,7 +1694,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(_subtitleBorderColorKey, color.value);
     await applySubtitleStylePreference();
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> setSubtitleShadowColor(Color color) async {
@@ -1703,7 +1703,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(_subtitleShadowColorKey, color.value);
     await applySubtitleStylePreference();
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> setSubtitleFontName(String name) async {
@@ -1713,7 +1713,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_subtitleFontNameKey, trimmed);
     await applySubtitleStylePreference();
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> setSubtitleFontDir(String dir) async {
@@ -1722,7 +1722,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_subtitleFontDirKey, dir);
     await applySubtitleStylePreference();
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> importSubtitleFontFile(String sourcePath) async {
@@ -1740,7 +1740,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
       await prefs.setString(_subtitleFontDirKey, _subtitleFontDir);
       await prefs.setString(_subtitleFontNameKey, _subtitleFontName);
       await applySubtitleStylePreference();
-      notifyListeners();
+      _notifyListeners();
     } catch (e) {
       debugPrint('[VideoPlayerState] 导入字幕字体失败: $e');
     }
@@ -1752,7 +1752,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(_subtitleOverrideModeKey, mode.index);
     await applySubtitleStylePreference();
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> resetSubtitleSettings() async {
@@ -1796,7 +1796,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     await prefs.setString(_subtitleFontDirKey, _subtitleFontDir);
     await prefs.setInt(_subtitleOverrideModeKey, _subtitleOverrideMode.index);
     await applySubtitleStylePreference();
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> applySubtitleStylePreference() async {
@@ -1860,7 +1860,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
   Future<void> _loadDanmakuDisplayArea() async {
     final prefs = await SharedPreferences.getInstance();
     _danmakuDisplayArea = prefs.getDouble(_danmakuDisplayAreaKey) ?? 1.0;
-    notifyListeners();
+    _notifyListeners();
   }
 
   // 设置弹幕轨道显示区域
@@ -1869,7 +1869,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
       _danmakuDisplayArea = area;
       final prefs = await SharedPreferences.getInstance();
       await prefs.setDouble(_danmakuDisplayAreaKey, area);
-      notifyListeners();
+      _notifyListeners();
     }
   }
 
@@ -1887,7 +1887,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     final prefs = await SharedPreferences.getInstance();
     final stored = prefs.getDouble(_danmakuSpeedMultiplierKey);
     _danmakuSpeedMultiplier = _normalizeDanmakuSpeed(stored ?? 1.0);
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> _loadRememberDanmakuOffset() async {
@@ -1895,7 +1895,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     final resolved = prefs.getBool(_rememberDanmakuOffsetKey) ?? false;
     if (_rememberDanmakuOffset != resolved) {
       _rememberDanmakuOffset = resolved;
-      notifyListeners();
+      _notifyListeners();
     } else {
       _rememberDanmakuOffset = resolved;
     }
@@ -1908,7 +1908,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_rememberDanmakuOffsetKey, remember);
     _rememberDanmakuOffset = remember;
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> setDanmakuSpeedMultiplier(double multiplier) async {
@@ -1919,7 +1919,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     _danmakuSpeedMultiplier = normalized;
     final prefs = await SharedPreferences.getInstance();
     await prefs.setDouble(_danmakuSpeedMultiplierKey, normalized);
-    notifyListeners();
+    _notifyListeners();
   }
 
   // 获取弹幕轨道间距倍数（基于字体大小计算）
@@ -1968,7 +1968,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
       final prefs = await SharedPreferences.getInstance();
       final stored = prefs.getInt(_screenshotSaveTargetKey);
       _screenshotSaveTarget = ScreenshotSaveTargetDisplay.fromPrefs(stored);
-      notifyListeners();
+      _notifyListeners();
     } catch (e) {
       debugPrint('加载截图默认保存位置失败: $e');
     }
@@ -1984,7 +1984,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     } catch (e) {
       debugPrint('保存截图默认保存位置失败: $e');
     }
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<Directory> _getDefaultScreenshotSaveDirectory() async {
@@ -2033,7 +2033,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
       }
 
       _screenshotSaveDirectory = resolved;
-      notifyListeners();
+      _notifyListeners();
     } catch (e) {
       debugPrint('加载截图保存位置失败: $e');
     }
@@ -2049,7 +2049,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
       await prefs.remove(_screenshotSaveDirectoryKey);
       final defaultDir = await _getDefaultScreenshotSaveDirectory();
       _screenshotSaveDirectory = defaultDir.path;
-      notifyListeners();
+      _notifyListeners();
       return;
     }
 
@@ -2073,7 +2073,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
 
     await prefs.setString(_screenshotSaveDirectoryKey, resolvedPath);
     _screenshotSaveDirectory = resolvedPath;
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> _loadAutoFullScreenEnabled() async {
@@ -2090,7 +2090,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
       _autoFullscreenEnabled = false;
     }
 
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> setAutoFullscreenEnabled(bool value) async {
@@ -2111,6 +2111,6 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
       debugPrint('[VideoPlayerState] 保存 AutoFullscreen 设置失败: $e');
     }
 
-    notifyListeners();
+    _notifyListeners();
   }
 }

--- a/lib/utils/video_player_state/video_player_state_streaming.dart
+++ b/lib/utils/video_player_state/video_player_state_streaming.dart
@@ -141,7 +141,7 @@ extension VideoPlayerStateStreaming on VideoPlayerState {
     }
 
     // 通知监听器
-    notifyListeners();
+    _notifyListeners();
   }
 
   /// 加载Jellyfin外挂字幕

--- a/lib/utils/video_player_state/video_player_state_subtitles.dart
+++ b/lib/utils/video_player_state/video_player_state_subtitles.dart
@@ -91,7 +91,7 @@ extension VideoPlayerStateSubtitles on VideoPlayerState {
       }
     }
 
-    notifyListeners();
+    _notifyListeners();
   }
 
   // 设置当前外部字幕路径
@@ -104,13 +104,13 @@ extension VideoPlayerStateSubtitles on VideoPlayerState {
   void setExternalSubtitle(String path, {bool isManualSetting = false}) {
     _subtitleManager.setExternalSubtitle(path,
         isManualSetting: isManualSetting);
-    notifyListeners();
+    _notifyListeners();
   }
 
   // 强制设置外部字幕（手动操作）
   void forceSetExternalSubtitle(String path) {
     _subtitleManager.forceSetExternalSubtitle(path);
-    notifyListeners();
+    _notifyListeners();
   }
 
   // 桥接方法：预加载字幕文件
@@ -172,7 +172,7 @@ extension VideoPlayerStateSubtitles on VideoPlayerState {
   Future<void> _loadBlockTopDanmaku() async {
     final prefs = await SharedPreferences.getInstance();
     _blockTopDanmaku = prefs.getBool(_blockTopDanmakuKey) ?? false;
-    notifyListeners();
+    _notifyListeners();
   }
 
   // 设置顶部弹幕屏蔽
@@ -189,7 +189,7 @@ extension VideoPlayerStateSubtitles on VideoPlayerState {
   Future<void> _loadBlockBottomDanmaku() async {
     final prefs = await SharedPreferences.getInstance();
     _blockBottomDanmaku = prefs.getBool(_blockBottomDanmakuKey) ?? false;
-    notifyListeners();
+    _notifyListeners();
   }
 
   // 设置底部弹幕屏蔽
@@ -206,7 +206,7 @@ extension VideoPlayerStateSubtitles on VideoPlayerState {
   Future<void> _loadBlockScrollDanmaku() async {
     final prefs = await SharedPreferences.getInstance();
     _blockScrollDanmaku = prefs.getBool(_blockScrollDanmakuKey) ?? false;
-    notifyListeners();
+    _notifyListeners();
   }
 
   // 设置滚动弹幕屏蔽
@@ -234,7 +234,7 @@ extension VideoPlayerStateSubtitles on VideoPlayerState {
     } else {
       _danmakuBlockWords = [];
     }
-    notifyListeners();
+    _notifyListeners();
   }
 
   String _normalizeSpoilerMatchText(String text) {
@@ -247,7 +247,7 @@ extension VideoPlayerStateSubtitles on VideoPlayerState {
     final prefs = await SharedPreferences.getInstance();
     _spoilerPreventionEnabled =
         prefs.getBool(_spoilerPreventionEnabledKey) ?? false;
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> setSpoilerPreventionEnabled(bool enabled) async {
@@ -331,7 +331,7 @@ extension VideoPlayerStateSubtitles on VideoPlayerState {
       _spoilerPreventionEnabled = false;
       await prefs.setBool(_spoilerPreventionEnabledKey, false);
     }
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> updateSpoilerAiSettings({
@@ -414,7 +414,7 @@ extension VideoPlayerStateSubtitles on VideoPlayerState {
       }
     }
 
-    notifyListeners();
+    _notifyListeners();
   }
 
   Future<void> setSpoilerAiUseCustomKey(bool enabled) async {

--- a/lib/utils/video_player_state/video_player_state_timeline_preview.dart
+++ b/lib/utils/video_player_state/video_player_state_timeline_preview.dart
@@ -15,7 +15,7 @@ extension VideoPlayerStateTimelinePreview on VideoPlayerState {
       final resolved = stored ?? false;
       if (_timelinePreviewEnabled != resolved) {
         _timelinePreviewEnabled = resolved;
-        notifyListeners();
+        _notifyListeners();
       } else {
         _timelinePreviewEnabled = resolved;
       }
@@ -40,7 +40,7 @@ extension VideoPlayerStateTimelinePreview on VideoPlayerState {
     } else if (_currentVideoPath != null) {
       unawaited(_setupTimelinePreviewForVideo(_currentVideoPath!));
     }
-    notifyListeners();
+    _notifyListeners();
   }
 
   void _resetTimelinePreviewState() {
@@ -60,7 +60,7 @@ extension VideoPlayerStateTimelinePreview on VideoPlayerState {
 
     if (!_isTimelinePreviewKernelSupported()) {
       _timelinePreviewSupported = false;
-      notifyListeners();
+      _notifyListeners();
       return;
     }
 
@@ -71,7 +71,7 @@ extension VideoPlayerStateTimelinePreview on VideoPlayerState {
     if (session != _timelinePreviewSessionId) return;
     _timelinePreviewSupported = supported;
     if (!supported) {
-      notifyListeners();
+      _notifyListeners();
       return;
     }
 
@@ -81,7 +81,7 @@ extension VideoPlayerStateTimelinePreview on VideoPlayerState {
     if (session != _timelinePreviewSessionId) return;
     _timelinePreviewDirectory = dir.path;
     _hydrateTimelinePreviewCache(dir);
-    notifyListeners();
+    _notifyListeners();
 
     unawaited(_prefetchInitialTimelineThumbnails(session));
     unawaited(_backgroundFillTimelineThumbnails(session));
@@ -130,9 +130,8 @@ extension VideoPlayerStateTimelinePreview on VideoPlayerState {
     }
     final totalMs = _duration.inMilliseconds;
     final clamped = time.inMilliseconds.clamp(0, totalMs - 1);
-    final interval = _timelinePreviewIntervalMs <= 0
-        ? 15000
-        : _timelinePreviewIntervalMs;
+    final interval =
+        _timelinePreviewIntervalMs <= 0 ? 15000 : _timelinePreviewIntervalMs;
     return (clamped ~/ interval) * interval;
   }
 
@@ -214,8 +213,7 @@ extension VideoPlayerStateTimelinePreview on VideoPlayerState {
 
     _disposeTimelinePreviewPlayer();
 
-    final previewPlayer =
-        PlayerFactory().createPlayer(kernelType: kernel);
+    final previewPlayer = PlayerFactory().createPlayer(kernelType: kernel);
     try {
       previewPlayer.volume = 0;
       previewPlayer.setMedia(source, PlayerMediaType.video);
@@ -260,8 +258,7 @@ extension VideoPlayerStateTimelinePreview on VideoPlayerState {
 
   Future<T> _withTimelinePreviewSerial<T>(Future<T> Function() task) {
     final next = _timelinePreviewSerialTask.then((_) => task());
-    _timelinePreviewSerialTask =
-        next.then((_) => null, onError: (_) => null);
+    _timelinePreviewSerialTask = next.then((_) => null, onError: (_) => null);
     return next;
   }
 
@@ -288,9 +285,8 @@ extension VideoPlayerStateTimelinePreview on VideoPlayerState {
         if (codec.width > 0 && codec.height > 0) {
           final aspect = codec.width / codec.height;
           targetWidth = (targetHeight * aspect).round();
-          targetWidth = targetWidth
-              .clamp(1, _timelinePreviewDefaultWidth * 3)
-              .toInt();
+          targetWidth =
+              targetWidth.clamp(1, _timelinePreviewDefaultWidth * 3).toInt();
         }
       }
 
@@ -363,8 +359,7 @@ extension VideoPlayerStateTimelinePreview on VideoPlayerState {
 
   img.Image? _decodeTimelineRawFrame(PlayerFrame frame) {
     final width = frame.width > 0 ? frame.width : _timelinePreviewDefaultWidth;
-    final height =
-        frame.height > 0 ? frame.height : _timelinePreviewMaxHeight;
+    final height = frame.height > 0 ? frame.height : _timelinePreviewMaxHeight;
     final bytes = frame.bytes;
     if (width <= 0 || height <= 0 || bytes.isEmpty) return null;
 
@@ -433,7 +428,8 @@ extension VideoPlayerStateTimelinePreview on VideoPlayerState {
   }
 
   img.ChannelOrder _resolveTimelinePreviewChannelOrder() {
-    final kernel = _timelinePreviewPlayerKernel ?? PlayerFactory.getKernelType();
+    final kernel =
+        _timelinePreviewPlayerKernel ?? PlayerFactory.getKernelType();
     if (kernel == PlayerKernelType.mediaKit) {
       return img.ChannelOrder.bgra;
     }
@@ -472,17 +468,15 @@ extension VideoPlayerStateTimelinePreview on VideoPlayerState {
     }
 
     final total = _duration.inMilliseconds;
-    final interval = _timelinePreviewIntervalMs <= 0
-        ? 15000
-        : _timelinePreviewIntervalMs;
+    final interval =
+        _timelinePreviewIntervalMs <= 0 ? 15000 : _timelinePreviewIntervalMs;
     const int maxThumbnails = 80;
     int generated = 0;
 
     for (int bucket = 0;
         bucket <= total && generated < maxThumbnails;
         bucket += interval) {
-      if (session != _timelinePreviewSessionId ||
-          !isTimelinePreviewAvailable) {
+      if (session != _timelinePreviewSessionId || !isTimelinePreviewAvailable) {
         return;
       }
       if (_timelinePreviewCache.containsKey(bucket)) {


### PR DESCRIPTION
## Summary
- route VideoPlayerState part-file notifications through a class-local wrapper
- avoid subscribing MainPageState to all VideoPlayerState changes while manually managing hotkeys
- call super.dispose() when HotkeyService is released

## Verification
- flutter analyze --no-pub --no-fatal-infos --no-fatal-warnings lib
- flutter test --no-pub --reporter expanded