### PR TITLE
Fix macOS HDR overlay resume black screen

### DIFF
--- a/lib/widgets/macos_native_video_view.dart
+++ b/lib/widgets/macos_native_video_view.dart
@@ -197,12 +197,14 @@ class _MacOSWindowNativeVideoOverlaySurfaceState
   Timer? _frameTimer;
   int _bindAttempts = 0;
   bool _isBound = false;
+  late final int _surfaceGeneration;
   String? _lastFrameSignature;
 
   @override
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
+    _surfaceGeneration = identityHashCode(this);
     widget.onPlatformViewIdChanged?.call(_windowHostedPlatformSurfaceId);
     _startFrameTimer();
     _scheduleAttach();
@@ -242,11 +244,6 @@ class _MacOSWindowNativeVideoOverlaySurfaceState
     );
     widget.onPlatformViewIdChanged?.call(null);
     unawaited(_hideOverlayFrame());
-    unawaited(
-      widget.player.detachPlatformVideoSurface(
-        platformViewId: _windowHostedPlatformSurfaceId,
-      ),
-    );
     super.dispose();
   }
 
@@ -367,6 +364,7 @@ class _MacOSWindowNativeVideoOverlaySurfaceState
         'setOverlayFrame',
         <String, dynamic>{
           'viewId': _windowHostedPlatformSurfaceId,
+          'generation': _surfaceGeneration,
           'x': rect.left,
           'y': rect.top,
           'width': rect.width,
@@ -391,6 +389,7 @@ class _MacOSWindowNativeVideoOverlaySurfaceState
         'setOverlayFrame',
         <String, dynamic>{
           'viewId': _windowHostedPlatformSurfaceId,
+          'generation': _surfaceGeneration,
           'x': 0.0,
           'y': 0.0,
           'width': 0.0,

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -157,6 +157,7 @@ final class MacOSWindowNativeVideoOverlayView: NSView, MacOSNativeVideoSurfaceHo
 
     private var videoRenderer: MediaKitOpenGLVideoRenderer?
     private var attachedPlayerHandle: Int64?
+    private var overlayFrameGeneration: Int64?
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -222,10 +223,30 @@ final class MacOSWindowNativeVideoOverlayView: NSView, MacOSNativeVideoSurfaceHo
     }
 
     func updateOverlayFrame(_ frame: CGRect?, visible: Bool, debugLabel: String?) {
+        updateOverlayFrame(frame, visible: visible, debugLabel: debugLabel, generation: nil)
+    }
+
+    func updateOverlayFrame(_ frame: CGRect?, visible: Bool, debugLabel: String?, generation: Int64?) {
         if !Thread.isMainThread {
             DispatchQueue.main.async { [weak self] in
-                self?.updateOverlayFrame(frame, visible: visible, debugLabel: debugLabel)
+                self?.updateOverlayFrame(
+                    frame,
+                    visible: visible,
+                    debugLabel: debugLabel,
+                    generation: generation
+                )
             }
+            return
+        }
+
+        if visible {
+            overlayFrameGeneration = generation
+        } else if let generation,
+                  let overlayFrameGeneration,
+                  generation != overlayFrameGeneration {
+            macOSHdrExitTrace(
+                "overlayView ignore stale hide generation=\(generation) active=\(overlayFrameGeneration) label=\(debugLabel ?? "")"
+            )
             return
         }
 
@@ -581,11 +602,21 @@ final class MacOSNativeVideoPlugin: NSObject, FlutterPlugin {
             if !visible {
                 macOSHdrExitTrace("plugin setOverlayFrame hide viewId=\(host.platformViewId)")
             }
-            host.updateOverlayFrame(
-                frame,
-                visible: visible,
-                debugLabel: args["debugLabel"] as? String
-            )
+            let generation = int64Value(args["generation"])
+            if let overlayHost = host as? MacOSWindowNativeVideoOverlayView {
+                overlayHost.updateOverlayFrame(
+                    frame,
+                    visible: visible,
+                    debugLabel: args["debugLabel"] as? String,
+                    generation: generation
+                )
+            } else {
+                host.updateOverlayFrame(
+                    frame,
+                    visible: visible,
+                    debugLabel: args["debugLabel"] as? String
+                )
+            }
             result(nil)
         default:
             result(FlutterMethodNotImplemented)


### PR DESCRIPTION
## Summary
- keep the window-hosted macOS HDR overlay attached to libmpv while the Flutter video page is temporarily unmounted during tab changes
- tag overlay frame updates with a surface generation so stale hide calls from the previous widget instance cannot hide the newly recreated overlay

## Testing
- Manually verified by reproducing the macOS HDR native video output tab switch: play video, switch to Home, switch back to playback, video remains visible
- `flutter analyze lib/widgets/macos_native_video_view.dart lib/themes/nipaplay/widgets/video_player_ui.dart lib/themes/nipaplay/widgets/custom_scaffold.dart` (existing warning: unused optional key parameter in custom_scaffold.dart)