### PR TITLE
设置新增实验室板块，控制大屏幕模式入口显示

### DIFF
--- a/lib/constants/settings_keys.dart
+++ b/lib/constants/settings_keys.dart
@@ -20,4 +20,7 @@ class SettingsKeys {
 
   static const String legacyAutoCheckUpdatesOnAboutPage =
       'auto_check_updates_on_about_page';
+
+  static const String labsEnableLargeScreenMode =
+      'labs_enable_large_screen_mode';
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1090,10 +1090,15 @@ class MainPage extends StatefulWidget {
 
 class MainPageState extends State<MainPage>
     with TickerProviderStateMixin, WindowListener {
+  static const double kWindowCaptionHeight = 28;
+  static const String _largeScreenLayoutPrefKey =
+      'nipaplay_use_large_screen_layout';
+
   bool isMaximized = false;
   TabController? globalTabController;
   bool _showSplash = true;
   bool _isThemeRevealRunning = false;
+  bool _useLargeScreenLayout = false;
 
   // 用于热键管理
   bool _hotkeysAreRegistered = false;
@@ -1200,6 +1205,7 @@ class MainPageState extends State<MainPage>
   Future<void> _initializeController() async {
     final prefs = await SharedPreferences.getInstance();
     _defaultPageIndex = prefs.getInt('default_page_index') ?? 0;
+    _useLargeScreenLayout = prefs.getBool(_largeScreenLayoutPrefKey) ?? false;
 
     // 强制启用页面滑动动画
     // ... (注释省略)
@@ -1373,6 +1379,19 @@ class MainPageState extends State<MainPage>
     await windowManager.close();
   }
 
+  Future<void> _toggleLargeScreenLayout() async {
+    final nextValue = !_useLargeScreenLayout;
+    setState(() {
+      _useLargeScreenLayout = nextValue;
+    });
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool(_largeScreenLayoutPrefKey, nextValue);
+    } catch (e) {
+      debugPrint('[MainPageState] 保存大屏幕模式设置失败: $e');
+    }
+  }
+
   ThemeMode _nextThemeMode() {
     final isDarkMode = Theme.of(context).brightness == Brightness.dark;
     return isDarkMode ? ThemeMode.light : ThemeMode.dark;
@@ -1496,6 +1515,9 @@ class MainPageState extends State<MainPage>
     final mediaPadding = MediaQuery.of(context).padding;
     final bool isMac = !kIsWeb && Platform.isMacOS;
     final bool isDesktop = globals.isDesktop;
+    final bool canUseLargeScreenLayout = globals.isDesktopOrTablet;
+    final bool isLargeScreenLayoutActive =
+        canUseLargeScreenLayout && _useLargeScreenLayout;
     final double baseTopPadding = isMac ? 10 : 4;
     final double baseRightPadding = isMac ? 20 : 10;
     final double topPadding =
@@ -1514,6 +1536,7 @@ class MainPageState extends State<MainPage>
               pageIsHome: true,
               shouldShowAppBar: shouldShowAppBar,
               tabController: globalTabController,
+              useLargeScreenLayout: isLargeScreenLayoutActive,
             );
           },
         ),
@@ -1549,63 +1572,199 @@ class MainPageState extends State<MainPage>
             if (!globals.isDesktopOrTablet || !shouldShowAppBar) {
               return const SizedBox.shrink();
             }
-            return Positioned(
-              top: topPadding,
-              right: rightPadding,
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  const SystemResourceDisplay(),
-                  const SizedBox(width: 8),
-                  SizedBox(
-                    height: kWindowCaptionHeight,
-                    child: Center(
-                      child: Image.asset(
-                        'assets/logo2.png',
-                        height: 24,
-                        fit: BoxFit.contain,
-                        color: isDarkMode ? Colors.white : Colors.black,
-                        colorBlendMode: BlendMode.srcIn,
-                      ),
-                    ),
-                  ),
-                  const SizedBox(width: 8),
-                  SizedBox(
-                    height: kWindowCaptionHeight,
-                    child: Center(
-                      child: _ThemeToggleButton(
-                        onToggleFromOrigin: _handleThemeToggleFromButton,
-                      ),
-                    ),
-                  ),
-                  const SizedBox(width: 8),
-                  SizedBox(
-                    height: kWindowCaptionHeight,
-                    child: Center(
-                      child: _SettingsEntryButton(
-                        onPressed: () => SettingsPage.showWindow(context),
-                      ),
-                    ),
-                  ),
-                  const SizedBox(width: 8),
-                  if (!kIsWeb && (Platform.isWindows || Platform.isLinux))
-                    SizedBox(
-                      height: kWindowCaptionHeight,
-                      child: Center(
-                        child: WindowControlButtons(
-                          isMaximized: isMaximized,
-                          onMinimize: _minimizeWindow,
-                          onMaximizeRestore: _toggleWindowSize,
-                          onClose: _closeWindow,
+            final String themeActionLabel = isDarkMode
+                ? context.l10n.toggleToLightMode
+                : context.l10n.toggleToDarkMode;
+            final IconData themeActionIcon = isDarkMode
+                ? Icons.nightlight_rounded
+                : Icons.light_mode_rounded;
+
+            final actionButtonsInLargeLayout = Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                NipaplaySidePanel(
+                  isDarkMode: isDarkMode,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      NipaplaySidePanelItem(
+                        isSelected: true,
+                        activeColor: const Color(0xFFFF2E55),
+                        inactiveColor:
+                            isDarkMode ? Colors.white60 : Colors.black54,
+                        onTap: _toggleLargeScreenLayout,
+                        child: Row(
+                          children: const [
+                            Icon(Icons.view_day_rounded, size: 20),
+                            SizedBox(width: 8),
+                            Expanded(
+                              child: Text(
+                                '退出大屏幕模式',
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: TextStyle(
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                            ),
+                          ],
                         ),
                       ),
+                      NipaplaySidePanelItem(
+                        isSelected: false,
+                        activeColor: const Color(0xFFFF2E55),
+                        inactiveColor:
+                            isDarkMode ? Colors.white60 : Colors.black54,
+                        onTap: () {
+                          context.read<ThemeNotifier>().themeMode =
+                              _nextThemeMode();
+                        },
+                        child: Row(
+                          children: [
+                            Icon(themeActionIcon, size: 20),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: Text(
+                                themeActionLabel,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: const TextStyle(
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      NipaplaySidePanelItem(
+                        isSelected: false,
+                        activeColor: const Color(0xFFFF2E55),
+                        inactiveColor:
+                            isDarkMode ? Colors.white60 : Colors.black54,
+                        onTap: () => SettingsPage.showWindow(context),
+                        child: Row(
+                          children: [
+                            const Icon(Icons.settings_rounded, size: 20),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: Text(
+                                context.l10n.settingsLabel,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: const TextStyle(
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            );
+            final actionButtonsInNormalLayout = Row(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SizedBox(
+                  height: kWindowCaptionHeight,
+                  child: Center(
+                    child: Image.asset(
+                      'assets/logo2.png',
+                      height: 24,
+                      fit: BoxFit.contain,
+                      color: isDarkMode ? Colors.white : Colors.black,
+                      colorBlendMode: BlendMode.srcIn,
                     ),
-                ],
-              ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                SizedBox(
+                  height: kWindowCaptionHeight,
+                  child: Center(
+                    child: _LargeScreenLayoutToggleButton(
+                      isActive: isLargeScreenLayoutActive,
+                      onPressed: _toggleLargeScreenLayout,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                SizedBox(
+                  height: kWindowCaptionHeight,
+                  child: Center(
+                    child: _ThemeToggleButton(
+                      onToggleFromOrigin: _handleThemeToggleFromButton,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                SizedBox(
+                  height: kWindowCaptionHeight,
+                  child: Center(
+                    child: _SettingsEntryButton(
+                      onPressed: () => SettingsPage.showWindow(context),
+                    ),
+                  ),
+                ),
+              ],
+            );
+            return Positioned(
+              top: isLargeScreenLayoutActive ? null : topPadding,
+              left: isLargeScreenLayoutActive ? 0 : null,
+              right: isLargeScreenLayoutActive ? null : rightPadding,
+              bottom: isLargeScreenLayoutActive
+                  ? 0
+                  : null,
+              child: isLargeScreenLayoutActive
+                  ? actionButtonsInLargeLayout
+                  : Row(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const SystemResourceDisplay(),
+                        const SizedBox(width: 8),
+                        actionButtonsInNormalLayout,
+                        const SizedBox(width: 8),
+                        if (!kIsWeb && (Platform.isWindows || Platform.isLinux))
+                          SizedBox(
+                            height: kWindowCaptionHeight,
+                            child: Center(
+                              child: WindowControlButtons(
+                                isMaximized: isMaximized,
+                                onMinimize: _minimizeWindow,
+                                onMaximizeRestore: _toggleWindowSize,
+                                onClose: _closeWindow,
+                              ),
+                            ),
+                          ),
+                      ],
+                    ),
             );
           },
         ),
+        if (isLargeScreenLayoutActive &&
+            !kIsWeb &&
+            (Platform.isWindows || Platform.isLinux))
+          Positioned(
+            top: topPadding,
+            right: rightPadding,
+            child: SizedBox(
+              height: kWindowCaptionHeight,
+              child: Center(
+                child: WindowControlButtons(
+                  isMaximized: isMaximized,
+                  onMinimize: _minimizeWindow,
+                  onMaximizeRestore: _toggleWindowSize,
+                  onClose: _closeWindow,
+                ),
+              ),
+            ),
+          ),
       ],
     );
 
@@ -1620,6 +1779,20 @@ class _SettingsEntryButton extends StatefulWidget {
 
   @override
   State<_SettingsEntryButton> createState() => _SettingsEntryButtonState();
+}
+
+class _LargeScreenLayoutToggleButton extends StatefulWidget {
+  const _LargeScreenLayoutToggleButton({
+    required this.isActive,
+    required this.onPressed,
+  });
+
+  final bool isActive;
+  final VoidCallback onPressed;
+
+  @override
+  State<_LargeScreenLayoutToggleButton> createState() =>
+      _LargeScreenLayoutToggleButtonState();
 }
 
 class _ThemeToggleButton extends StatefulWidget {
@@ -1711,6 +1884,57 @@ class _ThemeToggleButtonState extends State<_ThemeToggleButton> {
                 size: 22,
                 color: iconColor,
               ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _LargeScreenLayoutToggleButtonState
+    extends State<_LargeScreenLayoutToggleButton> {
+  bool _isHovered = false;
+  bool _isPressed = false;
+
+  void _setHovered(bool value) {
+    if (_isHovered == value) {
+      return;
+    }
+    setState(() {
+      _isHovered = value;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isDarkMode = Theme.of(context).brightness == Brightness.dark;
+    final bool isActive = widget.isActive;
+    final double scale = _isPressed ? 0.92 : (_isHovered ? 1.1 : 1.0);
+    final Color iconColor = isActive
+        ? const Color(0xFFFF2E55)
+        : (_isHovered
+            ? const Color(0xFFFF2E55)
+            : (isDarkMode ? Colors.white : Colors.black87));
+    final icon = isActive ? Icons.view_day_rounded : Icons.view_sidebar_rounded;
+
+    return Tooltip(
+      message: isActive ? '退出大屏幕模式' : '大屏幕模式',
+      child: MouseRegion(
+        onEnter: (_) => _setHovered(true),
+        onExit: (_) => _setHovered(false),
+        child: GestureDetector(
+          onTapDown: (_) => setState(() => _isPressed = true),
+          onTapUp: (_) => setState(() => _isPressed = false),
+          onTapCancel: () => setState(() => _isPressed = false),
+          onTap: widget.onPressed,
+          child: AnimatedScale(
+            scale: scale,
+            duration: const Duration(milliseconds: 120),
+            child: Icon(
+              icon,
+              size: 22,
+              color: iconColor,
             ),
           ),
         ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1560,6 +1560,9 @@ class MainPageState extends State<MainPage>
               shouldShowAppBar: shouldShowAppBar,
               tabController: globalTabController,
               useLargeScreenLayout: isLargeScreenLayoutActive,
+              onToggleLargeScreen: _toggleLargeScreenLayout,
+              onToggleThemeFromOrigin: _handleThemeToggleFromButton,
+              onOpenSettings: () => SettingsPage.showWindow(context),
             );
           },
         ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,7 @@ import 'package:nipaplay/utils/globals.dart' as globals;
 import 'package:nipaplay/utils/theme_notifier.dart';
 import 'package:nipaplay/utils/system_resource_monitor.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/custom_scaffold.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_mode_scope.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/large_screen_mode_actions.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/large_screen_mode_preferences.dart';
 import 'package:window_manager/window_manager.dart';
@@ -1547,78 +1548,81 @@ class MainPageState extends State<MainPage>
         isDesktop ? baseTopPadding : baseTopPadding + mediaPadding.top;
     final double rightPadding =
         isDesktop ? baseRightPadding : baseRightPadding + mediaPadding.right;
-    final content = Stack(
-      children: [
-        // 使用 Selector 只监听需要的状态
-        Selector<VideoPlayerState, bool>(
-          selector: (context, videoState) => videoState.shouldShowAppBar(),
-          builder: (context, shouldShowAppBar, child) {
-            return CustomScaffold(
-              pages: widget.pages,
-              tabPage: createTabLabels(context),
-              pageIsHome: true,
-              shouldShowAppBar: shouldShowAppBar,
-              tabController: globalTabController,
-              useLargeScreenLayout: isLargeScreenLayoutActive,
-              onToggleLargeScreen: _toggleLargeScreenLayout,
-              onToggleThemeFromOrigin: _handleThemeToggleFromButton,
-              onOpenSettings: () => SettingsPage.showWindow(context),
-            );
-          },
-        ),
-        AnimatedSwitcher(
-          duration: const Duration(milliseconds: 500),
-          transitionBuilder: (Widget child, Animation<double> animation) {
-            return FadeTransition(opacity: animation, child: child);
-          },
-          child: _showSplash
-              ? const SplashScreen(key: ValueKey('splash'))
-              : const SizedBox.shrink(key: ValueKey('no_splash')),
-        ),
-        Positioned(
-          top: 0,
-          left: 0,
-          right: 0,
-          child: SizedBox(
-            height: 40,
-            child: GestureDetector(
-              onDoubleTap: _toggleWindowSize,
-              onPanStart: (details) async {
-                if (globals.isDesktop) {
-                  await windowManager.startDragging();
-                }
-              },
+    final content = NipaplayLargeScreenModeScope(
+      isActive: isLargeScreenLayoutActive,
+      child: Stack(
+        children: [
+          // 使用 Selector 只监听需要的状态
+          Selector<VideoPlayerState, bool>(
+            selector: (context, videoState) => videoState.shouldShowAppBar(),
+            builder: (context, shouldShowAppBar, child) {
+              return CustomScaffold(
+                pages: widget.pages,
+                tabPage: createTabLabels(context),
+                pageIsHome: true,
+                shouldShowAppBar: shouldShowAppBar,
+                tabController: globalTabController,
+                useLargeScreenLayout: isLargeScreenLayoutActive,
+                onToggleLargeScreen: _toggleLargeScreenLayout,
+                onToggleThemeFromOrigin: _handleThemeToggleFromButton,
+                onOpenSettings: () => SettingsPage.showWindow(context),
+              );
+            },
+          ),
+          AnimatedSwitcher(
+            duration: const Duration(milliseconds: 500),
+            transitionBuilder: (Widget child, Animation<double> animation) {
+              return FadeTransition(opacity: animation, child: child);
+            },
+            child: _showSplash
+                ? const SplashScreen(key: ValueKey('splash'))
+                : const SizedBox.shrink(key: ValueKey('no_splash')),
+          ),
+          Positioned(
+            top: 0,
+            left: 0,
+            right: 0,
+            child: SizedBox(
+              height: 40,
+              child: GestureDetector(
+                onDoubleTap: _toggleWindowSize,
+                onPanStart: (details) async {
+                  if (globals.isDesktop) {
+                    await windowManager.startDragging();
+                  }
+                },
+              ),
             ),
           ),
-        ),
-        // 使用 Selector 只监听需要的状态
-        Selector<VideoPlayerState, bool>(
-          selector: (context, videoState) => videoState.shouldShowAppBar(),
-          builder: (context, shouldShowAppBar, child) {
-            if (!globals.isDesktopOrTablet) {
-              return const SizedBox.shrink();
-            }
-            if (!isLargeScreenLayoutActive && !shouldShowAppBar) {
-              return const SizedBox.shrink();
-            }
-            return NipaplayLargeScreenModeActionsOverlay(
-              isDarkMode: isDarkMode,
-              isLargeScreenLayoutActive: isLargeScreenLayoutActive,
-              topPadding: topPadding,
-              rightPadding: rightPadding,
-              showWindowsButtons:
-                  !kIsWeb && (Platform.isWindows || Platform.isLinux),
-              isMaximized: isMaximized,
-              onToggleLargeScreen: _toggleLargeScreenLayout,
-              onToggleThemeFromOrigin: _handleThemeToggleFromButton,
-              onOpenSettings: () => SettingsPage.showWindow(context),
-              onMinimize: _minimizeWindow,
-              onMaximizeRestore: _toggleWindowSize,
-              onClose: _closeWindow,
-            );
-          },
-        ),
-      ],
+          // 使用 Selector 只监听需要的状态
+          Selector<VideoPlayerState, bool>(
+            selector: (context, videoState) => videoState.shouldShowAppBar(),
+            builder: (context, shouldShowAppBar, child) {
+              if (!globals.isDesktopOrTablet) {
+                return const SizedBox.shrink();
+              }
+              if (!isLargeScreenLayoutActive && !shouldShowAppBar) {
+                return const SizedBox.shrink();
+              }
+              return NipaplayLargeScreenModeActionsOverlay(
+                isDarkMode: isDarkMode,
+                isLargeScreenLayoutActive: isLargeScreenLayoutActive,
+                topPadding: topPadding,
+                rightPadding: rightPadding,
+                showWindowsButtons:
+                    !kIsWeb && (Platform.isWindows || Platform.isLinux),
+                isMaximized: isMaximized,
+                onToggleLargeScreen: _toggleLargeScreenLayout,
+                onToggleThemeFromOrigin: _handleThemeToggleFromButton,
+                onOpenSettings: () => SettingsPage.showWindow(context),
+                onMinimize: _minimizeWindow,
+                onMaximizeRestore: _toggleWindowSize,
+                onClose: _closeWindow,
+              );
+            },
+          ),
+        ],
+      ),
     );
 
     return content;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -44,6 +44,7 @@ import 'package:nipaplay/providers/shared_remote_library_provider.dart';
 import 'package:nipaplay/providers/ui_theme_provider.dart';
 import 'package:nipaplay/providers/jellyfin_transcode_provider.dart';
 import 'package:nipaplay/providers/emby_transcode_provider.dart';
+import 'package:nipaplay/providers/labs_settings_provider.dart';
 import 'package:nipaplay/themes/theme_descriptor.dart';
 import 'themes/nipaplay/pages/settings/account_page.dart';
 import 'dart:async';
@@ -672,6 +673,7 @@ void main(List<String> args) async {
           ChangeNotifierProvider.value(value: ServiceProvider.scanService),
           ChangeNotifierProvider(create: (_) => DeveloperOptionsProvider()),
           ChangeNotifierProvider(create: (_) => AppearanceSettingsProvider()),
+          ChangeNotifierProvider(create: (_) => LabsSettingsProvider()),
           ChangeNotifierProvider(create: (_) => HomeSectionsSettingsProvider()),
           ChangeNotifierProvider(create: (_) => UIThemeProvider()),
           ChangeNotifierProvider(create: (_) => SharedRemoteLibraryProvider()),
@@ -1240,7 +1242,7 @@ class MainPageState extends State<MainPage>
         _initializeHotkeys();
       }
 
-      if (_useLargeScreenLayout) {
+      if (_useLargeScreenLayout && _isLabsLargeScreenModeEnabled()) {
         unawaited(_syncDesktopFullScreenWithLargeScreenMode(true));
       }
     });
@@ -1379,6 +1381,10 @@ class MainPageState extends State<MainPage>
   }
 
   Future<void> _toggleLargeScreenLayout() async {
+    final labsSettings = context.read<LabsSettingsProvider>();
+    if (!labsSettings.enableLargeScreenMode && !_useLargeScreenLayout) {
+      return;
+    }
     final nextValue = !_useLargeScreenLayout;
     setState(() {
       _useLargeScreenLayout = nextValue;
@@ -1406,6 +1412,13 @@ class MainPageState extends State<MainPage>
     } catch (e) {
       debugPrint('[MainPageState] 切换大屏幕模式全屏状态失败: $e');
     }
+  }
+
+  bool _isLabsLargeScreenModeEnabled() {
+    if (!mounted) {
+      return false;
+    }
+    return context.read<LabsSettingsProvider>().enableLargeScreenMode;
   }
 
   ThemeMode _nextThemeMode() {
@@ -1517,14 +1530,16 @@ class MainPageState extends State<MainPage>
 
   @override
   void onWindowEvent(String eventName) {
-    if (eventName == 'leave-full-screen' && _useLargeScreenLayout) {
+    if (eventName == 'leave-full-screen' &&
+        _useLargeScreenLayout &&
+        _isLabsLargeScreenModeEnabled()) {
       unawaited(_syncDesktopFullScreenWithLargeScreenMode(true));
     }
   }
 
   @override
   void onWindowLeaveFullScreen() {
-    if (_useLargeScreenLayout) {
+    if (_useLargeScreenLayout && _isLabsLargeScreenModeEnabled()) {
       unawaited(_syncDesktopFullScreenWithLargeScreenMode(true));
     }
   }
@@ -1540,8 +1555,12 @@ class MainPageState extends State<MainPage>
     final bool isMac = !kIsWeb && Platform.isMacOS;
     final bool isDesktop = globals.isDesktop;
     final bool canUseLargeScreenLayout = globals.isDesktopOrTablet;
-    final bool isLargeScreenLayoutActive =
-        canUseLargeScreenLayout && _useLargeScreenLayout;
+    final bool labsEnableLargeScreenMode =
+        context.watch<LabsSettingsProvider>().enableLargeScreenMode;
+    final bool allowLargeScreenControls = labsEnableLargeScreenMode;
+    final bool isLargeScreenLayoutActive = canUseLargeScreenLayout &&
+        allowLargeScreenControls &&
+        _useLargeScreenLayout;
     final double baseTopPadding = isMac ? 10 : 4;
     final double baseRightPadding = isMac ? 20 : 10;
     final double topPadding =
@@ -1563,7 +1582,8 @@ class MainPageState extends State<MainPage>
                 shouldShowAppBar: shouldShowAppBar,
                 tabController: globalTabController,
                 useLargeScreenLayout: isLargeScreenLayoutActive,
-                onToggleLargeScreen: _toggleLargeScreenLayout,
+                onToggleLargeScreen:
+                    allowLargeScreenControls ? _toggleLargeScreenLayout : null,
                 onToggleThemeFromOrigin: _handleThemeToggleFromButton,
                 onOpenSettings: () => SettingsPage.showWindow(context),
               );
@@ -1612,7 +1632,8 @@ class MainPageState extends State<MainPage>
                 showWindowsButtons:
                     !kIsWeb && (Platform.isWindows || Platform.isLinux),
                 isMaximized: isMaximized,
-                onToggleLargeScreen: _toggleLargeScreenLayout,
+                onToggleLargeScreen:
+                    allowLargeScreenControls ? _toggleLargeScreenLayout : null,
                 onToggleThemeFromOrigin: _handleThemeToggleFromButton,
                 onOpenSettings: () => SettingsPage.showWindow(context),
                 onMinimize: _minimizeWindow,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1588,7 +1588,7 @@ class MainPageState extends State<MainPage>
                     mainAxisSize: MainAxisSize.min,
                     children: [
                       NipaplaySidePanelItem(
-                        isSelected: true,
+                        isSelected: false,
                         activeColor: const Color(0xFFFF2E55),
                         inactiveColor:
                             isDarkMode ? Colors.white60 : Colors.black54,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1238,6 +1238,10 @@ class MainPageState extends State<MainPage>
       if (globals.isDesktop) {
         _initializeHotkeys();
       }
+
+      if (_useLargeScreenLayout) {
+        unawaited(_syncDesktopFullScreenWithLargeScreenMode(true));
+      }
     });
   }
 
@@ -1383,6 +1387,24 @@ class MainPageState extends State<MainPage>
     } catch (e) {
       debugPrint('[MainPageState] 保存大屏幕模式设置失败: $e');
     }
+
+    await _syncDesktopFullScreenWithLargeScreenMode(nextValue);
+  }
+
+  Future<void> _syncDesktopFullScreenWithLargeScreenMode(
+      bool shouldUseFullScreen) async {
+    if (!globals.isDesktop || kIsWeb) {
+      return;
+    }
+
+    try {
+      final isFullScreen = await windowManager.isFullScreen();
+      if (isFullScreen != shouldUseFullScreen) {
+        await windowManager.setFullScreen(shouldUseFullScreen);
+      }
+    } catch (e) {
+      debugPrint('[MainPageState] 切换大屏幕模式全屏状态失败: $e');
+    }
   }
 
   ThemeMode _nextThemeMode() {
@@ -1494,8 +1516,16 @@ class MainPageState extends State<MainPage>
 
   @override
   void onWindowEvent(String eventName) {
-    // 监听所有窗口事件，可以在这里添加日志
-    // print('窗口事件: $eventName');
+    if (eventName == 'leave-full-screen' && _useLargeScreenLayout) {
+      unawaited(_syncDesktopFullScreenWithLargeScreenMode(true));
+    }
+  }
+
+  @override
+  void onWindowLeaveFullScreen() {
+    if (_useLargeScreenLayout) {
+      unawaited(_syncDesktopFullScreenWithLargeScreenMode(true));
+    }
   }
 
   @override
@@ -1562,7 +1592,10 @@ class MainPageState extends State<MainPage>
         Selector<VideoPlayerState, bool>(
           selector: (context, videoState) => videoState.shouldShowAppBar(),
           builder: (context, shouldShowAppBar, child) {
-            if (!globals.isDesktopOrTablet || !shouldShowAppBar) {
+            if (!globals.isDesktopOrTablet) {
+              return const SizedBox.shrink();
+            }
+            if (!isLargeScreenLayoutActive && !shouldShowAppBar) {
               return const SizedBox.shrink();
             }
             return NipaplayLargeScreenModeActionsOverlay(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,15 +9,13 @@ import 'package:kmbal_ionicons/kmbal_ionicons.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:nipaplay/l10n/app_locale_utils.dart';
 import 'package:nipaplay/l10n/app_localizations.dart';
-import 'package:nipaplay/l10n/l10n.dart';
 import 'package:nipaplay/pages/tab_labels.dart';
-import 'package:nipaplay/utils/app_theme.dart';
 import 'package:nipaplay/utils/globals.dart' as globals;
 import 'package:nipaplay/utils/theme_notifier.dart';
 import 'package:nipaplay/utils/system_resource_monitor.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/custom_scaffold.dart';
-import 'package:nipaplay/themes/nipaplay/widgets/menu_button.dart';
-import 'package:nipaplay/themes/nipaplay/widgets/system_resource_display.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_mode_actions.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_mode_preferences.dart';
 import 'package:window_manager/window_manager.dart';
 import 'package:provider/provider.dart';
 import 'pages/anime_page.dart';
@@ -1090,10 +1088,6 @@ class MainPage extends StatefulWidget {
 
 class MainPageState extends State<MainPage>
     with TickerProviderStateMixin, WindowListener {
-  static const double kWindowCaptionHeight = 28;
-  static const String _largeScreenLayoutPrefKey =
-      'nipaplay_use_large_screen_layout';
-
   bool isMaximized = false;
   TabController? globalTabController;
   bool _showSplash = true;
@@ -1205,7 +1199,7 @@ class MainPageState extends State<MainPage>
   Future<void> _initializeController() async {
     final prefs = await SharedPreferences.getInstance();
     _defaultPageIndex = prefs.getInt('default_page_index') ?? 0;
-    _useLargeScreenLayout = prefs.getBool(_largeScreenLayoutPrefKey) ?? false;
+    _useLargeScreenLayout = await LargeScreenModePreferences.load();
 
     // 强制启用页面滑动动画
     // ... (注释省略)
@@ -1385,8 +1379,7 @@ class MainPageState extends State<MainPage>
       _useLargeScreenLayout = nextValue;
     });
     try {
-      final prefs = await SharedPreferences.getInstance();
-      await prefs.setBool(_largeScreenLayoutPrefKey, nextValue);
+      await LargeScreenModePreferences.save(nextValue);
     } catch (e) {
       debugPrint('[MainPageState] 保存大屏幕模式设置失败: $e');
     }
@@ -1572,420 +1565,27 @@ class MainPageState extends State<MainPage>
             if (!globals.isDesktopOrTablet || !shouldShowAppBar) {
               return const SizedBox.shrink();
             }
-            final String themeActionLabel = isDarkMode
-                ? context.l10n.toggleToLightMode
-                : context.l10n.toggleToDarkMode;
-            final IconData themeActionIcon = isDarkMode
-                ? Icons.nightlight_rounded
-                : Icons.light_mode_rounded;
-
-            final actionButtonsInLargeLayout = Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                NipaplaySidePanel(
-                  isDarkMode: isDarkMode,
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      NipaplaySidePanelItem(
-                        isSelected: false,
-                        activeColor: const Color(0xFFFF2E55),
-                        inactiveColor:
-                            isDarkMode ? Colors.white60 : Colors.black54,
-                        onTap: _toggleLargeScreenLayout,
-                        child: Row(
-                          children: const [
-                            Icon(Icons.view_day_rounded, size: 20),
-                            SizedBox(width: 8),
-                            Expanded(
-                              child: Text(
-                                '退出大屏幕模式',
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
-                                style: TextStyle(
-                                  fontSize: 16,
-                                  fontWeight: FontWeight.bold,
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                      NipaplaySidePanelItem(
-                        isSelected: false,
-                        activeColor: const Color(0xFFFF2E55),
-                        inactiveColor:
-                            isDarkMode ? Colors.white60 : Colors.black54,
-                        onTap: () {
-                          context.read<ThemeNotifier>().themeMode =
-                              _nextThemeMode();
-                        },
-                        child: Row(
-                          children: [
-                            Icon(themeActionIcon, size: 20),
-                            const SizedBox(width: 8),
-                            Expanded(
-                              child: Text(
-                                themeActionLabel,
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
-                                style: const TextStyle(
-                                  fontSize: 16,
-                                  fontWeight: FontWeight.bold,
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                      NipaplaySidePanelItem(
-                        isSelected: false,
-                        activeColor: const Color(0xFFFF2E55),
-                        inactiveColor:
-                            isDarkMode ? Colors.white60 : Colors.black54,
-                        onTap: () => SettingsPage.showWindow(context),
-                        child: Row(
-                          children: [
-                            const Icon(Icons.settings_rounded, size: 20),
-                            const SizedBox(width: 8),
-                            Expanded(
-                              child: Text(
-                                context.l10n.settingsLabel,
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
-                                style: const TextStyle(
-                                  fontSize: 16,
-                                  fontWeight: FontWeight.bold,
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ],
-            );
-            final actionButtonsInNormalLayout = Row(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                SizedBox(
-                  height: kWindowCaptionHeight,
-                  child: Center(
-                    child: Image.asset(
-                      'assets/logo2.png',
-                      height: 24,
-                      fit: BoxFit.contain,
-                      color: isDarkMode ? Colors.white : Colors.black,
-                      colorBlendMode: BlendMode.srcIn,
-                    ),
-                  ),
-                ),
-                const SizedBox(width: 8),
-                SizedBox(
-                  height: kWindowCaptionHeight,
-                  child: Center(
-                    child: _LargeScreenLayoutToggleButton(
-                      isActive: isLargeScreenLayoutActive,
-                      onPressed: _toggleLargeScreenLayout,
-                    ),
-                  ),
-                ),
-                const SizedBox(width: 8),
-                SizedBox(
-                  height: kWindowCaptionHeight,
-                  child: Center(
-                    child: _ThemeToggleButton(
-                      onToggleFromOrigin: _handleThemeToggleFromButton,
-                    ),
-                  ),
-                ),
-                const SizedBox(width: 8),
-                SizedBox(
-                  height: kWindowCaptionHeight,
-                  child: Center(
-                    child: _SettingsEntryButton(
-                      onPressed: () => SettingsPage.showWindow(context),
-                    ),
-                  ),
-                ),
-              ],
-            );
-            return Positioned(
-              top: isLargeScreenLayoutActive ? null : topPadding,
-              left: isLargeScreenLayoutActive ? 0 : null,
-              right: isLargeScreenLayoutActive ? null : rightPadding,
-              bottom: isLargeScreenLayoutActive
-                  ? 0
-                  : null,
-              child: isLargeScreenLayoutActive
-                  ? actionButtonsInLargeLayout
-                  : Row(
-                      mainAxisSize: MainAxisSize.min,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        const SystemResourceDisplay(),
-                        const SizedBox(width: 8),
-                        actionButtonsInNormalLayout,
-                        const SizedBox(width: 8),
-                        if (!kIsWeb && (Platform.isWindows || Platform.isLinux))
-                          SizedBox(
-                            height: kWindowCaptionHeight,
-                            child: Center(
-                              child: WindowControlButtons(
-                                isMaximized: isMaximized,
-                                onMinimize: _minimizeWindow,
-                                onMaximizeRestore: _toggleWindowSize,
-                                onClose: _closeWindow,
-                              ),
-                            ),
-                          ),
-                      ],
-                    ),
+            return NipaplayLargeScreenModeActionsOverlay(
+              isDarkMode: isDarkMode,
+              isLargeScreenLayoutActive: isLargeScreenLayoutActive,
+              topPadding: topPadding,
+              rightPadding: rightPadding,
+              showWindowsButtons:
+                  !kIsWeb && (Platform.isWindows || Platform.isLinux),
+              isMaximized: isMaximized,
+              onToggleLargeScreen: _toggleLargeScreenLayout,
+              onToggleThemeFromOrigin: _handleThemeToggleFromButton,
+              onOpenSettings: () => SettingsPage.showWindow(context),
+              onMinimize: _minimizeWindow,
+              onMaximizeRestore: _toggleWindowSize,
+              onClose: _closeWindow,
             );
           },
         ),
-        if (isLargeScreenLayoutActive &&
-            !kIsWeb &&
-            (Platform.isWindows || Platform.isLinux))
-          Positioned(
-            top: topPadding,
-            right: rightPadding,
-            child: SizedBox(
-              height: kWindowCaptionHeight,
-              child: Center(
-                child: WindowControlButtons(
-                  isMaximized: isMaximized,
-                  onMinimize: _minimizeWindow,
-                  onMaximizeRestore: _toggleWindowSize,
-                  onClose: _closeWindow,
-                ),
-              ),
-            ),
-          ),
       ],
     );
 
     return content;
-  }
-}
-
-class _SettingsEntryButton extends StatefulWidget {
-  final VoidCallback onPressed;
-
-  const _SettingsEntryButton({required this.onPressed});
-
-  @override
-  State<_SettingsEntryButton> createState() => _SettingsEntryButtonState();
-}
-
-class _LargeScreenLayoutToggleButton extends StatefulWidget {
-  const _LargeScreenLayoutToggleButton({
-    required this.isActive,
-    required this.onPressed,
-  });
-
-  final bool isActive;
-  final VoidCallback onPressed;
-
-  @override
-  State<_LargeScreenLayoutToggleButton> createState() =>
-      _LargeScreenLayoutToggleButtonState();
-}
-
-class _ThemeToggleButton extends StatefulWidget {
-  final Future<void> Function(Offset globalOrigin)? onToggleFromOrigin;
-
-  const _ThemeToggleButton({this.onToggleFromOrigin});
-
-  @override
-  State<_ThemeToggleButton> createState() => _ThemeToggleButtonState();
-}
-
-class _ThemeToggleButtonState extends State<_ThemeToggleButton> {
-  bool _isHovered = false;
-  bool _isPressed = false;
-
-  void _setHovered(bool value) {
-    if (_isHovered == value) {
-      return;
-    }
-    setState(() {
-      _isHovered = value;
-    });
-  }
-
-  void _toggleTheme() {
-    final onToggleFromOrigin = widget.onToggleFromOrigin;
-    if (onToggleFromOrigin != null) {
-      final renderObject = context.findRenderObject();
-      if (renderObject is RenderBox && renderObject.hasSize) {
-        final origin =
-            renderObject.localToGlobal(renderObject.size.center(Offset.zero));
-        unawaited(onToggleFromOrigin(origin));
-        return;
-      }
-    }
-
-    final isDarkMode = Theme.of(context).brightness == Brightness.dark;
-    context.read<ThemeNotifier>().themeMode =
-        isDarkMode ? ThemeMode.light : ThemeMode.dark;
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final isDarkMode = Theme.of(context).brightness == Brightness.dark;
-    final double scale = _isPressed ? 0.92 : (_isHovered ? 1.1 : 1.0);
-    final Color iconColor = _isHovered
-        ? const Color(0xFFFF2E55)
-        : (isDarkMode ? Colors.white : Colors.black87);
-    final icon =
-        isDarkMode ? Icons.nightlight_rounded : Icons.light_mode_rounded;
-    final tooltip = isDarkMode
-        ? context.l10n.toggleToLightMode
-        : context.l10n.toggleToDarkMode;
-
-    return Tooltip(
-      message: tooltip,
-      child: MouseRegion(
-        onEnter: (_) => _setHovered(true),
-        onExit: (_) => _setHovered(false),
-        child: GestureDetector(
-          onTapDown: (_) => setState(() => _isPressed = true),
-          onTapUp: (_) => setState(() => _isPressed = false),
-          onTapCancel: () => setState(() => _isPressed = false),
-          onTap: _toggleTheme,
-          child: AnimatedScale(
-            scale: scale,
-            duration: const Duration(milliseconds: 120),
-            child: AnimatedSwitcher(
-              duration: const Duration(milliseconds: 320),
-              switchInCurve: Curves.easeOutCubic,
-              switchOutCurve: Curves.easeInCubic,
-              transitionBuilder: (child, animation) {
-                return FadeTransition(
-                  opacity: animation,
-                  child: ScaleTransition(
-                    scale:
-                        Tween<double>(begin: 0.85, end: 1.0).animate(animation),
-                    child: RotationTransition(
-                      turns: Tween<double>(begin: 0.9, end: 1.0)
-                          .animate(animation),
-                      child: child,
-                    ),
-                  ),
-                );
-              },
-              child: Icon(
-                icon,
-                key: ValueKey<bool>(isDarkMode),
-                size: 22,
-                color: iconColor,
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _LargeScreenLayoutToggleButtonState
-    extends State<_LargeScreenLayoutToggleButton> {
-  bool _isHovered = false;
-  bool _isPressed = false;
-
-  void _setHovered(bool value) {
-    if (_isHovered == value) {
-      return;
-    }
-    setState(() {
-      _isHovered = value;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final isDarkMode = Theme.of(context).brightness == Brightness.dark;
-    final bool isActive = widget.isActive;
-    final double scale = _isPressed ? 0.92 : (_isHovered ? 1.1 : 1.0);
-    final Color iconColor = isActive
-        ? const Color(0xFFFF2E55)
-        : (_isHovered
-            ? const Color(0xFFFF2E55)
-            : (isDarkMode ? Colors.white : Colors.black87));
-    final icon = isActive ? Icons.view_day_rounded : Icons.view_sidebar_rounded;
-
-    return Tooltip(
-      message: isActive ? '退出大屏幕模式' : '大屏幕模式',
-      child: MouseRegion(
-        onEnter: (_) => _setHovered(true),
-        onExit: (_) => _setHovered(false),
-        child: GestureDetector(
-          onTapDown: (_) => setState(() => _isPressed = true),
-          onTapUp: (_) => setState(() => _isPressed = false),
-          onTapCancel: () => setState(() => _isPressed = false),
-          onTap: widget.onPressed,
-          child: AnimatedScale(
-            scale: scale,
-            duration: const Duration(milliseconds: 120),
-            child: Icon(
-              icon,
-              size: 22,
-              color: iconColor,
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _SettingsEntryButtonState extends State<_SettingsEntryButton> {
-  bool _isHovered = false;
-  bool _isPressed = false;
-
-  void _setHovered(bool value) {
-    if (_isHovered == value) {
-      return;
-    }
-    setState(() {
-      _isHovered = value;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final isDarkMode = Theme.of(context).brightness == Brightness.dark;
-    final double scale = _isPressed ? 0.92 : (_isHovered ? 1.1 : 1.0);
-    final Color iconColor = _isHovered
-        ? const Color(0xFFFF2E55)
-        : (isDarkMode ? Colors.white : Colors.black87);
-
-    return Tooltip(
-      message: context.l10n.settingsLabel,
-      child: MouseRegion(
-        onEnter: (_) => _setHovered(true),
-        onExit: (_) => _setHovered(false),
-        child: GestureDetector(
-          onTapDown: (_) => setState(() => _isPressed = true),
-          onTapUp: (_) => setState(() => _isPressed = false),
-          onTapCancel: () => setState(() => _isPressed = false),
-          onTap: widget.onPressed,
-          child: AnimatedScale(
-            scale: scale,
-            duration: const Duration(milliseconds: 120),
-            child: Icon(
-              Icons.settings_rounded,
-              size: 22,
-              color: iconColor,
-            ),
-          ),
-        ),
-      ),
-    );
   }
 }
 

--- a/lib/pages/anime_detail_page.dart
+++ b/lib/pages/anime_detail_page.dart
@@ -30,10 +30,14 @@ import 'package:nipaplay/providers/appearance_settings_provider.dart';
 import 'package:nipaplay/providers/watch_history_provider.dart';
 import 'package:nipaplay/utils/globals.dart' as globals;
 import 'package:nipaplay/utils/media_source_utils.dart';
-import 'package:meta/meta.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/anime_detail_shell.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_anime_detail_page.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_focusable_action.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_mode_scope.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_home_scope.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/settings_no_ripple_theme.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/nipaplay_window.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_window_page.dart';
 import 'package:nipaplay/services/web_remote_access_service.dart';
 
 enum _EpisodeCleanupAction {
@@ -48,6 +52,7 @@ class AnimeDetailPage extends StatefulWidget {
   final PlayableItem Function(SharedRemoteEpisode episode)?
       sharedEpisodeBuilder;
   final String? sharedSourceLabel;
+  final bool renderInWindowScaffold;
 
   const AnimeDetailPage({
     super.key,
@@ -56,6 +61,7 @@ class AnimeDetailPage extends StatefulWidget {
     this.sharedEpisodeLoader,
     this.sharedEpisodeBuilder,
     this.sharedSourceLabel,
+    this.renderInWindowScaffold = true,
   });
 
   @override
@@ -77,6 +83,22 @@ class AnimeDetailPage extends StatefulWidget {
     PlayableItem Function(SharedRemoteEpisode episode)? sharedEpisodeBuilder,
     String? sharedSourceLabel,
   }) {
+    if (NipaplayLargeScreenModeScope.isActiveOf(context)) {
+      return Navigator.of(context).push<WatchHistoryItem>(
+        NipaplayLargeScreenWindowPageRoute<WatchHistoryItem>(
+          enableAnimation: true,
+          dismissible: false,
+          builder: (_) => NipaplayLargeScreenAnimeDetailPage(
+                animeId: animeId,
+                sharedSummary: sharedSummary,
+                sharedEpisodeLoader: sharedEpisodeLoader,
+                sharedEpisodeBuilder: sharedEpisodeBuilder,
+                sharedSourceLabel: sharedSourceLabel,
+              ),
+        ),
+      );
+    }
+
     // 获取外观设置Provider
     final appearanceSettings =
         Provider.of<AppearanceSettingsProvider>(context, listen: false);
@@ -122,6 +144,9 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
   int? _hoveredEpisodeTileId;
   int? _hoveredWatchToggleEpisodeId;
   bool _isBangumiRatingButtonHovered = false;
+  final FocusNode _largeScreenDetailsFocusNode = FocusNode(
+    debugLabel: 'large_screen_anime_detail_content_focus',
+  );
 
   // 弹弹play观看状态相关
   /// 存储弹弹play的观看状态
@@ -180,6 +205,30 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
     4: '搁置',
     5: '抛弃',
   };
+
+  bool get _isLargeScreenModeActive {
+    return NipaplayLargeScreenHomeScope.isActive(context) ||
+        NipaplayLargeScreenModeScope.isActiveOf(context);
+  }
+
+  Widget _wrapLargeScreenFocusable({
+    required Widget child,
+    required VoidCallback? onActivate,
+    BorderRadius borderRadius = BorderRadius.zero,
+    EdgeInsetsGeometry? padding,
+    bool autofocus = false,
+  }) {
+    if (!_isLargeScreenModeActive) {
+      return child;
+    }
+    return NipaplayLargeScreenFocusableAction(
+      onActivate: onActivate,
+      borderRadius: borderRadius,
+      padding: padding,
+      autofocus: autofocus,
+      child: child,
+    );
+  }
 
   @override
   void initState() {
@@ -278,6 +327,7 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
         .removeListener(_onBangumiLoginStatusChanged);
     _tabController?.removeListener(_handleTabChange);
     _tabController?.dispose();
+    _largeScreenDetailsFocusNode.dispose();
     super.dispose();
   }
 
@@ -619,22 +669,78 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
     }
   }
 
-  String _formatDate(String? dateStr) {
-    if (dateStr == null || dateStr.isEmpty) return '';
-    try {
-      // 移除 T00:00:00 部分
-      dateStr = dateStr.replaceAll(RegExp(r'T\d{2}:\d{2}:\d{2}'), '');
-
-      final parts = dateStr.split('-');
-      if (parts.length >= 3) return '${parts[0]}年${parts[1]}月${parts[2]}日';
-      return dateStr;
-    } catch (e) {
-      return dateStr ?? '';
-    }
-  }
-
   String _collectionTypeLabel(int type) {
     return _collectionTypeLabels[type] ?? '未收藏';
+  }
+
+  Future<void> _playEpisodeFromHistoryOrShared({
+    required BangumiAnime anime,
+    required EpisodeData episode,
+    required WatchHistoryItem? historyItem,
+    required ConnectionState historyState,
+    required bool sharedPlayableAvailable,
+    required PlayableItem? sharedPlayable,
+  }) async {
+    if (sharedPlayableAvailable && sharedPlayable != null) {
+      await PlaybackService().play(sharedPlayable);
+      if (mounted) {
+        Navigator.of(context).pop();
+      }
+      return;
+    }
+
+    if (historyState == ConnectionState.done &&
+        historyItem != null &&
+        historyItem.filePath.isNotEmpty) {
+      final filePath = historyItem.filePath;
+      final lowerPath = filePath.toLowerCase();
+      final bool isRemoteSource = historyItem.isDandanplayRemote ||
+          lowerPath.startsWith('http://') ||
+          lowerPath.startsWith('https://') ||
+          lowerPath.startsWith('jellyfin://') ||
+          lowerPath.startsWith('emby://') ||
+          MediaSourceUtils.isWebDavPath(filePath) ||
+          MediaSourceUtils.isSmbPath(filePath);
+
+      if (isRemoteSource) {
+        final playableItem = PlayableItem(
+          videoPath: filePath,
+          title: anime.nameCn,
+          subtitle: episode.title,
+          animeId: anime.id,
+          episodeId: episode.id,
+          historyItem: historyItem,
+        );
+        await PlaybackService().play(playableItem);
+        if (mounted) {
+          Navigator.of(context).pop();
+        }
+        return;
+      }
+
+      final file = File(filePath);
+      if (await file.exists()) {
+        final playableItem = PlayableItem(
+          videoPath: filePath,
+          title: anime.nameCn,
+          subtitle: episode.title,
+          animeId: anime.id,
+          episodeId: episode.id,
+          historyItem: historyItem,
+        );
+        await PlaybackService().play(playableItem);
+        if (mounted) {
+          Navigator.of(context).pop();
+        }
+      } else if (mounted) {
+        BlurSnackBar.show(context, '文件已不存在于: ${historyItem.filePath}');
+      }
+      return;
+    }
+
+    if (mounted) {
+      BlurSnackBar.show(context, '媒体库中找不到此剧集的视频文件');
+    }
   }
 
   int _getTotalEpisodeCount(BangumiAnime anime) {
@@ -1162,7 +1268,7 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
                             : textColor.withOpacity(0.9))
                         : textColor.withOpacity(0.45);
 
-                    return MouseRegion(
+                    final button = MouseRegion(
                       cursor: enableBangumiHover
                           ? SystemMouseCursors.click
                           : SystemMouseCursors.basic,
@@ -1223,6 +1329,12 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
                           ),
                         ),
                       ),
+                    );
+                    return _wrapLargeScreenFocusable(
+                      child: button,
+                      onActivate:
+                          isBangumiActionEnabled ? _showRatingDialog : null,
+                      borderRadius: BorderRadius.circular(6),
                     );
                   },
                 ),
@@ -1404,14 +1516,18 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 Text('标签:', style: sectionTitleStyle),
-                IconButton(
-                  onPressed: () => _openTagSearch(),
-                  icon: Icon(
-                    Ionicons.search,
-                    color: secondaryTextColor,
+                _wrapLargeScreenFocusable(
+                  onActivate: _openTagSearch,
+                  borderRadius: BorderRadius.circular(6),
+                  child: IconButton(
+                    onPressed: _isLargeScreenModeActive ? null : _openTagSearch,
+                    icon: Icon(
+                      Ionicons.search,
+                      color: secondaryTextColor,
+                    ),
+                    padding: const EdgeInsets.all(4),
+                    constraints: const BoxConstraints(),
                   ),
-                  padding: const EdgeInsets.all(4),
-                  constraints: const BoxConstraints(),
                 ),
               ],
             ),
@@ -1423,6 +1539,7 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
                     .map((tag) => _HoverableTag(
                           tag: tag,
                           onTap: () => _searchByTag(tag),
+                          isLargeScreenMode: _isLargeScreenModeActive,
                         ))
                     .toList())
           ],
@@ -1554,51 +1671,59 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
               else
                 const SizedBox.shrink(),
               const Spacer(),
-              MouseRegion(
-                cursor: _isCleaningEpisodeHistory
-                    ? SystemMouseCursors.basic
-                    : SystemMouseCursors.click,
-                onEnter: _isCleaningEpisodeHistory
+              _wrapLargeScreenFocusable(
+                onActivate: _isCleaningEpisodeHistory
                     ? null
-                    : (_) => setState(() => _isCleanupButtonHovered = true),
-                onExit: _isCleaningEpisodeHistory
-                    ? null
-                    : (_) => setState(() => _isCleanupButtonHovered = false),
-                child: GestureDetector(
-                  onTap: _isCleaningEpisodeHistory
+                    : () => _showEpisodeListCleanupDialog(anime),
+                borderRadius: BorderRadius.circular(6),
+                child: MouseRegion(
+                  cursor: _isCleaningEpisodeHistory
+                      ? SystemMouseCursors.basic
+                      : SystemMouseCursors.click,
+                  onEnter: _isCleaningEpisodeHistory
                       ? null
-                      : () => _showEpisodeListCleanupDialog(anime),
-                  behavior: HitTestBehavior.opaque,
-                  child: AnimatedScale(
-                    scale: _isCleanupButtonHovered ? 1.1 : 1.0,
-                    duration: const Duration(milliseconds: 180),
-                    curve: Curves.easeOutCubic,
-                    child: AnimatedDefaultTextStyle(
+                      : (_) => setState(() => _isCleanupButtonHovered = true),
+                  onExit: _isCleaningEpisodeHistory
+                      ? null
+                      : (_) => setState(() => _isCleanupButtonHovered = false),
+                  child: GestureDetector(
+                    onTap: _isLargeScreenModeActive
+                        ? null
+                        : (_isCleaningEpisodeHistory
+                            ? null
+                            : () => _showEpisodeListCleanupDialog(anime)),
+                    behavior: HitTestBehavior.opaque,
+                    child: AnimatedScale(
+                      scale: _isCleanupButtonHovered ? 1.1 : 1.0,
                       duration: const Duration(milliseconds: 180),
-                      style: TextStyle(
-                        color: cleanupButtonColor,
-                        fontSize: 12,
-                      ),
-                      child: IconTheme(
-                        data: IconThemeData(
+                      curve: Curves.easeOutCubic,
+                      child: AnimatedDefaultTextStyle(
+                        duration: const Duration(milliseconds: 180),
+                        style: TextStyle(
                           color: cleanupButtonColor,
-                          size: 16,
+                          fontSize: 12,
                         ),
-                        child: Padding(
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 8,
-                            vertical: 6,
+                        child: IconTheme(
+                          data: IconThemeData(
+                            color: cleanupButtonColor,
+                            size: 16,
                           ),
-                          child: Row(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              const Icon(Ionicons.trash_outline),
-                              const SizedBox(width: 4),
-                              Text(
-                                _isCleaningEpisodeHistory ? '处理中' : '清理记录',
-                                locale: const Locale('zh-Hans', 'zh'),
-                              ),
-                            ],
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 8,
+                              vertical: 6,
+                            ),
+                            child: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                const Icon(Ionicons.trash_outline),
+                                const SizedBox(width: 4),
+                                Text(
+                                  _isCleaningEpisodeHistory ? '处理中' : '清理记录',
+                                  locale: const Locale('zh-Hans', 'zh'),
+                                ),
+                              ],
+                            ),
                           ),
                         ),
                       ),
@@ -1606,47 +1731,57 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
                   ),
                 ),
               ),
-              MouseRegion(
-                cursor: SystemMouseCursors.click,
-                onEnter: (_) => setState(() => _isSortButtonHovered = true),
-                onExit: (_) => setState(() => _isSortButtonHovered = false),
-                child: GestureDetector(
-                  onTap: () {
-                    setState(() {
-                      _isEpisodeListReversed = !_isEpisodeListReversed;
-                    });
-                  },
-                  behavior: HitTestBehavior.opaque,
-                  child: AnimatedScale(
-                    scale: _isSortButtonHovered ? 1.1 : 1.0,
-                    duration: const Duration(milliseconds: 180),
-                    curve: Curves.easeOutCubic,
-                    child: AnimatedDefaultTextStyle(
+              _wrapLargeScreenFocusable(
+                onActivate: () {
+                  setState(() {
+                    _isEpisodeListReversed = !_isEpisodeListReversed;
+                  });
+                },
+                borderRadius: BorderRadius.circular(6),
+                child: MouseRegion(
+                  cursor: SystemMouseCursors.click,
+                  onEnter: (_) => setState(() => _isSortButtonHovered = true),
+                  onExit: (_) => setState(() => _isSortButtonHovered = false),
+                  child: GestureDetector(
+                    onTap: _isLargeScreenModeActive
+                        ? null
+                        : () {
+                            setState(() {
+                              _isEpisodeListReversed = !_isEpisodeListReversed;
+                            });
+                          },
+                    behavior: HitTestBehavior.opaque,
+                    child: AnimatedScale(
+                      scale: _isSortButtonHovered ? 1.1 : 1.0,
                       duration: const Duration(milliseconds: 180),
-                      style: TextStyle(
-                        color: sortButtonColor,
-                        fontSize: 12,
-                      ),
-                      child: IconTheme(
-                        data: IconThemeData(
+                      curve: Curves.easeOutCubic,
+                      child: AnimatedDefaultTextStyle(
+                        duration: const Duration(milliseconds: 180),
+                        style: TextStyle(
                           color: sortButtonColor,
-                          size: 16,
+                          fontSize: 12,
                         ),
-                        child: Padding(
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 8,
-                            vertical: 6,
+                        child: IconTheme(
+                          data: IconThemeData(
+                            color: sortButtonColor,
+                            size: 16,
                           ),
-                          child: Row(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              const Icon(Ionicons.swap_vertical_outline),
-                              const SizedBox(width: 4),
-                              Text(
-                                _isEpisodeListReversed ? '倒序' : '正序',
-                                locale: const Locale('zh-Hans', 'zh'),
-                              ),
-                            ],
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 8,
+                              vertical: 6,
+                            ),
+                            child: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                const Icon(Ionicons.swap_vertical_outline),
+                                const SizedBox(width: 4),
+                                Text(
+                                  _isEpisodeListReversed ? '倒序' : '正序',
+                                  locale: const Locale('zh-Hans', 'zh'),
+                                ),
+                              ],
+                            ),
                           ),
                         ),
                       ),
@@ -1753,7 +1888,7 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
                       }
                     }
 
-                    return MouseRegion(
+                    final tile = MouseRegion(
                       cursor: enableEpisodeHover
                           ? SystemMouseCursors.click
                           : SystemMouseCursors.basic,
@@ -1851,6 +1986,7 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
                                       !isEpisodeWatched &&
                                       _hoveredWatchToggleEpisodeId ==
                                           episode.id,
+                                  isLargeScreenMode: _isLargeScreenModeActive,
                                   onHoverChanged: (value) {
                                     if (!mounted || isEpisodeWatched) return;
                                     setState(() {
@@ -1888,63 +2024,33 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
                                 ),
                             ],
                           ),
-                          onTap: () async {
-                            if (sharedPlayableAvailable) {
-                              await PlaybackService().play(sharedPlayable!);
-                              if (mounted) Navigator.pop(context);
-                              return;
-                            }
-
-                            if (historySnapshot.connectionState ==
-                                    ConnectionState.done &&
-                                historyItem != null &&
-                                historyItem.filePath.isNotEmpty) {
-                              final filePath = historyItem.filePath;
-                              final lowerPath = filePath.toLowerCase();
-                              final bool isRemoteSource =
-                                  historyItem.isDandanplayRemote ||
-                                      lowerPath.startsWith('http://') ||
-                                      lowerPath.startsWith('https://') ||
-                                      lowerPath.startsWith('jellyfin://') ||
-                                      lowerPath.startsWith('emby://') ||
-                                      MediaSourceUtils.isWebDavPath(filePath) ||
-                                      MediaSourceUtils.isSmbPath(filePath);
-
-                              if (isRemoteSource) {
-                                final playableItem = PlayableItem(
-                                  videoPath: filePath,
-                                  title: anime.nameCn,
-                                  subtitle: episode.title,
-                                  animeId: anime.id,
-                                  episodeId: episode.id,
-                                  historyItem: historyItem,
-                                );
-                                await PlaybackService().play(playableItem);
-                                if (mounted) Navigator.pop(context);
-                              } else {
-                                final file = File(filePath);
-                                if (await file.exists()) {
-                                  final playableItem = PlayableItem(
-                                    videoPath: filePath,
-                                    title: anime.nameCn,
-                                    subtitle: episode.title,
-                                    animeId: anime.id,
-                                    episodeId: episode.id,
+                          onTap: _isLargeScreenModeActive
+                              ? null
+                              : () => _playEpisodeFromHistoryOrShared(
+                                    anime: anime,
+                                    episode: episode,
                                     historyItem: historyItem,
-                                  );
-                                  await PlaybackService().play(playableItem);
-                                  if (mounted) Navigator.pop(context);
-                                } else {
-                                  BlurSnackBar.show(context,
-                                      '文件已不存在于: ${historyItem.filePath}');
-                                }
-                              }
-                            } else {
-                              BlurSnackBar.show(context, '媒体库中找不到此剧集的视频文件');
-                            }
-                          },
+                                    historyState:
+                                        historySnapshot.connectionState,
+                                    sharedPlayableAvailable:
+                                        sharedPlayableAvailable,
+                                    sharedPlayable: sharedPlayable,
+                                  ),
                         ),
                       ),
+                    );
+                    return _wrapLargeScreenFocusable(
+                      child: tile,
+                      onActivate: () => _playEpisodeFromHistoryOrShared(
+                        anime: anime,
+                        episode: episode,
+                        historyItem: historyItem,
+                        historyState: historySnapshot.connectionState,
+                        sharedPlayableAvailable: sharedPlayableAvailable,
+                        sharedPlayable: sharedPlayable,
+                      ),
+                      borderRadius: BorderRadius.circular(6),
+                      autofocus: index == 0,
                     );
                   },
                 );
@@ -1956,7 +2062,7 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
     );
   }
 
-  Widget _buildContent() {
+  Widget _buildContent({Widget? inlineHeaderAction}) {
     final bool isDark = Theme.of(context).brightness == Brightness.dark;
     final Color textColor = isDark ? Colors.white : Colors.black87;
     final Color secondaryTextColor = isDark ? Colors.white70 : Colors.black54;
@@ -2023,6 +2129,8 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
       title: displayTitle,
       subtitle: displaySubTitle,
       sourceLabel: _sharedSourceLabel,
+      headerActions:
+          inlineHeaderAction == null ? null : <Widget>[inlineHeaderAction],
       onClose: () => Navigator.of(context).pop(),
       tabController: _tabController,
       showTabs: !isDesktopOrTablet,
@@ -2051,6 +2159,15 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
 
   @override
   Widget build(BuildContext context) {
+    if (_isLargeScreenModeActive) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        if (!_largeScreenDetailsFocusNode.hasFocus) {
+          _largeScreenDetailsFocusNode.requestFocus();
+        }
+      });
+    }
+
     final bool isDark = Theme.of(context).brightness == Brightness.dark;
     final Color secondaryTextColor = isDark ? Colors.white70 : Colors.black54;
     final Widget? topRightAction = DandanplayService.isLoggedIn
@@ -2059,15 +2176,28 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
             isToggling: _isTogglingFavorite,
             onTap: _toggleFavorite,
             secondaryTextColor: secondaryTextColor,
+            isLargeScreenMode: _isLargeScreenModeActive,
           )
         : null;
+    final Widget? inlineHeaderAction =
+        widget.renderInWindowScaffold ? null : topRightAction;
+
+    final content = Focus(
+      focusNode: _largeScreenDetailsFocusNode,
+      canRequestFocus: _isLargeScreenModeActive,
+      child: _buildContent(inlineHeaderAction: inlineHeaderAction),
+    );
+
+    if (!widget.renderInWindowScaffold) {
+      return content;
+    }
 
     return NipaplayWindowScaffold(
       backgroundImageUrl: _getPosterUrl(),
       blurBackground: true, // Bangumi通常返回的是竖向封面，开启模糊以提升质感
       onClose: () => Navigator.of(context).pop(),
       topRightAction: topRightAction,
-      child: _buildContent(),
+      child: content,
     );
   }
 
@@ -2444,10 +2574,12 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
 class _HoverableTag extends StatefulWidget {
   final String tag;
   final VoidCallback onTap;
+  final bool isLargeScreenMode;
 
   const _HoverableTag({
     required this.tag,
     required this.onTap,
+    required this.isLargeScreenMode,
   });
 
   @override
@@ -2509,9 +2641,17 @@ class _HoverableTagState extends State<_HoverableTag> {
       );
     }
 
-    return GestureDetector(
-      onTap: widget.onTap,
+    final tappable = GestureDetector(
+      onTap: widget.isLargeScreenMode ? null : widget.onTap,
       child: chip,
+    );
+    if (!widget.isLargeScreenMode) {
+      return tappable;
+    }
+    return NipaplayLargeScreenFocusableAction(
+      onActivate: widget.onTap,
+      borderRadius: BorderRadius.circular(20),
+      child: tappable,
     );
   }
 }
@@ -2523,6 +2663,7 @@ class _EpisodeWatchToggleButton extends StatelessWidget {
   final Color idleColor;
   final VoidCallback? onTap;
   final ValueChanged<bool>? onHoverChanged;
+  final bool isLargeScreenMode;
 
   const _EpisodeWatchToggleButton({
     required this.isEnabled,
@@ -2531,18 +2672,19 @@ class _EpisodeWatchToggleButton extends StatelessWidget {
     required this.idleColor,
     required this.onTap,
     required this.onHoverChanged,
+    required this.isLargeScreenMode,
   });
 
   @override
   Widget build(BuildContext context) {
     final Color displayColor = isHovered ? const Color(0xFFFF2E55) : idleColor;
 
-    return MouseRegion(
+    final button = MouseRegion(
       cursor: isEnabled ? SystemMouseCursors.click : SystemMouseCursors.basic,
       onEnter: isEnabled ? (_) => onHoverChanged?.call(true) : null,
       onExit: isEnabled ? (_) => onHoverChanged?.call(false) : null,
       child: GestureDetector(
-        onTap: onTap,
+        onTap: isLargeScreenMode ? null : onTap,
         behavior: HitTestBehavior.opaque,
         child: AnimatedScale(
           scale: isHovered ? 1.1 : 1.0,
@@ -2562,6 +2704,14 @@ class _EpisodeWatchToggleButton extends StatelessWidget {
         ),
       ),
     );
+    if (!isLargeScreenMode) {
+      return button;
+    }
+    return NipaplayLargeScreenFocusableAction(
+      onActivate: onTap,
+      borderRadius: BorderRadius.circular(8),
+      child: button,
+    );
   }
 }
 
@@ -2570,12 +2720,14 @@ class _WindowFavoriteButton extends StatefulWidget {
   final bool isToggling;
   final VoidCallback onTap;
   final Color secondaryTextColor;
+  final bool isLargeScreenMode;
 
   const _WindowFavoriteButton({
     required this.isFavorited,
     required this.isToggling,
     required this.onTap,
     required this.secondaryTextColor,
+    required this.isLargeScreenMode,
   });
 
   @override
@@ -2623,7 +2775,7 @@ class _WindowFavoriteButtonState extends State<_WindowFavoriteButton>
     final Color iconColor = _isHovered ? baseColor : baseColor;
     final double scale = _isPressed ? 0.92 : (_isHovered ? 1.1 : 1.0);
 
-    return ScaleTransition(
+    final button = ScaleTransition(
       scale: _scaleAnimation,
       child: MouseRegion(
         cursor: widget.isToggling
@@ -2632,11 +2784,15 @@ class _WindowFavoriteButtonState extends State<_WindowFavoriteButton>
         onEnter: (_) => setState(() => _isHovered = true),
         onExit: (_) => setState(() => _isHovered = false),
         child: GestureDetector(
-          onTap: widget.isToggling ? null : widget.onTap,
-          onTapDown:
-              widget.isToggling ? null : (_) => setState(() => _isPressed = true),
-          onTapUp:
-              widget.isToggling ? null : (_) => setState(() => _isPressed = false),
+          onTap: (widget.isToggling || widget.isLargeScreenMode)
+              ? null
+              : widget.onTap,
+          onTapDown: widget.isToggling
+              ? null
+              : (_) => setState(() => _isPressed = true),
+          onTapUp: widget.isToggling
+              ? null
+              : (_) => setState(() => _isPressed = false),
           onTapCancel: () => setState(() => _isPressed = false),
           behavior: HitTestBehavior.opaque,
           child: AnimatedScale(
@@ -2654,7 +2810,8 @@ class _WindowFavoriteButtonState extends State<_WindowFavoriteButton>
                           height: 14,
                           child: CircularProgressIndicator(
                             strokeWidth: 2,
-                            valueColor: AlwaysStoppedAnimation<Color>(baseColor),
+                            valueColor:
+                                AlwaysStoppedAnimation<Color>(baseColor),
                           ),
                         )
                       : Icon(
@@ -2670,6 +2827,14 @@ class _WindowFavoriteButtonState extends State<_WindowFavoriteButton>
           ),
         ),
       ),
+    );
+    if (!widget.isLargeScreenMode) {
+      return button;
+    }
+    return NipaplayLargeScreenFocusableAction(
+      onActivate: widget.isToggling ? null : widget.onTap,
+      borderRadius: BorderRadius.circular(6),
+      child: button,
     );
   }
 }

--- a/lib/pages/dashboard_home_page.dart
+++ b/lib/pages/dashboard_home_page.dart
@@ -36,6 +36,7 @@ import 'package:nipaplay/themes/nipaplay/widgets/nipaplay_window.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/tag_search_widget.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/floating_action_glass_button.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/startup_notification_controller.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_focusable_action.dart';
 import 'package:nipaplay/themes/nipaplay/pages/settings/watch_history_page.dart';
 import 'package:nipaplay/pages/media_server_detail_page.dart';
 import 'package:nipaplay/pages/anime_detail_page.dart';

--- a/lib/pages/dashboard_home_page.dart
+++ b/lib/pages/dashboard_home_page.dart
@@ -52,13 +52,14 @@ import 'package:nipaplay/providers/home_sections_settings_provider.dart';
 import 'package:nipaplay/utils/video_player_state.dart';
 import 'package:nipaplay/utils/tab_change_notifier.dart';
 import 'package:nipaplay/utils/media_source_utils.dart';
-import 'package:nipaplay/main.dart'; // 用于MainPageState
+import 'package:nipaplay/main.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:nipaplay/models/watch_history_model.dart';
 import 'package:nipaplay/services/server_history_sync_service.dart';
 import 'package:nipaplay/models/shared_remote_library.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/themed_anime_detail.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_home_scope.dart';
 import 'package:nipaplay/utils/watch_history_auto_match_helper.dart';
 
 part '../themes/nipaplay/widgets/dashboard_home_page_data_loading.dart';
@@ -78,6 +79,27 @@ class DashboardHomePage extends StatefulWidget {
 
 class _DashboardHomePageState extends State<DashboardHomePage>
     with AutomaticKeepAliveClientMixin {
+  bool get _isLargeScreenModeActive {
+    return NipaplayLargeScreenHomeScope.isActive(context);
+  }
+
+  Widget _wrapLargeScreenFocusable({
+    required Widget child,
+    required VoidCallback? onActivate,
+    BorderRadius borderRadius = BorderRadius.zero,
+    EdgeInsetsGeometry? padding,
+  }) {
+    if (!_isLargeScreenModeActive) {
+      return child;
+    }
+    return NipaplayLargeScreenFocusableAction(
+      onActivate: onActivate,
+      borderRadius: borderRadius,
+      padding: padding,
+      child: child,
+    );
+  }
+
   // 持有Provider实例引用，确保在dispose中能正确移除监听器
   JellyfinProvider? _jellyfinProviderRef;
   EmbyProvider? _embyProviderRef;
@@ -961,18 +983,24 @@ class _DashboardHomePageState extends State<DashboardHomePage>
           return SingleChildScrollView(
             controller: _mainScrollController,
             physics: const AlwaysScrollableScrollPhysics(),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                // 大海报推荐区域
-                _buildHeroBanner(isPhone: isPhone),
+            child: PrimaryScrollController(
+              controller: _mainScrollController,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // 大海报推荐区域
+                  _buildHeroBanner(isPhone: isPhone),
 
-                SizedBox(height: isPhone ? 16 : 32),
-                ...configuredSections,
+                  SizedBox(height: isPhone ? 16 : 32),
+                  ...configuredSections,
 
-                // 底部间距
-                SizedBox(height: isPhone ? 30 : 50),
-              ],
+                  // 底部间距（大屏幕模式额外预留40px，避免被底部overlay遮挡）
+                  SizedBox(
+                    height: (isPhone ? 30 : 50) +
+                        (_isLargeScreenModeActive ? 40 : 0),
+                  ),
+                ],
+              ),
             ),
           );
         },

--- a/lib/providers/labs_settings_provider.dart
+++ b/lib/providers/labs_settings_provider.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/foundation.dart';
+import 'package:nipaplay/constants/settings_keys.dart';
+import 'package:nipaplay/utils/settings_storage.dart';
+
+class LabsSettingsProvider extends ChangeNotifier {
+  LabsSettingsProvider() {
+    _loadSettings();
+  }
+
+  bool _enableLargeScreenMode = false;
+  bool _isLoaded = false;
+
+  bool get enableLargeScreenMode => _enableLargeScreenMode;
+  bool get isLoaded => _isLoaded;
+
+  Future<void> _loadSettings() async {
+    _enableLargeScreenMode = await SettingsStorage.loadBool(
+      SettingsKeys.labsEnableLargeScreenMode,
+      defaultValue: false,
+    );
+    _isLoaded = true;
+    notifyListeners();
+  }
+
+  Future<void> setEnableLargeScreenMode(bool enabled) async {
+    if (_enableLargeScreenMode == enabled) return;
+    _enableLargeScreenMode = enabled;
+    notifyListeners();
+    await SettingsStorage.saveBool(
+      SettingsKeys.labsEnableLargeScreenMode,
+      enabled,
+    );
+  }
+}

--- a/lib/themes/cupertino/pages/cupertino_settings_page.dart
+++ b/lib/themes/cupertino/pages/cupertino_settings_page.dart
@@ -3,6 +3,7 @@ import 'package:nipaplay/l10n/l10n.dart';
 
 import 'settings/sections/cupertino_settings_general_section.dart';
 import 'settings/sections/cupertino_settings_about_section.dart';
+import 'settings/sections/cupertino_settings_labs_section.dart';
 
 class CupertinoSettingsPage extends StatefulWidget {
   const CupertinoSettingsPage({super.key});
@@ -59,6 +60,8 @@ class _CupertinoSettingsPageState extends State<CupertinoSettingsPage> {
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: const [
                       CupertinoSettingsGeneralSection(),
+                      SizedBox(height: 24),
+                      CupertinoSettingsLabsSection(),
                       SizedBox(height: 24),
                       CupertinoSettingsAboutSection(),
                     ],

--- a/lib/themes/cupertino/pages/settings/pages/cupertino_labs_settings_page.dart
+++ b/lib/themes/cupertino/pages/settings/pages/cupertino_labs_settings_page.dart
@@ -1,0 +1,73 @@
+import 'package:nipaplay/themes/cupertino/cupertino_adaptive_platform_ui.dart';
+import 'package:nipaplay/themes/cupertino/cupertino_imports.dart';
+import 'package:nipaplay/providers/labs_settings_provider.dart';
+import 'package:nipaplay/themes/cupertino/widgets/cupertino_settings_group_card.dart';
+import 'package:nipaplay/themes/cupertino/widgets/cupertino_settings_tile.dart';
+import 'package:nipaplay/utils/cupertino_settings_colors.dart';
+import 'package:provider/provider.dart';
+
+class CupertinoLabsSettingsPage extends StatelessWidget {
+  const CupertinoLabsSettingsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final Color backgroundColor = CupertinoDynamicColor.resolve(
+      CupertinoColors.systemGroupedBackground,
+      context,
+    );
+    final double topPadding = MediaQuery.of(context).padding.top + 64;
+
+    return Consumer<LabsSettingsProvider>(
+      builder: (context, labsSettings, child) {
+        return AdaptiveScaffold(
+          appBar: const AdaptiveAppBar(
+            title: '实验室',
+            useNativeToolbar: true,
+          ),
+          body: ColoredBox(
+            color: backgroundColor,
+            child: SafeArea(
+              top: false,
+              bottom: false,
+              child: ListView(
+                physics: const BouncingScrollPhysics(
+                  parent: AlwaysScrollableScrollPhysics(),
+                ),
+                padding: EdgeInsets.fromLTRB(16, topPadding, 16, 32),
+                children: [
+                  CupertinoSettingsGroupCard(
+                    margin: EdgeInsets.zero,
+                    backgroundColor: resolveSettingsSectionBackground(context),
+                    addDividers: true,
+                    children: [
+                      CupertinoSettingsTile(
+                        leading: Icon(
+                          CupertinoIcons.tv,
+                          color: resolveSettingsIconColor(context),
+                        ),
+                        title: const Text('大屏幕模式'),
+                        subtitle: const Text('开启后，NipaPlay 主题右上角显示大屏幕模式按钮'),
+                        trailing: AdaptiveSwitch(
+                          value: labsSettings.enableLargeScreenMode,
+                          onChanged: (value) {
+                            labsSettings.setEnableLargeScreenMode(value);
+                          },
+                        ),
+                        onTap: () {
+                          labsSettings.setEnableLargeScreenMode(
+                            !labsSettings.enableLargeScreenMode,
+                          );
+                        },
+                        backgroundColor: resolveSettingsTileBackground(context),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/themes/cupertino/pages/settings/sections/cupertino_settings_labs_section.dart
+++ b/lib/themes/cupertino/pages/settings/sections/cupertino_settings_labs_section.dart
@@ -1,0 +1,39 @@
+import 'package:nipaplay/themes/cupertino/cupertino_imports.dart';
+import 'package:nipaplay/themes/cupertino/widgets/cupertino_settings_group_card.dart';
+import 'package:nipaplay/utils/cupertino_settings_colors.dart';
+
+import '../widgets/labs_setting_tile.dart';
+
+class CupertinoSettingsLabsSection extends StatelessWidget {
+  const CupertinoSettingsLabsSection({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final textStyle = CupertinoTheme.of(context).textTheme.textStyle.copyWith(
+          fontSize: 13,
+          color: CupertinoDynamicColor.resolve(
+            CupertinoColors.systemGrey,
+            context,
+          ),
+          letterSpacing: 0.2,
+        );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20),
+          child: Text('实验室', style: textStyle),
+        ),
+        const SizedBox(height: 8),
+        CupertinoSettingsGroupCard(
+          addDividers: true,
+          backgroundColor: resolveSettingsSectionBackground(context),
+          children: const [
+            CupertinoLabsSettingTile(),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/themes/cupertino/pages/settings/widgets/labs_setting_tile.dart
+++ b/lib/themes/cupertino/pages/settings/widgets/labs_setting_tile.dart
@@ -1,0 +1,29 @@
+import 'package:nipaplay/themes/cupertino/cupertino_imports.dart';
+import 'package:nipaplay/themes/cupertino/pages/settings/pages/cupertino_labs_settings_page.dart';
+import 'package:nipaplay/themes/cupertino/widgets/cupertino_settings_tile.dart';
+import 'package:nipaplay/utils/cupertino_settings_colors.dart';
+
+class CupertinoLabsSettingTile extends StatelessWidget {
+  const CupertinoLabsSettingTile({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final Color iconColor = resolveSettingsIconColor(context);
+    final Color tileColor = resolveSettingsTileBackground(context);
+
+    return CupertinoSettingsTile(
+      leading: Icon(CupertinoIcons.lab_flask, color: iconColor),
+      title: const Text('实验室'),
+      subtitle: const Text('实验性功能与开关'),
+      backgroundColor: tileColor,
+      showChevron: true,
+      onTap: () {
+        Navigator.of(context).push(
+          CupertinoPageRoute(
+            builder: (_) => const CupertinoLabsSettingsPage(),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/themes/nipaplay/pages/settings/danmaku_settings_page.dart
+++ b/lib/themes/nipaplay/pages/settings/danmaku_settings_page.dart
@@ -9,6 +9,7 @@ import 'package:nipaplay/services/danmaku_spoiler_filter_service.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_button.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_dropdown.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_snackbar.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_editable_slider.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/settings_card.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/settings_item.dart';
 import 'package:nipaplay/utils/video_player_state.dart';
@@ -464,7 +465,7 @@ class _DanmakuSettingsPageState extends State<DanmakuSettingsPage> {
                             'default': _fluentAccentColor,
                           }),
                         ),
-                        child: fluent.Slider(
+                        child: NipaplayLargeScreenEditableSlider(
                           min: 0.0,
                           max: 2.0,
                           divisions: 40,

--- a/lib/themes/nipaplay/pages/settings/labs_page.dart
+++ b/lib/themes/nipaplay/pages/settings/labs_page.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:kmbal_ionicons/kmbal_ionicons.dart';
+import 'package:nipaplay/providers/labs_settings_provider.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/settings_item.dart';
+import 'package:provider/provider.dart';
+
+class LabsPage extends StatelessWidget {
+  const LabsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Consumer<LabsSettingsProvider>(
+      builder: (context, labsSettings, child) {
+        return ListView(
+          children: [
+            SettingsItem.toggle(
+              title: '大屏幕模式',
+              subtitle: '开启后，NipaPlay 主题右上角显示大屏幕模式按钮',
+              icon: Ionicons.tv_outline,
+              value: labsSettings.enableLargeScreenMode,
+              onChanged: (bool value) {
+                labsSettings.setEnableLargeScreenMode(value);
+              },
+            ),
+            Divider(
+              color: colorScheme.onSurface.withValues(alpha: 0.12),
+              height: 1,
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/themes/nipaplay/pages/settings/settings_entries.dart
+++ b/lib/themes/nipaplay/pages/settings/settings_entries.dart
@@ -1,0 +1,187 @@
+import 'package:flutter/material.dart';
+import 'package:kmbal_ionicons/kmbal_ionicons.dart';
+import 'package:nipaplay/l10n/l10n.dart';
+import 'package:nipaplay/pages/shortcuts_settings_page.dart';
+import 'package:nipaplay/themes/nipaplay/pages/settings/about_page.dart';
+import 'package:nipaplay/themes/nipaplay/pages/settings/backup_restore_page.dart';
+import 'package:nipaplay/themes/nipaplay/pages/settings/danmaku_settings_page.dart';
+import 'package:nipaplay/themes/nipaplay/pages/settings/developer_options_page.dart';
+import 'package:nipaplay/themes/nipaplay/pages/settings/external_player_settings_page.dart';
+import 'package:nipaplay/themes/nipaplay/pages/settings/general_page.dart';
+import 'package:nipaplay/themes/nipaplay/pages/settings/language_page.dart';
+import 'package:nipaplay/themes/nipaplay/pages/settings/network_settings_page.dart';
+import 'package:nipaplay/themes/nipaplay/pages/settings/player_settings_page.dart';
+import 'package:nipaplay/themes/nipaplay/pages/settings/remote_access_page.dart';
+import 'package:nipaplay/themes/nipaplay/pages/settings/remote_media_library_page.dart';
+import 'package:nipaplay/themes/nipaplay/pages/settings/storage_page.dart';
+import 'package:nipaplay/themes/nipaplay/pages/settings/theme_mode_page.dart';
+import 'package:nipaplay/utils/globals.dart' as globals;
+import 'package:nipaplay/utils/theme_notifier.dart';
+import 'package:provider/provider.dart';
+
+class NipaplaySettingEntryIds {
+  const NipaplaySettingEntryIds._();
+
+  static const String appearance = 'appearance';
+  static const String language = 'language';
+  static const String general = 'general';
+  static const String storage = 'storage';
+  static const String network = 'network';
+  static const String backupRestore = 'backup_restore';
+  static const String player = 'player';
+  static const String danmaku = 'danmaku';
+  static const String externalPlayer = 'external_player';
+  static const String shortcuts = 'shortcuts';
+  static const String remoteAccess = 'remote_access';
+  static const String remoteMediaLibrary = 'remote_media_library';
+  static const String developerOptions = 'developer_options';
+  static const String about = 'about';
+}
+
+class NipaplaySettingEntry {
+  const NipaplaySettingEntry({
+    required this.id,
+    required this.title,
+    required this.icon,
+    required this.pageTitle,
+    required this.page,
+  });
+
+  final String id;
+  final String title;
+  final IconData icon;
+  final String pageTitle;
+  final Widget page;
+}
+
+List<NipaplaySettingEntry> buildNipaplaySettingEntries(BuildContext context) {
+  final themeNotifier = context.read<ThemeNotifier>();
+  final l10n = context.l10n;
+  final entries = <NipaplaySettingEntry>[
+    NipaplaySettingEntry(
+      id: NipaplaySettingEntryIds.appearance,
+      title: l10n.appearance,
+      icon: Ionicons.color_palette_outline,
+      pageTitle: l10n.appearanceSettings,
+      page: ThemeModePage(themeNotifier: themeNotifier),
+    ),
+  ];
+
+  entries.addAll([
+    NipaplaySettingEntry(
+      id: NipaplaySettingEntryIds.language,
+      title: l10n.language,
+      icon: Ionicons.language_outline,
+      pageTitle: l10n.languageSettingsTitle,
+      page: const LanguagePage(),
+    ),
+    NipaplaySettingEntry(
+      id: NipaplaySettingEntryIds.general,
+      title: l10n.general,
+      icon: Ionicons.settings_outline,
+      pageTitle: l10n.generalSettings,
+      page: const GeneralPage(),
+    ),
+    NipaplaySettingEntry(
+      id: NipaplaySettingEntryIds.storage,
+      title: l10n.storage,
+      icon: Ionicons.folder_open_outline,
+      pageTitle: l10n.storageSettings,
+      page: const StoragePage(),
+    ),
+    NipaplaySettingEntry(
+      id: NipaplaySettingEntryIds.network,
+      title: l10n.networkSettings,
+      icon: Ionicons.wifi_outline,
+      pageTitle: l10n.networkSettings,
+      page: const NetworkSettingsPage(),
+    ),
+  ]);
+
+  if (!globals.isPhone) {
+    entries.add(
+      NipaplaySettingEntry(
+        id: NipaplaySettingEntryIds.backupRestore,
+        title: l10n.backupAndRestore,
+        icon: Ionicons.cloud_upload_outline,
+        pageTitle: l10n.backupAndRestore,
+        page: const BackupRestorePage(),
+      ),
+    );
+  }
+
+  entries.add(
+    NipaplaySettingEntry(
+      id: NipaplaySettingEntryIds.player,
+      title: l10n.player,
+      icon: Ionicons.play_circle_outline,
+      pageTitle: l10n.playerSettings,
+      page: const PlayerSettingsPage(),
+    ),
+  );
+
+  entries.add(
+    const NipaplaySettingEntry(
+      id: NipaplaySettingEntryIds.danmaku,
+      title: '弹幕',
+      icon: Ionicons.hardware_chip_outline,
+      pageTitle: '弹幕设置',
+      page: DanmakuSettingsPage(),
+    ),
+  );
+
+  entries.add(
+    NipaplaySettingEntry(
+      id: NipaplaySettingEntryIds.externalPlayer,
+      title: l10n.externalCall,
+      icon: Ionicons.open_outline,
+      pageTitle: l10n.externalCall,
+      page: const ExternalPlayerSettingsPage(),
+    ),
+  );
+
+  if (!globals.isPhone) {
+    entries.addAll([
+      NipaplaySettingEntry(
+        id: NipaplaySettingEntryIds.shortcuts,
+        title: l10n.shortcuts,
+        icon: Ionicons.key_outline,
+        pageTitle: l10n.shortcutsSettings,
+        page: const ShortcutsSettingsPage(),
+      ),
+      NipaplaySettingEntry(
+        id: NipaplaySettingEntryIds.remoteAccess,
+        title: l10n.remoteAccess,
+        icon: Ionicons.link_outline,
+        pageTitle: l10n.remoteAccess,
+        page: const RemoteAccessPage(),
+      ),
+    ]);
+  }
+
+  entries.addAll([
+    NipaplaySettingEntry(
+      id: NipaplaySettingEntryIds.remoteMediaLibrary,
+      title: l10n.remoteMediaLibrary,
+      icon: Ionicons.library_outline,
+      pageTitle: l10n.remoteMediaLibrary,
+      page: const RemoteMediaLibraryPage(),
+    ),
+    NipaplaySettingEntry(
+      id: NipaplaySettingEntryIds.developerOptions,
+      title: l10n.developerOptions,
+      icon: Ionicons.code_slash_outline,
+      pageTitle: l10n.developerOptions,
+      page: const DeveloperOptionsPage(),
+    ),
+    NipaplaySettingEntry(
+      id: NipaplaySettingEntryIds.about,
+      title: l10n.about,
+      icon: Ionicons.information_circle_outline,
+      pageTitle: l10n.about,
+      page: const AboutPage(),
+    ),
+  ]);
+
+  return entries;
+}

--- a/lib/themes/nipaplay/pages/settings/settings_entries.dart
+++ b/lib/themes/nipaplay/pages/settings/settings_entries.dart
@@ -9,6 +9,7 @@ import 'package:nipaplay/themes/nipaplay/pages/settings/developer_options_page.d
 import 'package:nipaplay/themes/nipaplay/pages/settings/external_player_settings_page.dart';
 import 'package:nipaplay/themes/nipaplay/pages/settings/general_page.dart';
 import 'package:nipaplay/themes/nipaplay/pages/settings/language_page.dart';
+import 'package:nipaplay/themes/nipaplay/pages/settings/labs_page.dart';
 import 'package:nipaplay/themes/nipaplay/pages/settings/network_settings_page.dart';
 import 'package:nipaplay/themes/nipaplay/pages/settings/player_settings_page.dart';
 import 'package:nipaplay/themes/nipaplay/pages/settings/remote_access_page.dart';
@@ -35,6 +36,7 @@ class NipaplaySettingEntryIds {
   static const String remoteAccess = 'remote_access';
   static const String remoteMediaLibrary = 'remote_media_library';
   static const String developerOptions = 'developer_options';
+  static const String labs = 'labs';
   static const String about = 'about';
 }
 
@@ -173,6 +175,13 @@ List<NipaplaySettingEntry> buildNipaplaySettingEntries(BuildContext context) {
       icon: Ionicons.code_slash_outline,
       pageTitle: l10n.developerOptions,
       page: const DeveloperOptionsPage(),
+    ),
+    const NipaplaySettingEntry(
+      id: NipaplaySettingEntryIds.labs,
+      title: '实验室',
+      icon: Ionicons.flask_outline,
+      pageTitle: '实验室',
+      page: LabsPage(),
     ),
     NipaplaySettingEntry(
       id: NipaplaySettingEntryIds.about,

--- a/lib/themes/nipaplay/pages/settings_page.dart
+++ b/lib/themes/nipaplay/pages/settings_page.dart
@@ -1,34 +1,18 @@
-// settings_page.dart
 import 'package:flutter/material.dart';
-import 'package:kmbal_ionicons/kmbal_ionicons.dart';
 import 'package:nipaplay/l10n/l10n.dart';
-import 'package:nipaplay/themes/nipaplay/pages/settings/theme_mode_page.dart'; // 导入 ThemeModePage
-import 'package:nipaplay/themes/nipaplay/pages/settings/general_page.dart';
-import 'package:nipaplay/themes/nipaplay/pages/settings/developer_options_page.dart'; // 导入开发者选项页面
-import 'package:nipaplay/utils/theme_notifier.dart';
+import 'package:nipaplay/themes/nipaplay/pages/settings/about_page.dart';
+import 'package:nipaplay/themes/nipaplay/pages/settings/settings_entries.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/custom_scaffold.dart';
-import 'package:nipaplay/themes/nipaplay/widgets/responsive_container.dart'; // 导入响应式容器
-import 'package:nipaplay/themes/nipaplay/pages/settings/about_page.dart'; // 导入 AboutPage
-import 'package:nipaplay/themes/nipaplay/widgets/settings_no_ripple_theme.dart';
-import 'package:nipaplay/utils/globals.dart'
-    as globals; // 导入包含 isDesktop 的全局变量文件
-import 'package:nipaplay/pages/shortcuts_settings_page.dart';
-import 'package:nipaplay/themes/nipaplay/pages/settings/player_settings_page.dart'; // 导入播放器设置页面
-import 'package:nipaplay/themes/nipaplay/pages/settings/danmaku_settings_page.dart';
-import 'package:nipaplay/themes/nipaplay/pages/settings/external_player_settings_page.dart'; // 导入外部调用设置页面
-import 'package:nipaplay/themes/nipaplay/pages/settings/remote_media_library_page.dart'; // 导入远程媒体库设置页面
-import 'package:nipaplay/themes/nipaplay/pages/settings/remote_access_page.dart'; // 导入远程访问设置页面
 import 'package:nipaplay/themes/nipaplay/widgets/nipaplay_window.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/responsive_container.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/settings_no_ripple_theme.dart';
 import 'package:nipaplay/providers/appearance_settings_provider.dart';
-import 'package:nipaplay/themes/nipaplay/pages/settings/storage_page.dart';
-import 'package:nipaplay/themes/nipaplay/pages/settings/backup_restore_page.dart';
-import 'package:nipaplay/themes/nipaplay/pages/settings/network_settings_page.dart';
-import 'package:nipaplay/themes/nipaplay/pages/settings/language_page.dart';
+import 'package:nipaplay/utils/globals.dart' as globals;
 import 'package:nipaplay/utils/video_player_state.dart';
 import 'package:provider/provider.dart';
 
 class SettingsPage extends StatefulWidget {
-  static const String entryRemoteAccess = 'remote_access';
+  static const String entryRemoteAccess = NipaplaySettingEntryIds.remoteAccess;
   final String? initialEntryId;
 
   const SettingsPage({super.key, this.initialEntryId});
@@ -85,42 +69,24 @@ class SettingsPage extends StatefulWidget {
   }
 
   @override
-  // ignore: library_private_types_in_public_api
-  _SettingsPageState createState() => _SettingsPageState();
+  State<SettingsPage> createState() => _SettingsPageState();
 }
 
 class _SettingsPageState extends State<SettingsPage>
     with SingleTickerProviderStateMixin {
-  // currentPage 状态现在用于桌面端的右侧面板
-  // 也可以考虑给它一个初始值，这样桌面端一进来右侧不是空的
-  Widget? currentPage; // 初始可以为 null
+  Widget? currentPage;
   late TabController _tabController;
   static const Color _selectedColor = Color(0xFFFF2E55);
-  static const String _entryAppearance = 'appearance';
-  static const String _entryLanguage = 'language';
-  static const String _entryGeneral = 'general';
-  static const String _entryStorage = 'storage';
-  static const String _entryNetwork = 'network';
-  static const String _entryBackupRestore = 'backup_restore';
-  static const String _entryPlayer = 'player';
-  static const String _entryDanmaku = 'danmaku';
-  static const String _entryExternalPlayer = 'external_player';
-  static const String _entryShortcuts = 'shortcuts';
-  static const String _entryRemoteMediaLibrary = 'remote_media_library';
-  static const String _entryDeveloperOptions = 'developer_options';
-  static const String _entryAbout = 'about';
   String? _selectedEntryId;
 
   @override
   void initState() {
     super.initState();
-    // 初始化TabController
     _tabController = TabController(length: 1, vsync: this);
 
-    // 可以在这里为桌面端和平板设备设置一个默认显示的页面
     if (globals.isDesktop || globals.isTablet) {
-      currentPage = const AboutPage(); // 例如默认显示 AboutPage
-      _selectedEntryId = _entryAbout;
+      currentPage = const AboutPage();
+      _selectedEntryId = NipaplaySettingEntryIds.about;
     }
 
     _applyInitialEntry();
@@ -149,7 +115,7 @@ class _SettingsPageState extends State<SettingsPage>
     }
   }
 
-  _SettingEntry? _findEntryById(String entryId) {
+  NipaplaySettingEntry? _findEntryById(String entryId) {
     final entries = _buildSettingEntries(context);
     for (final entry in entries) {
       if (entry.id == entryId) {
@@ -159,25 +125,26 @@ class _SettingsPageState extends State<SettingsPage>
     return null;
   }
 
-  // 封装导航或更新状态的逻辑
   void _handleItemTap(String entryId, Widget pageToShow, String title) {
     List<Widget> settingsTabLabels() {
       final colorScheme = Theme.of(context).colorScheme;
       return [
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16.0),
-          child: Text(title,
-              style: TextStyle(
-                  fontSize: 20,
-                  fontWeight: FontWeight.bold,
-                  color: colorScheme.onSurface)),
+          child: Text(
+            title,
+            style: TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+              color: colorScheme.onSurface,
+            ),
+          ),
         ),
       ];
     }
 
     final List<Widget> pages = [pageToShow];
     if (globals.isDesktop || globals.isTablet) {
-      // 桌面端和平板设备：更新状态，改变右侧面板内容
       setState(() {
         currentPage = pageToShow;
         _selectedEntryId = entryId;
@@ -186,26 +153,25 @@ class _SettingsPageState extends State<SettingsPage>
       setState(() {
         _selectedEntryId = entryId;
       });
-      // 移动端：导航到新页面
       Navigator.push(
         context,
         MaterialPageRoute(
-            builder: (context) => Selector<VideoPlayerState, bool>(
-                  selector: (context, videoState) =>
-                      videoState.shouldShowAppBar(),
-                  builder: (context, shouldShowAppBar, child) {
-                    return SettingsNoRippleTheme(
-                      disableBlurEffect: true,
-                      child: CustomScaffold(
-                        pages: pages,
-                        tabPage: settingsTabLabels(),
-                        pageIsHome: false,
-                        shouldShowAppBar: shouldShowAppBar,
-                        tabController: _tabController,
-                      ),
-                    );
-                  },
-                )),
+          builder: (context) => Selector<VideoPlayerState, bool>(
+            selector: (context, videoState) => videoState.shouldShowAppBar(),
+            builder: (context, shouldShowAppBar, child) {
+              return SettingsNoRippleTheme(
+                disableBlurEffect: true,
+                child: CustomScaffold(
+                  pages: pages,
+                  tabPage: settingsTabLabels(),
+                  pageIsHome: false,
+                  shouldShowAppBar: shouldShowAppBar,
+                  tabController: _tabController,
+                ),
+              );
+            },
+          ),
+        ),
       );
     }
   }
@@ -214,13 +180,10 @@ class _SettingsPageState extends State<SettingsPage>
   Widget build(BuildContext context) {
     final entries = _buildSettingEntries(context);
     final colorScheme = Theme.of(context).colorScheme;
-    // ResponsiveContainer 会根据 isDesktop 决定是否显示 currentPage
     return SettingsNoRippleTheme(
       disableBlurEffect: true,
       child: ResponsiveContainer(
-        currentPage:
-            currentPage ?? Container(), // 将当前页面状态传递给 ResponsiveContainer
-        // child 是 ListView，始终显示
+        currentPage: currentPage ?? Container(),
         child: ListView.separated(
           itemCount: entries.length,
           itemBuilder: (context, index) => _buildSettingTile(entries[index]),
@@ -233,139 +196,11 @@ class _SettingsPageState extends State<SettingsPage>
     );
   }
 
-  List<_SettingEntry> _buildSettingEntries(BuildContext context) {
-    final themeNotifier = context.read<ThemeNotifier>();
-    final l10n = context.l10n;
-    final entries = <_SettingEntry>[
-      _SettingEntry(
-        id: _entryAppearance,
-        title: l10n.appearance,
-        icon: Ionicons.color_palette_outline,
-        pageTitle: l10n.appearanceSettings,
-        page: ThemeModePage(themeNotifier: themeNotifier),
-      ),
-    ];
-
-    entries.addAll([
-      _SettingEntry(
-        id: _entryLanguage,
-        title: l10n.language,
-        icon: Ionicons.language_outline,
-        pageTitle: l10n.languageSettingsTitle,
-        page: const LanguagePage(),
-      ),
-      _SettingEntry(
-        id: _entryGeneral,
-        title: l10n.general,
-        icon: Ionicons.settings_outline,
-        pageTitle: l10n.generalSettings,
-        page: const GeneralPage(),
-      ),
-      _SettingEntry(
-        id: _entryStorage,
-        title: l10n.storage,
-        icon: Ionicons.folder_open_outline,
-        pageTitle: l10n.storageSettings,
-        page: const StoragePage(),
-      ),
-      _SettingEntry(
-        id: _entryNetwork,
-        title: l10n.networkSettings,
-        icon: Ionicons.wifi_outline,
-        pageTitle: l10n.networkSettings,
-        page: const NetworkSettingsPage(),
-      ),
-    ]);
-
-    if (!globals.isPhone) {
-      entries.add(
-        _SettingEntry(
-          id: _entryBackupRestore,
-          title: l10n.backupAndRestore,
-          icon: Ionicons.cloud_upload_outline,
-          pageTitle: l10n.backupAndRestore,
-          page: const BackupRestorePage(),
-        ),
-      );
-    }
-
-    entries.add(
-      _SettingEntry(
-        id: _entryPlayer,
-        title: l10n.player,
-        icon: Ionicons.play_circle_outline,
-        pageTitle: l10n.playerSettings,
-        page: const PlayerSettingsPage(),
-      ),
-    );
-
-    entries.add(
-      const _SettingEntry(
-        id: _entryDanmaku,
-        title: '弹幕',
-        icon: Ionicons.hardware_chip_outline,
-        pageTitle: '弹幕设置',
-        page: DanmakuSettingsPage(),
-      ),
-    );
-
-    entries.add(
-      _SettingEntry(
-        id: _entryExternalPlayer,
-        title: l10n.externalCall,
-        icon: Ionicons.open_outline,
-        pageTitle: l10n.externalCall,
-        page: const ExternalPlayerSettingsPage(),
-      ),
-    );
-
-    if (!globals.isPhone) {
-      entries.addAll([
-        _SettingEntry(
-          id: _entryShortcuts,
-          title: l10n.shortcuts,
-          icon: Ionicons.key_outline,
-          pageTitle: l10n.shortcutsSettings,
-          page: const ShortcutsSettingsPage(),
-        ),
-        _SettingEntry(
-          id: SettingsPage.entryRemoteAccess,
-          title: l10n.remoteAccess,
-          icon: Ionicons.link_outline,
-          pageTitle: l10n.remoteAccess,
-          page: const RemoteAccessPage(),
-        ),
-      ]);
-    }
-
-    entries.addAll([
-      _SettingEntry(
-        id: _entryRemoteMediaLibrary,
-        title: l10n.remoteMediaLibrary,
-        icon: Ionicons.library_outline,
-        pageTitle: l10n.remoteMediaLibrary,
-        page: const RemoteMediaLibraryPage(),
-      ),
-      _SettingEntry(
-        id: _entryDeveloperOptions,
-        title: l10n.developerOptions,
-        icon: Ionicons.code_slash_outline,
-        pageTitle: l10n.developerOptions,
-        page: const DeveloperOptionsPage(),
-      ),
-      _SettingEntry(
-        id: _entryAbout,
-        title: l10n.about,
-        icon: Ionicons.information_circle_outline,
-        pageTitle: l10n.about,
-        page: const AboutPage(),
-      ),
-    ]);
-
-    return entries;
+  List<NipaplaySettingEntry> _buildSettingEntries(BuildContext context) {
+    return buildNipaplaySettingEntries(context);
   }
 
-  Widget _buildSettingTile(_SettingEntry entry) {
+  Widget _buildSettingTile(NipaplaySettingEntry entry) {
     final colorScheme = Theme.of(context).colorScheme;
     final isSelected = entry.id == _selectedEntryId;
     final itemColor = isSelected ? _selectedColor : colorScheme.onSurface;
@@ -378,20 +213,4 @@ class _SettingsPageState extends State<SettingsPage>
       onTap: () => _handleItemTap(entry.id, entry.page, entry.pageTitle),
     );
   }
-}
-
-class _SettingEntry {
-  const _SettingEntry({
-    required this.id,
-    required this.title,
-    required this.icon,
-    required this.pageTitle,
-    required this.page,
-  });
-
-  final String id;
-  final String title;
-  final IconData icon;
-  final String pageTitle;
-  final Widget page;
 }

--- a/lib/themes/nipaplay/widgets/blur_dropdown.dart
+++ b/lib/themes/nipaplay/widgets/blur_dropdown.dart
@@ -2,9 +2,16 @@
 // ignore_for_file: deprecated_member_use
 
 import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:kmbal_ionicons/kmbal_ionicons.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_mode_scope.dart';
 import 'package:nipaplay/utils/theme_utils.dart';
+
+class _BlurDropdownGlobalState {
+  static int expandedCount = 0;
+}
 
 class BlurDropdown<T> extends StatefulWidget {
   final GlobalKey dropdownKey;
@@ -18,9 +25,10 @@ class BlurDropdown<T> extends StatefulWidget {
     required this.onItemSelected,
   });
 
+  static bool get isAnyExpanded => _BlurDropdownGlobalState.expandedCount > 0;
+
   @override
-  // ignore: library_private_types_in_public_api
-  _BlurDropdownState<T> createState() => _BlurDropdownState<T>();
+  State<BlurDropdown<T>> createState() => _BlurDropdownState<T>();
 }
 
 class _BlurDropdownState<T> extends State<BlurDropdown<T>>
@@ -28,17 +36,28 @@ class _BlurDropdownState<T> extends State<BlurDropdown<T>>
   OverlayEntry? _overlayEntry;
   bool _isDropdownOpen = false;
   bool _isSelecting = false;
+  bool _isControlFocused = false;
+  bool _isCountedAsExpanded = false;
   T? _currentSelectedValue;
+  int _keyboardHighlightedIndex = 0;
 
-  late AnimationController _animationController;
-  late Animation<double> _fadeAnimation;
-  late Animation<double> _scaleAnimation;
+  late final AnimationController _animationController;
+  late final Animation<double> _fadeAnimation;
+  late final Animation<double> _scaleAnimation;
   final Duration _animationDuration = const Duration(milliseconds: 200);
+
+  final FocusNode _controlFocusNode = FocusNode(
+    debugLabel: 'blur_dropdown_control',
+  );
+  final FocusNode _menuFocusNode = FocusNode(
+    debugLabel: 'blur_dropdown_menu',
+  );
 
   @override
   void initState() {
     super.initState();
     _currentSelectedValue = _findInitialValue();
+    _keyboardHighlightedIndex = _findSelectedIndex();
     _animationController = AnimationController(
       vsync: this,
       duration: _animationDuration,
@@ -67,6 +86,7 @@ class _BlurDropdownState<T> extends State<BlurDropdown<T>>
         selectedFromProps != _currentSelectedValue) {
       setState(() {
         _currentSelectedValue = selectedFromProps;
+        _keyboardHighlightedIndex = _findSelectedIndex();
       });
       return;
     }
@@ -77,15 +97,38 @@ class _BlurDropdownState<T> extends State<BlurDropdown<T>>
       setState(() {
         _currentSelectedValue =
             widget.items.isNotEmpty ? widget.items.first.value : null;
+        _keyboardHighlightedIndex = _findSelectedIndex();
       });
     }
   }
 
   @override
   void dispose() {
+    _setExpandedTracked(false);
     _removeOverlay();
     _animationController.dispose();
+    _menuFocusNode.dispose();
+    _controlFocusNode.dispose();
     super.dispose();
+  }
+
+  void _setExpandedTracked(bool expanded) {
+    if (expanded) {
+      if (_isCountedAsExpanded) {
+        return;
+      }
+      _isCountedAsExpanded = true;
+      _BlurDropdownGlobalState.expandedCount++;
+      return;
+    }
+
+    if (!_isCountedAsExpanded) {
+      return;
+    }
+    _isCountedAsExpanded = false;
+    if (_BlurDropdownGlobalState.expandedCount > 0) {
+      _BlurDropdownGlobalState.expandedCount--;
+    }
   }
 
   void _removeOverlay() {
@@ -113,9 +156,38 @@ class _BlurDropdownState<T> extends State<BlurDropdown<T>>
     return null;
   }
 
+  int _findSelectedIndex() {
+    if (widget.items.isEmpty) {
+      return 0;
+    }
+    final selectedIndex = widget.items.indexWhere(
+      (item) => item.value == _currentSelectedValue,
+    );
+    if (selectedIndex < 0) {
+      return 0;
+    }
+    return selectedIndex;
+  }
+
+  void _moveHighlighted(int delta) {
+    if (widget.items.isEmpty) {
+      return;
+    }
+    final length = widget.items.length;
+    setState(() {
+      _keyboardHighlightedIndex = (_keyboardHighlightedIndex + delta) % length;
+      if (_keyboardHighlightedIndex < 0) {
+        _keyboardHighlightedIndex += length;
+      }
+    });
+    _overlayEntry?.markNeedsBuild();
+  }
+
   @override
   Widget build(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
+    final isLargeScreenModeActive =
+        NipaplayLargeScreenModeScope.isActiveOf(context);
     const activeColor = Color(0xFFFF2E55);
     final idleBorderColor = isDark
         ? Colors.white.withValues(alpha: 0.1)
@@ -123,14 +195,18 @@ class _BlurDropdownState<T> extends State<BlurDropdown<T>>
     final bgColor =
         isDark ? Colors.white.withValues(alpha: 0.12) : Colors.white;
 
-    return Container(
-      height: 40, // 统一高度
+    final control = Container(
+      height: 40,
       decoration: BoxDecoration(
         color: bgColor,
         borderRadius: BorderRadius.circular(8),
         border: Border.all(
-          color: _isDropdownOpen ? activeColor : idleBorderColor,
-          width: _isDropdownOpen ? 1.5 : 1,
+          color: (_isDropdownOpen || (isLargeScreenModeActive && _isControlFocused))
+              ? activeColor
+              : idleBorderColor,
+          width: (_isDropdownOpen || (isLargeScreenModeActive && _isControlFocused))
+              ? 1.5
+              : 1,
         ),
       ),
       padding: const EdgeInsets.symmetric(horizontal: 12),
@@ -140,12 +216,15 @@ class _BlurDropdownState<T> extends State<BlurDropdown<T>>
         children: [
           GestureDetector(
             onTap: () {
-              if (_isSelecting) return;
-              if (_animationController.isAnimating) return;
+              if (_isSelecting || _animationController.isAnimating) {
+                return;
+              }
               if (_isDropdownOpen) {
-                _closeDropdown();
+                _closeDropdown(restoreControlFocus: true);
               } else {
-                _openDropdown();
+                _openDropdown(
+                  requestMenuFocus: isLargeScreenModeActive,
+                );
               }
             },
             child: MouseRegion(
@@ -175,6 +254,42 @@ class _BlurDropdownState<T> extends State<BlurDropdown<T>>
         ],
       ),
     );
+
+    if (!isLargeScreenModeActive) {
+      return control;
+    }
+
+    return Actions(
+      actions: <Type, Action<Intent>>{
+        ActivateIntent: CallbackAction<ActivateIntent>(
+          onInvoke: (intent) {
+            if (_isSelecting || _animationController.isAnimating) {
+              return null;
+            }
+            if (_isDropdownOpen) {
+              _closeDropdown(restoreControlFocus: true);
+            } else {
+              _openDropdown(requestMenuFocus: true);
+            }
+            return null;
+          },
+        ),
+      },
+      child: Focus(
+        focusNode: _controlFocusNode,
+        onFocusChange: (focused) {
+          if (_isControlFocused == focused) {
+            return;
+          }
+          setState(() {
+            _isControlFocused = focused;
+          });
+        },
+        onKeyEvent: _handleControlKeyEvent,
+        descendantsAreFocusable: false,
+        child: control,
+      ),
+    );
   }
 
   String _getSelectedItemText() {
@@ -189,11 +304,17 @@ class _BlurDropdownState<T> extends State<BlurDropdown<T>>
     return widget.items.first.title;
   }
 
-  Future<void> _handleItemSelected(T value) async {
-    if (_isSelecting) return;
+  Future<void> _handleItemSelected(
+    T value, {
+    bool restoreControlFocus = false,
+  }) async {
+    if (_isSelecting) {
+      return;
+    }
     setState(() {
       _isSelecting = true;
       _currentSelectedValue = value;
+      _keyboardHighlightedIndex = _findSelectedIndex();
     });
     try {
       await widget.onItemSelected(value);
@@ -204,18 +325,101 @@ class _BlurDropdownState<T> extends State<BlurDropdown<T>>
         setState(() {
           _isSelecting = false;
         });
-        _closeDropdown();
+        _closeDropdown(restoreControlFocus: restoreControlFocus);
       }
     }
   }
 
-  void _openDropdown() {
-    if (_isDropdownOpen || _animationController.isAnimating) return;
+  KeyEventResult _handleControlKeyEvent(FocusNode node, KeyEvent event) {
+    if (!NipaplayLargeScreenModeScope.isActiveOf(context)) {
+      return KeyEventResult.ignored;
+    }
+    if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
+      return KeyEventResult.ignored;
+    }
+
+    final key = event.logicalKey;
+    final isEnter = key == LogicalKeyboardKey.enter ||
+        key == LogicalKeyboardKey.numpadEnter ||
+        key == LogicalKeyboardKey.select ||
+        key == LogicalKeyboardKey.gameButtonA;
+    final isEscape = key == LogicalKeyboardKey.escape ||
+        key == LogicalKeyboardKey.goBack ||
+        key == LogicalKeyboardKey.gameButtonB;
+
+    if (isEnter) {
+      if (_isSelecting || _animationController.isAnimating) {
+        return KeyEventResult.handled;
+      }
+      if (_isDropdownOpen) {
+        _closeDropdown(restoreControlFocus: true);
+      } else {
+        _openDropdown(requestMenuFocus: true);
+      }
+      return KeyEventResult.handled;
+    }
+
+    if (isEscape && _isDropdownOpen) {
+      _closeDropdown(restoreControlFocus: true);
+      return KeyEventResult.handled;
+    }
+
+    return KeyEventResult.ignored;
+  }
+
+  KeyEventResult _handleMenuKeyEvent(FocusNode node, KeyEvent event) {
+    if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
+      return KeyEventResult.ignored;
+    }
+
+    final key = event.logicalKey;
+    final isEnter = key == LogicalKeyboardKey.enter ||
+        key == LogicalKeyboardKey.numpadEnter ||
+        key == LogicalKeyboardKey.select ||
+        key == LogicalKeyboardKey.gameButtonA;
+    final isEscape = key == LogicalKeyboardKey.escape ||
+        key == LogicalKeyboardKey.goBack ||
+        key == LogicalKeyboardKey.gameButtonB;
+
+    if (isEscape) {
+      _closeDropdown(restoreControlFocus: true);
+      return KeyEventResult.handled;
+    }
+
+    if (key == LogicalKeyboardKey.arrowUp) {
+      _moveHighlighted(-1);
+      return KeyEventResult.handled;
+    }
+
+    if (key == LogicalKeyboardKey.arrowDown) {
+      _moveHighlighted(1);
+      return KeyEventResult.handled;
+    }
+
+    if (isEnter) {
+      if (widget.items.isEmpty || _isSelecting) {
+        _closeDropdown(restoreControlFocus: true);
+        return KeyEventResult.handled;
+      }
+      final item = widget.items[_keyboardHighlightedIndex];
+      unawaited(_handleItemSelected(item.value, restoreControlFocus: true));
+      return KeyEventResult.handled;
+    }
+
+    return KeyEventResult.ignored;
+  }
+
+  void _openDropdown({bool requestMenuFocus = false}) {
+    if (_isDropdownOpen || _animationController.isAnimating) {
+      return;
+    }
     _removeOverlay();
 
     final RenderBox? renderBox =
         widget.dropdownKey.currentContext?.findRenderObject() as RenderBox?;
-    if (renderBox == null) return;
+    if (renderBox == null) {
+      return;
+    }
 
     final size = renderBox.size;
     final position = renderBox.localToGlobal(Offset.zero);
@@ -241,13 +445,17 @@ class _BlurDropdownState<T> extends State<BlurDropdown<T>>
     final Color dropdownBgColor =
         isDark ? const Color(0xFF2C2C2C) : const Color(0xFFFFFFFF);
 
+    _keyboardHighlightedIndex = _findSelectedIndex();
+
     _overlayEntry = OverlayEntry(
-      builder: (context) {
+      builder: (overlayContext) {
         return Stack(
           children: [
             Positioned.fill(
               child: GestureDetector(
-                onTap: _isSelecting ? null : _closeDropdown,
+                onTap: _isSelecting
+                    ? null
+                    : () => _closeDropdown(restoreControlFocus: true),
                 behavior: HitTestBehavior.opaque,
                 child: Container(color: Colors.transparent),
               ),
@@ -263,82 +471,93 @@ class _BlurDropdownState<T> extends State<BlurDropdown<T>>
                     child: ScaleTransition(
                       scale: _scaleAnimation,
                       alignment: Alignment.topRight,
-                      child: GestureDetector(
-                        onTap: () {},
-                        child: child!,
-                      ),
+                      child: child!,
                     ),
                   ),
                 );
               },
               child: Material(
                 color: Colors.transparent,
-                child: Container(
-                  constraints: BoxConstraints(
-                    maxWidth: screenWidth - left - safeRight > 100
-                        ? screenWidth - left - safeRight
-                        : size.width * 1.5,
-                    maxHeight: screenHeight - top - 10,
-                  ),
-                  decoration: BoxDecoration(
-                    border: Border.all(color: borderColor, width: 0.5),
-                    color: dropdownBgColor,
-                    borderRadius: BorderRadius.circular(6),
-                    boxShadow: [
-                      BoxShadow(
-                        color: Colors.black.withValues(alpha: 0.1),
-                        blurRadius: 10,
-                        spreadRadius: 0,
-                        offset: const Offset(0, 4),
+                child: Focus(
+                  focusNode: _menuFocusNode,
+                  onKeyEvent: _handleMenuKeyEvent,
+                  child: GestureDetector(
+                    onTap: () {},
+                    child: Container(
+                      constraints: BoxConstraints(
+                        maxWidth: screenWidth - left - safeRight > 100
+                            ? screenWidth - left - safeRight
+                            : size.width * 1.5,
+                        maxHeight: screenHeight - top - 10,
                       ),
-                    ],
-                  ),
-                  clipBehavior: Clip.hardEdge,
-                  child: ClipRRect(
-                    borderRadius: BorderRadius.circular(6),
-                    child: ListView.builder(
-                      shrinkWrap: true,
-                      physics: const AlwaysScrollableScrollPhysics(),
-                      padding: EdgeInsets.zero,
-                      itemCount: widget.items.length,
-                      itemBuilder: (context, index) {
-                        final item = widget.items[index];
-                        final Widget menuItem = InkWell(
-                          onTap: _isSelecting
-                              ? null
-                              : () async {
-                                  await _handleItemSelected(item.value);
-                                },
-                          child: Container(
-                            width: double.infinity,
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 16,
-                              vertical: 8,
-                            ),
-                            decoration: BoxDecoration(
-                              color: item.value == _currentSelectedValue
-                                  ? (isDark
-                                      ? Colors.white.withValues(alpha: 0.1)
-                                      : Colors.black.withValues(alpha: 0.05))
-                                  : Colors.transparent,
-                              border: Border(
-                                bottom: BorderSide(
-                                  color: isDark
-                                      ? Colors.white.withValues(alpha: 0.1)
-                                      : Colors.black.withValues(alpha: 0.05),
-                                  width: 0.5,
+                      decoration: BoxDecoration(
+                        border: Border.all(color: borderColor, width: 0.5),
+                        color: dropdownBgColor,
+                        borderRadius: BorderRadius.circular(6),
+                        boxShadow: [
+                          BoxShadow(
+                            color: Colors.black.withValues(alpha: 0.1),
+                            blurRadius: 10,
+                            spreadRadius: 0,
+                            offset: const Offset(0, 4),
+                          ),
+                        ],
+                      ),
+                      clipBehavior: Clip.hardEdge,
+                      child: ClipRRect(
+                        borderRadius: BorderRadius.circular(6),
+                        child: ListView.builder(
+                          shrinkWrap: true,
+                          physics: const AlwaysScrollableScrollPhysics(),
+                          padding: EdgeInsets.zero,
+                          itemCount: widget.items.length,
+                          itemBuilder: (context, index) {
+                            final item = widget.items[index];
+                            final isHighlighted = index == _keyboardHighlightedIndex;
+                            final isSelected = item.value == _currentSelectedValue;
+                            final backgroundColor = isHighlighted
+                                ? const Color(0xFFFF2E55).withValues(alpha: 0.2)
+                                : (isSelected
+                                    ? (isDark
+                                        ? Colors.white.withValues(alpha: 0.1)
+                                        : Colors.black.withValues(alpha: 0.05))
+                                    : Colors.transparent);
+
+                            return InkWell(
+                              onTap: _isSelecting
+                                  ? null
+                                  : () async {
+                                      await _handleItemSelected(
+                                        item.value,
+                                        restoreControlFocus: true,
+                                      );
+                                    },
+                              child: Container(
+                                width: double.infinity,
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 16,
+                                  vertical: 8,
+                                ),
+                                decoration: BoxDecoration(
+                                  color: backgroundColor,
+                                  border: Border(
+                                    bottom: BorderSide(
+                                      color: isDark
+                                          ? Colors.white.withValues(alpha: 0.1)
+                                          : Colors.black.withValues(alpha: 0.05),
+                                      width: 0.5,
+                                    ),
+                                  ),
+                                ),
+                                child: Text(
+                                  item.title,
+                                  style: getTitleTextStyle(context),
                                 ),
                               ),
-                            ),
-                            child: Text(
-                              item.title,
-                              style: getTitleTextStyle(context),
-                            ),
-                          ),
-                        );
-
-                        return menuItem;
-                      },
+                            );
+                          },
+                        ),
+                      ),
                     ),
                   ),
                 ),
@@ -350,22 +569,41 @@ class _BlurDropdownState<T> extends State<BlurDropdown<T>>
     );
 
     Overlay.of(context).insert(_overlayEntry!);
+    _setExpandedTracked(true);
     setState(() {
       _isDropdownOpen = true;
     });
     _animationController.forward();
+
+    if (requestMenuFocus) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted || !_isDropdownOpen) {
+          return;
+        }
+        _menuFocusNode.requestFocus();
+      });
+    }
   }
 
-  void _closeDropdown() {
+  void _closeDropdown({bool restoreControlFocus = false}) {
     if (!_isDropdownOpen ||
         (_animationController.status == AnimationStatus.reverse)) {
       return;
     }
     _animationController.reverse().then((_) {
       _removeOverlay();
+      _setExpandedTracked(false);
       if (mounted) {
         setState(() {
           _isDropdownOpen = false;
+        });
+      }
+      if (restoreControlFocus) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!mounted) {
+            return;
+          }
+          _controlFocusNode.requestFocus();
         });
       }
     });

--- a/lib/themes/nipaplay/widgets/custom_scaffold.dart
+++ b/lib/themes/nipaplay/widgets/custom_scaffold.dart
@@ -15,6 +15,7 @@ class CustomScaffold extends StatefulWidget {
   final bool pageIsHome;
   final bool shouldShowAppBar;
   final TabController? tabController;
+  final bool useLargeScreenLayout;
 
   const CustomScaffold({
     super.key,
@@ -23,6 +24,7 @@ class CustomScaffold extends StatefulWidget {
     required this.pageIsHome,
     required this.shouldShowAppBar,
     this.tabController,
+    this.useLargeScreenLayout = false,
   });
 
   @override
@@ -104,6 +106,12 @@ class _CustomScaffoldState extends State<CustomScaffold> {
     }
 
     final bool isDesktopOrTablet = globals.isDesktopOrTablet;
+    final bool useLargeScreenLayout =
+        widget.useLargeScreenLayout &&
+        widget.pageIsHome &&
+        isDesktopOrTablet &&
+        widget.shouldShowAppBar &&
+        widget.tabPage.isNotEmpty;
     const enableAnimation = true;
 
     final currentIndex = widget.tabController!.index;
@@ -143,11 +151,25 @@ class _CustomScaffoldState extends State<CustomScaffold> {
       overlayStyle: appBarOverlayStyle,
     );
 
+    final switchableContent = SwitchableView(
+      enableAnimation: enableAnimation,
+      keepAlive: true,
+      preloadIndices: preloadIndices,
+      currentIndex: currentIndex,
+      physics: const PageScrollPhysics(),
+      onPageChanged: _handlePageChangedBySwitchableView,
+      children: widget.pages
+          .map((page) => RepaintBoundary(child: page))
+          .toList(),
+    );
+
     final scaffold = Scaffold(
       primary: false,
       backgroundColor: Colors.transparent,
       extendBodyBehindAppBar: false,
-      appBar: widget.shouldShowAppBar && widget.tabPage.isNotEmpty
+      appBar: widget.shouldShowAppBar &&
+              widget.tabPage.isNotEmpty &&
+              !useLargeScreenLayout
           ? AppBar(
               toolbarHeight: !widget.pageIsHome && !isDesktopOrTablet
                   ? 100
@@ -197,17 +219,13 @@ class _CustomScaffoldState extends State<CustomScaffold> {
       body: TabControllerScope(
         controller: widget.tabController!,
         enabled: true,
-        child: SwitchableView(
-          enableAnimation: enableAnimation,
-          keepAlive: true,
-          preloadIndices: preloadIndices,
-          currentIndex: currentIndex,
-          physics: const PageScrollPhysics(),
-          onPageChanged: _handlePageChangedBySwitchableView,
-          children: widget.pages
-              .map((page) => RepaintBoundary(child: page))
-              .toList(),
-        ),
+        child: useLargeScreenLayout
+            ? _buildLargeScreenLayout(
+                currentIndex: currentIndex,
+                isDarkMode: isDarkMode,
+                content: switchableContent,
+              )
+            : switchableContent,
       ),
     );
 
@@ -215,6 +233,61 @@ class _CustomScaffoldState extends State<CustomScaffold> {
       transparentCutout: useVideoUnderlay ? videoUnderlayRect : null,
       child: scaffold,
     );
+  }
+
+  Widget _buildLargeScreenLayout({
+    required int currentIndex,
+    required bool isDarkMode,
+    required Widget content,
+  }) {
+    const Color activeColor = Color(0xFFFF2E55);
+    final Color inactiveColor = isDarkMode ? Colors.white60 : Colors.black54;
+    final mediaPadding = MediaQuery.of(context).padding;
+    final double topInset = globals.isDesktop ? 50 : mediaPadding.top + 14;
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        NipaplaySidePanel(
+          isDarkMode: isDarkMode,
+          child: ListView.builder(
+            padding: EdgeInsets.zero,
+            itemCount: widget.tabPage.length,
+            itemBuilder: (context, index) {
+              return NipaplaySidePanelItem(
+                isSelected: currentIndex == index,
+                activeColor: activeColor,
+                inactiveColor: inactiveColor,
+                onTap: () {
+                  if (widget.tabController!.index != index) {
+                    widget.tabController!.animateTo(index);
+                  }
+                },
+                child: _stripOuterTabPadding(widget.tabPage[index]),
+              );
+            },
+          ),
+        ),
+        Expanded(
+          child: Padding(
+            padding: EdgeInsets.fromLTRB(
+              14,
+              topInset,
+              14,
+              14 + mediaPadding.bottom,
+            ),
+            child: content,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _stripOuterTabPadding(Widget tabWidget) {
+    if (tabWidget is Padding && tabWidget.child != null) {
+      return tabWidget.child!;
+    }
+    return tabWidget;
   }
 
   void _logAppBarOverlayStyle({
@@ -236,6 +309,127 @@ class _CustomScaffoldState extends State<CustomScaffold> {
       'isDark=$isDarkMode, '
       'icon=${overlayStyle.statusBarIconBrightness?.name}, '
       'ios=${overlayStyle.statusBarBrightness?.name}',
+    );
+  }
+}
+
+class NipaplaySidePanel extends StatelessWidget {
+  const NipaplaySidePanel({
+    super.key,
+    required this.isDarkMode,
+    required this.child,
+    this.width = 220,
+  });
+
+  final bool isDarkMode;
+  final Widget child;
+  final double width;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: width,
+      decoration: BoxDecoration(
+        border: Border(
+          right: BorderSide(
+            color: isDarkMode ? Colors.white12 : Colors.black12,
+            width: 1,
+          ),
+        ),
+      ),
+      child: child,
+    );
+  }
+}
+
+class NipaplaySidePanelItem extends StatefulWidget {
+  const NipaplaySidePanelItem({
+    super.key,
+    required this.isSelected,
+    required this.activeColor,
+    required this.inactiveColor,
+    required this.onTap,
+    required this.child,
+  });
+
+  final bool isSelected;
+  final Color activeColor;
+  final Color inactiveColor;
+  final VoidCallback onTap;
+  final Widget child;
+
+  @override
+  State<NipaplaySidePanelItem> createState() => _NipaplaySidePanelItemState();
+}
+
+class _NipaplaySidePanelItemState extends State<NipaplaySidePanelItem> {
+  bool _isHovered = false;
+  bool _isPressed = false;
+
+  void _setHovered(bool value) {
+    if (_isHovered == value) return;
+    setState(() {
+      _isHovered = value;
+    });
+  }
+
+  void _setPressed(bool value) {
+    if (_isPressed == value) return;
+    setState(() {
+      _isPressed = value;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bool isInteractiveActive = _isHovered || _isPressed;
+    final bool isActive = widget.isSelected || isInteractiveActive;
+    final Color itemColor = isActive ? Colors.white : widget.inactiveColor;
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.zero,
+        splashFactory: NoSplash.splashFactory,
+        overlayColor: WidgetStateProperty.all(Colors.transparent),
+        splashColor: Colors.transparent,
+        highlightColor: Colors.transparent,
+        onTap: widget.onTap,
+        onHover: _setHovered,
+        onHighlightChanged: _setPressed,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 180),
+          curve: Curves.easeOutCubic,
+          width: double.infinity,
+          padding: const EdgeInsets.symmetric(
+            horizontal: 12,
+            vertical: 10,
+          ),
+          decoration: BoxDecoration(
+            color: isActive
+                ? widget.activeColor
+                : Colors.transparent,
+            border: Border(
+              left: BorderSide(
+                color: isActive
+                    ? widget.activeColor
+                    : Colors.transparent,
+                width: 3,
+              ),
+            ),
+          ),
+          child: DefaultTextStyle.merge(
+            style: TextStyle(color: itemColor),
+            child: IconTheme.merge(
+              data: IconThemeData(color: itemColor),
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: widget.child,
+              ),
+            ),
+          ),
+        ),
+      ),
     );
   }
 }
@@ -307,7 +501,7 @@ class _CustomPainter extends BoxPainter {
 class _LogoTabBar extends StatelessWidget implements PreferredSizeWidget {
   final TabBar tabBar;
 
-  const _LogoTabBar({super.key, required this.tabBar});
+  const _LogoTabBar({required this.tabBar});
 
   @override
   Size get preferredSize => tabBar.preferredSize;

--- a/lib/themes/nipaplay/widgets/custom_scaffold.dart
+++ b/lib/themes/nipaplay/widgets/custom_scaffold.dart
@@ -17,6 +17,9 @@ class CustomScaffold extends StatefulWidget {
   final bool shouldShowAppBar;
   final TabController? tabController;
   final bool useLargeScreenLayout;
+  final VoidCallback? onToggleLargeScreen;
+  final Future<void> Function(Offset globalOrigin)? onToggleThemeFromOrigin;
+  final VoidCallback? onOpenSettings;
 
   const CustomScaffold({
     super.key,
@@ -26,6 +29,9 @@ class CustomScaffold extends StatefulWidget {
     required this.shouldShowAppBar,
     this.tabController,
     this.useLargeScreenLayout = false,
+    this.onToggleLargeScreen,
+    this.onToggleThemeFromOrigin,
+    this.onOpenSettings,
   });
 
   @override
@@ -226,6 +232,9 @@ class _CustomScaffoldState extends State<CustomScaffold> {
                 tabPage: widget.tabPage,
                 tabController: widget.tabController!,
                 content: switchableContent,
+                onToggleLargeScreen: widget.onToggleLargeScreen,
+                onToggleThemeFromOrigin: widget.onToggleThemeFromOrigin,
+                onOpenSettings: widget.onOpenSettings,
               )
             : switchableContent,
       ),

--- a/lib/themes/nipaplay/widgets/custom_scaffold.dart
+++ b/lib/themes/nipaplay/widgets/custom_scaffold.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:kmbal_ionicons/kmbal_ionicons.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/background_with_blur.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/large_screen_scaffold_layout.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_home_page.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/switchable_view.dart';
 import 'package:nipaplay/utils/globals.dart' as globals;
 import 'package:nipaplay/utils/platform_utils.dart';
@@ -113,8 +114,7 @@ class _CustomScaffoldState extends State<CustomScaffold> {
     }
 
     final bool isDesktopOrTablet = globals.isDesktopOrTablet;
-    final bool useLargeScreenLayout =
-        widget.useLargeScreenLayout &&
+    final bool useLargeScreenLayout = widget.useLargeScreenLayout &&
         widget.pageIsHome &&
         isDesktopOrTablet &&
         widget.tabPage.isNotEmpty;
@@ -138,8 +138,7 @@ class _CustomScaffoldState extends State<CustomScaffold> {
     final Rect? videoUnderlayRect = context.select<VideoPlayerState, Rect?>(
       (videoState) => videoState.macOSWindowHostedVideoRect,
     );
-    final bool useVideoUnderlay =
-        _macOSHdrTransparentUnderlayEnabled &&
+    final bool useVideoUnderlay = _macOSHdrTransparentUnderlayEnabled &&
         hasNativeVideoSurface &&
         widget.pageIsHome &&
         currentIndex == 1 &&
@@ -164,9 +163,16 @@ class _CustomScaffoldState extends State<CustomScaffold> {
       currentIndex: currentIndex,
       physics: const PageScrollPhysics(),
       onPageChanged: _handlePageChangedBySwitchableView,
-      children: widget.pages
-          .map((page) => RepaintBoundary(child: page))
-          .toList(),
+      children: widget.pages.asMap().entries.map((entry) {
+        final index = entry.key;
+        final page = entry.value;
+        final bool useLargeScreenHomePage =
+            useLargeScreenLayout && widget.pageIsHome && index == 0;
+        if (useLargeScreenHomePage) {
+          return const RepaintBoundary(child: NipaplayLargeScreenHomePage());
+        }
+        return RepaintBoundary(child: page);
+      }).toList(),
     );
 
     final scaffold = Scaffold(
@@ -180,8 +186,8 @@ class _CustomScaffoldState extends State<CustomScaffold> {
               toolbarHeight: !widget.pageIsHome && !isDesktopOrTablet
                   ? 100
                   : isDesktopOrTablet
-                  ? 20
-                  : 60,
+                      ? 20
+                      : 60,
               leading: widget.pageIsHome
                   ? null
                   : IconButton(
@@ -201,16 +207,14 @@ class _CustomScaffoldState extends State<CustomScaffold> {
                   isScrollable: true,
                   tabs: widget.tabPage,
                   labelColor: const Color(0xFFFF2E55),
-                  unselectedLabelColor: isDarkMode
-                      ? Colors.white60
-                      : Colors.black54,
+                  unselectedLabelColor:
+                      isDarkMode ? Colors.white60 : Colors.black54,
                   labelPadding: const EdgeInsets.only(bottom: 15.0),
                   tabAlignment: TabAlignment.start,
                   splashFactory: NoSplash.splashFactory,
                   overlayColor: WidgetStateProperty.all(Colors.transparent),
-                  dividerColor: showTabDivider
-                      ? tabDividerColor
-                      : Colors.transparent,
+                  dividerColor:
+                      showTabDivider ? tabDividerColor : Colors.transparent,
                   dividerHeight: 3.0,
                   indicator: const _CustomTabIndicator(
                     indicatorHeight: 3.0,
@@ -281,8 +285,8 @@ class TabControllerScope extends InheritedWidget {
   });
 
   static TabController? of(BuildContext context) {
-    final TabControllerScope? scope = context
-        .dependOnInheritedWidgetOfExactType<TabControllerScope>();
+    final TabControllerScope? scope =
+        context.dependOnInheritedWidgetOfExactType<TabControllerScope>();
     return scope?.enabled == true ? scope?.controller : null;
   }
 
@@ -317,8 +321,7 @@ class _CustomPainter extends BoxPainter {
   @override
   void paint(Canvas canvas, Offset offset, ImageConfiguration configuration) {
     assert(configuration.size != null);
-    final Rect rect =
-        Offset(
+    final Rect rect = Offset(
           offset.dx,
           (configuration.size!.height - decoration.indicatorHeight),
         ) &

--- a/lib/themes/nipaplay/widgets/custom_scaffold.dart
+++ b/lib/themes/nipaplay/widgets/custom_scaffold.dart
@@ -111,7 +111,6 @@ class _CustomScaffoldState extends State<CustomScaffold> {
         widget.useLargeScreenLayout &&
         widget.pageIsHome &&
         isDesktopOrTablet &&
-        widget.shouldShowAppBar &&
         widget.tabPage.isNotEmpty;
     const enableAnimation = true;
 

--- a/lib/themes/nipaplay/widgets/custom_scaffold.dart
+++ b/lib/themes/nipaplay/widgets/custom_scaffold.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:kmbal_ionicons/kmbal_ionicons.dart';
+import 'package:nipaplay/pages/tab_labels.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/background_with_blur.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/switchable_view.dart';
 import 'package:nipaplay/utils/globals.dart' as globals;
@@ -254,8 +255,13 @@ class _CustomScaffoldState extends State<CustomScaffold> {
             padding: EdgeInsets.zero,
             itemCount: widget.tabPage.length,
             itemBuilder: (context, index) {
+              final bool isSelected = currentIndex == index;
+              final bool isDarkMode = Theme.of(context).brightness == Brightness.dark;
+              final Color itemColor = isSelected
+                  ? Colors.white
+                  : (isDarkMode ? Colors.white60 : Colors.black54);
               return NipaplaySidePanelItem(
-                isSelected: currentIndex == index,
+                isSelected: isSelected,
                 activeColor: activeColor,
                 inactiveColor: inactiveColor,
                 onTap: () {
@@ -263,7 +269,10 @@ class _CustomScaffoldState extends State<CustomScaffold> {
                     widget.tabController!.animateTo(index);
                   }
                 },
-                child: _stripOuterTabPadding(widget.tabPage[index]),
+                child: _buildSidePanelTabContent(
+                  _stripOuterTabPadding(widget.tabPage[index]),
+                  itemColor: itemColor,
+                ),
               );
             },
           ),
@@ -286,6 +295,35 @@ class _CustomScaffoldState extends State<CustomScaffold> {
   Widget _stripOuterTabPadding(Widget tabWidget) {
     if (tabWidget is Padding && tabWidget.child != null) {
       return tabWidget.child!;
+    }
+    return tabWidget;
+  }
+
+  Widget _buildSidePanelTabContent(
+    Widget tabWidget, {
+    required Color itemColor,
+  }) {
+    if (tabWidget is HoverZoomTab) {
+      return Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (tabWidget.icon != null) ...[
+            IconTheme(
+              data: IconThemeData(color: itemColor),
+              child: tabWidget.icon!,
+            ),
+            const SizedBox(width: 6),
+          ],
+          Text(
+            tabWidget.text,
+            style: TextStyle(
+              color: itemColor,
+              fontSize: tabWidget.fontSize,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ],
+      );
     }
     return tabWidget;
   }

--- a/lib/themes/nipaplay/widgets/custom_scaffold.dart
+++ b/lib/themes/nipaplay/widgets/custom_scaffold.dart
@@ -2,8 +2,8 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:kmbal_ionicons/kmbal_ionicons.dart';
-import 'package:nipaplay/pages/tab_labels.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/background_with_blur.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_scaffold_layout.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/switchable_view.dart';
 import 'package:nipaplay/utils/globals.dart' as globals;
 import 'package:nipaplay/utils/platform_utils.dart';
@@ -221,9 +221,11 @@ class _CustomScaffoldState extends State<CustomScaffold> {
         controller: widget.tabController!,
         enabled: true,
         child: useLargeScreenLayout
-            ? _buildLargeScreenLayout(
+            ? NipaplayLargeScreenScaffoldLayout(
                 currentIndex: currentIndex,
                 isDarkMode: isDarkMode,
+                tabPage: widget.tabPage,
+                tabController: widget.tabController!,
                 content: switchableContent,
               )
             : switchableContent,
@@ -234,98 +236,6 @@ class _CustomScaffoldState extends State<CustomScaffold> {
       transparentCutout: useVideoUnderlay ? videoUnderlayRect : null,
       child: scaffold,
     );
-  }
-
-  Widget _buildLargeScreenLayout({
-    required int currentIndex,
-    required bool isDarkMode,
-    required Widget content,
-  }) {
-    const Color activeColor = Color(0xFFFF2E55);
-    final Color inactiveColor = isDarkMode ? Colors.white60 : Colors.black54;
-    final mediaPadding = MediaQuery.of(context).padding;
-    final double topInset = globals.isDesktop ? 50 : mediaPadding.top + 14;
-
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        NipaplaySidePanel(
-          isDarkMode: isDarkMode,
-          child: ListView.builder(
-            padding: EdgeInsets.zero,
-            itemCount: widget.tabPage.length,
-            itemBuilder: (context, index) {
-              final bool isSelected = currentIndex == index;
-              final bool isDarkMode = Theme.of(context).brightness == Brightness.dark;
-              final Color itemColor = isSelected
-                  ? Colors.white
-                  : (isDarkMode ? Colors.white60 : Colors.black54);
-              return NipaplaySidePanelItem(
-                isSelected: isSelected,
-                activeColor: activeColor,
-                inactiveColor: inactiveColor,
-                onTap: () {
-                  if (widget.tabController!.index != index) {
-                    widget.tabController!.animateTo(index);
-                  }
-                },
-                child: _buildSidePanelTabContent(
-                  _stripOuterTabPadding(widget.tabPage[index]),
-                  itemColor: itemColor,
-                ),
-              );
-            },
-          ),
-        ),
-        Expanded(
-          child: Padding(
-            padding: EdgeInsets.fromLTRB(
-              14,
-              topInset,
-              14,
-              14 + mediaPadding.bottom,
-            ),
-            child: content,
-          ),
-        ),
-      ],
-    );
-  }
-
-  Widget _stripOuterTabPadding(Widget tabWidget) {
-    if (tabWidget is Padding && tabWidget.child != null) {
-      return tabWidget.child!;
-    }
-    return tabWidget;
-  }
-
-  Widget _buildSidePanelTabContent(
-    Widget tabWidget, {
-    required Color itemColor,
-  }) {
-    if (tabWidget is HoverZoomTab) {
-      return Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          if (tabWidget.icon != null) ...[
-            IconTheme(
-              data: IconThemeData(color: itemColor),
-              child: tabWidget.icon!,
-            ),
-            const SizedBox(width: 6),
-          ],
-          Text(
-            tabWidget.text,
-            style: TextStyle(
-              color: itemColor,
-              fontSize: tabWidget.fontSize,
-              fontWeight: FontWeight.bold,
-            ),
-          ),
-        ],
-      );
-    }
-    return tabWidget;
   }
 
   void _logAppBarOverlayStyle({
@@ -347,127 +257,6 @@ class _CustomScaffoldState extends State<CustomScaffold> {
       'isDark=$isDarkMode, '
       'icon=${overlayStyle.statusBarIconBrightness?.name}, '
       'ios=${overlayStyle.statusBarBrightness?.name}',
-    );
-  }
-}
-
-class NipaplaySidePanel extends StatelessWidget {
-  const NipaplaySidePanel({
-    super.key,
-    required this.isDarkMode,
-    required this.child,
-    this.width = 220,
-  });
-
-  final bool isDarkMode;
-  final Widget child;
-  final double width;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      width: width,
-      decoration: BoxDecoration(
-        border: Border(
-          right: BorderSide(
-            color: isDarkMode ? Colors.white12 : Colors.black12,
-            width: 1,
-          ),
-        ),
-      ),
-      child: child,
-    );
-  }
-}
-
-class NipaplaySidePanelItem extends StatefulWidget {
-  const NipaplaySidePanelItem({
-    super.key,
-    required this.isSelected,
-    required this.activeColor,
-    required this.inactiveColor,
-    required this.onTap,
-    required this.child,
-  });
-
-  final bool isSelected;
-  final Color activeColor;
-  final Color inactiveColor;
-  final VoidCallback onTap;
-  final Widget child;
-
-  @override
-  State<NipaplaySidePanelItem> createState() => _NipaplaySidePanelItemState();
-}
-
-class _NipaplaySidePanelItemState extends State<NipaplaySidePanelItem> {
-  bool _isHovered = false;
-  bool _isPressed = false;
-
-  void _setHovered(bool value) {
-    if (_isHovered == value) return;
-    setState(() {
-      _isHovered = value;
-    });
-  }
-
-  void _setPressed(bool value) {
-    if (_isPressed == value) return;
-    setState(() {
-      _isPressed = value;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final bool isInteractiveActive = _isHovered || _isPressed;
-    final bool isActive = widget.isSelected || isInteractiveActive;
-    final Color itemColor = isActive ? Colors.white : widget.inactiveColor;
-
-    return Material(
-      color: Colors.transparent,
-      child: InkWell(
-        borderRadius: BorderRadius.zero,
-        splashFactory: NoSplash.splashFactory,
-        overlayColor: WidgetStateProperty.all(Colors.transparent),
-        splashColor: Colors.transparent,
-        highlightColor: Colors.transparent,
-        onTap: widget.onTap,
-        onHover: _setHovered,
-        onHighlightChanged: _setPressed,
-        child: AnimatedContainer(
-          duration: const Duration(milliseconds: 180),
-          curve: Curves.easeOutCubic,
-          width: double.infinity,
-          padding: const EdgeInsets.symmetric(
-            horizontal: 12,
-            vertical: 10,
-          ),
-          decoration: BoxDecoration(
-            color: isActive
-                ? widget.activeColor
-                : Colors.transparent,
-            border: Border(
-              left: BorderSide(
-                color: isActive
-                    ? widget.activeColor
-                    : Colors.transparent,
-                width: 3,
-              ),
-            ),
-          ),
-          child: DefaultTextStyle.merge(
-            style: TextStyle(color: itemColor),
-            child: IconTheme.merge(
-              data: IconThemeData(color: itemColor),
-              child: Align(
-                alignment: Alignment.centerLeft,
-                child: widget.child,
-              ),
-            ),
-          ),
-        ),
-      ),
     );
   }
 }

--- a/lib/themes/nipaplay/widgets/dashboard_home_page_build_hero.dart
+++ b/lib/themes/nipaplay/widgets/dashboard_home_page_build_hero.dart
@@ -40,7 +40,9 @@ extension DashboardHomePageHeroBuild on _DashboardHomePageState {
     }
 
     // 确保至少有7个项目用于布局
-    final items = _recommendedItems.length >= 7 ? _recommendedItems.take(7).toList() : _recommendedItems;
+    final items = _recommendedItems.length >= 7
+        ? _recommendedItems.take(7).toList()
+        : _recommendedItems;
     if (items.length < 7) {
       // 如果不足7个，填充占位符
       while (items.length < 7) {
@@ -111,15 +113,17 @@ extension DashboardHomePageHeroBuild on _DashboardHomePageState {
                   flex: 1,
                   child: Column(
                     children: [
-                      Expanded(child: _buildSmallRecommendationCard(items[5], 5)),
+                      Expanded(
+                          child: _buildSmallRecommendationCard(items[5], 5)),
                       const SizedBox(height: 8),
-                      Expanded(child: _buildSmallRecommendationCard(items[6], 6)),
+                      Expanded(
+                          child: _buildSmallRecommendationCard(items[6], 6)),
                     ],
                   ),
                 ),
               ],
             ),
-          
+
           // 页面指示器
           _buildPageIndicator(fullWidth: isPhone, count: pageCount),
         ],
@@ -127,9 +131,11 @@ extension DashboardHomePageHeroBuild on _DashboardHomePageState {
     );
   }
 
-  Widget _buildMainHeroBannerItem(RecommendedItem item, {bool compact = false}) {
-    return GestureDetector(
-      onTap: () => _onRecommendedItemTap(item),
+  Widget _buildMainHeroBannerItem(RecommendedItem item,
+      {bool compact = false}) {
+    return NipaplayLargeScreenFocusableAction(
+      onActivate: () => _onRecommendedItemTap(item),
+      borderRadius: BorderRadius.circular(8),
       child: Container(
         key: ValueKey('hero_banner_${item.id}_${item.source.name}'), // 添加唯一key
         margin: const EdgeInsets.symmetric(horizontal: 4),
@@ -141,20 +147,25 @@ extension DashboardHomePageHeroBuild on _DashboardHomePageState {
           fit: StackFit.expand,
           children: [
             // 背景图 - 使用高效缓存组件
-            if (item.backgroundImageUrl != null && item.backgroundImageUrl!.isNotEmpty)
+            if (item.backgroundImageUrl != null &&
+                item.backgroundImageUrl!.isNotEmpty)
               Stack(
                 fit: StackFit.expand,
                 children: [
                   Container(color: Colors.white),
                   CachedNetworkImageWidget(
-                    key: ValueKey('hero_img_${item.id}_${item.backgroundImageUrl}'),
+                    key: ValueKey(
+                        'hero_img_${item.id}_${item.backgroundImageUrl}'),
                     imageUrl: item.backgroundImageUrl!,
                     fit: BoxFit.cover,
                     width: double.infinity,
                     height: double.infinity,
                     delayLoad: _shouldDelayImageLoad(), // 根据推荐内容来源决定是否延迟
-                    blurIfLowRes: item.source != RecommendedItemSource.dandanplay,
-                    forceBlur: item.source != RecommendedItemSource.dandanplay ? item.isLowRes : false,
+                    blurIfLowRes:
+                        item.source != RecommendedItemSource.dandanplay,
+                    forceBlur: item.source != RecommendedItemSource.dandanplay
+                        ? item.isLowRes
+                        : false,
                     lowResBlurSigma: 40,
                     lowResMinScale: 0.8,
                     errorBuilder: (context, error) => Container(
@@ -174,7 +185,7 @@ extension DashboardHomePageHeroBuild on _DashboardHomePageState {
                       : Colors.black12,
                 ),
               ),
-            
+
             // 遮罩层
             Container(
               decoration: BoxDecoration(
@@ -188,7 +199,7 @@ extension DashboardHomePageHeroBuild on _DashboardHomePageState {
                 ),
               ),
             ),
-            
+
             // 右上角评分
             if (item.rating != null)
               Positioned(
@@ -197,9 +208,20 @@ extension DashboardHomePageHeroBuild on _DashboardHomePageState {
                 child: ClipRRect(
                   borderRadius: BorderRadius.circular(12),
                   child: BackdropFilter(
-                    filter: ImageFilter.blur(sigmaX: context.watch<AppearanceSettingsProvider>().enableWidgetBlurEffect ? 25 : 0, sigmaY: context.watch<AppearanceSettingsProvider>().enableWidgetBlurEffect ? 25 : 0),
+                    filter: ImageFilter.blur(
+                        sigmaX: context
+                                .watch<AppearanceSettingsProvider>()
+                                .enableWidgetBlurEffect
+                            ? 25
+                            : 0,
+                        sigmaY: context
+                                .watch<AppearanceSettingsProvider>()
+                                .enableWidgetBlurEffect
+                            ? 25
+                            : 0),
                     child: Container(
-                      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 8, vertical: 4),
                       decoration: BoxDecoration(
                         color: Colors.white.withOpacity(0.2),
                         borderRadius: BorderRadius.circular(12),
@@ -231,7 +253,7 @@ extension DashboardHomePageHeroBuild on _DashboardHomePageState {
                   ),
                 ),
               ),
-            
+
             // 左下角Logo - 使用高效缓存组件
             if (item.logoImageUrl != null && item.logoImageUrl!.isNotEmpty)
               Positioned(
@@ -241,10 +263,11 @@ extension DashboardHomePageHeroBuild on _DashboardHomePageState {
                   child: Container(
                     constraints: BoxConstraints(
                       maxWidth: compact ? 120 : 200, // 手机端更小
-                      maxHeight: compact ? 50 : 80,  // 手机端更小
+                      maxHeight: compact ? 50 : 80, // 手机端更小
                     ),
                     child: CachedNetworkImageWidget(
-                      key: ValueKey('hero_logo_${item.id}_${item.logoImageUrl}'),
+                      key:
+                          ValueKey('hero_logo_${item.id}_${item.logoImageUrl}'),
                       imageUrl: item.logoImageUrl!,
                       delayLoad: _shouldDelayImageLoad(), // 根据推荐内容来源决定是否延迟
                       fit: BoxFit.contain,
@@ -260,7 +283,7 @@ extension DashboardHomePageHeroBuild on _DashboardHomePageState {
                   child: Container(
                     constraints: BoxConstraints(
                       maxWidth: compact ? 120 : 200, // 手机端更小
-                      maxHeight: compact ? 50 : 80,  // 手机端更小
+                      maxHeight: compact ? 50 : 80, // 手机端更小
                     ),
                     child: Image.network(
                       item.logoImageUrl!,
@@ -282,11 +305,13 @@ extension DashboardHomePageHeroBuild on _DashboardHomePageState {
                   ),
                 ),
               ),
-            
+
             // 左侧中间位置的标题和简介
             Positioned(
               left: 16,
-              right: compact ? 16 : MediaQuery.of(context).size.width * 0.3, // 手机上不预留右侧空间
+              right: compact
+                  ? 16
+                  : MediaQuery.of(context).size.width * 0.3, // 手机上不预留右侧空间
               top: 0,
               bottom: 0,
               child: Align(
@@ -322,15 +347,18 @@ extension DashboardHomePageHeroBuild on _DashboardHomePageState {
                         ),
                       ],
                     ),
-                    
+
                     // 桌面端显示间距和简介，手机端不显示
                     if (!compact) ...[
                       const SizedBox(height: 12),
-                      
+
                       // 剧情简介（只在桌面端显示）
                       if (item.subtitle.isNotEmpty)
                         Text(
-                          item.subtitle.replaceAll('<br>', ' ').replaceAll('<br/>', ' ').replaceAll('<br />', ' '),
+                          item.subtitle
+                              .replaceAll('<br>', ' ')
+                              .replaceAll('<br/>', ' ')
+                              .replaceAll('<br />', ' '),
                           style: const TextStyle(
                             color: Colors.white70,
                             fontSize: 14,
@@ -356,10 +384,12 @@ extension DashboardHomePageHeroBuild on _DashboardHomePageState {
   }
 
   Widget _buildSmallRecommendationCard(RecommendedItem item, int index) {
-    return GestureDetector(
-      onTap: () => _onRecommendedItemTap(item),
+    return NipaplayLargeScreenFocusableAction(
+      onActivate: () => _onRecommendedItemTap(item),
+      borderRadius: BorderRadius.circular(4),
       child: Container(
-        key: ValueKey('small_card_${item.id}_${item.source.name}_$index'), // 添加唯一key包含索引
+        key: ValueKey(
+            'small_card_${item.id}_${item.source.name}_$index'), // 添加唯一key包含索引
         margin: const EdgeInsets.symmetric(horizontal: 2),
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(4),
@@ -369,26 +399,32 @@ extension DashboardHomePageHeroBuild on _DashboardHomePageState {
           fit: StackFit.expand,
           children: [
             // 背景图 - 使用高效缓存组件
-            if (item.backgroundImageUrl != null && item.backgroundImageUrl!.isNotEmpty)
+            if (item.backgroundImageUrl != null &&
+                item.backgroundImageUrl!.isNotEmpty)
               Stack(
                 fit: StackFit.expand,
                 children: [
                   Container(color: Colors.white),
                   CachedNetworkImageWidget(
-                    key: ValueKey('small_img_${item.id}_${item.backgroundImageUrl}_$index'),
+                    key: ValueKey(
+                        'small_img_${item.id}_${item.backgroundImageUrl}_$index'),
                     imageUrl: item.backgroundImageUrl!,
                     fit: BoxFit.cover,
                     delayLoad: _shouldDelayImageLoad(), // 根据推荐内容来源决定是否延迟
                     width: double.infinity,
                     height: double.infinity,
-                    blurIfLowRes: item.source != RecommendedItemSource.dandanplay,
-                    forceBlur: item.source != RecommendedItemSource.dandanplay ? item.isLowRes : false,
+                    blurIfLowRes:
+                        item.source != RecommendedItemSource.dandanplay,
+                    forceBlur: item.source != RecommendedItemSource.dandanplay
+                        ? item.isLowRes
+                        : false,
                     lowResBlurSigma: 40,
                     lowResMinScale: 0.8,
                     errorBuilder: (context, error) => Container(
                       color: Colors.white10,
                       child: const Center(
-                        child: Icon(Icons.broken_image, color: Colors.white30, size: 16),
+                        child: Icon(Icons.broken_image,
+                            color: Colors.white30, size: 16),
                       ),
                     ),
                   ),
@@ -402,7 +438,7 @@ extension DashboardHomePageHeroBuild on _DashboardHomePageState {
                       : Colors.black12,
                 ),
               ),
-            
+
             // 遮罩层
             Container(
               decoration: BoxDecoration(
@@ -416,7 +452,7 @@ extension DashboardHomePageHeroBuild on _DashboardHomePageState {
                 ),
               ),
             ),
-            
+
             // 右上角评分
             if (item.rating != null)
               Positioned(
@@ -425,9 +461,20 @@ extension DashboardHomePageHeroBuild on _DashboardHomePageState {
                 child: ClipRRect(
                   borderRadius: BorderRadius.circular(8),
                   child: BackdropFilter(
-                    filter: ImageFilter.blur(sigmaX: context.watch<AppearanceSettingsProvider>().enableWidgetBlurEffect ? 25 : 0, sigmaY: context.watch<AppearanceSettingsProvider>().enableWidgetBlurEffect ? 25 : 0),
+                    filter: ImageFilter.blur(
+                        sigmaX: context
+                                .watch<AppearanceSettingsProvider>()
+                                .enableWidgetBlurEffect
+                            ? 25
+                            : 0,
+                        sigmaY: context
+                                .watch<AppearanceSettingsProvider>()
+                                .enableWidgetBlurEffect
+                            ? 25
+                            : 0),
                     child: Container(
-                      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 6, vertical: 2),
                       decoration: BoxDecoration(
                         color: Colors.white.withOpacity(0.2),
                         borderRadius: BorderRadius.circular(8),
@@ -459,7 +506,7 @@ extension DashboardHomePageHeroBuild on _DashboardHomePageState {
                   ),
                 ),
               ),
-            
+
             // 左下角小Logo（如果有的话）
             // Logo图片 - 使用高效缓存组件
             if (item.logoImageUrl != null && item.logoImageUrl!.isNotEmpty)
@@ -472,7 +519,8 @@ extension DashboardHomePageHeroBuild on _DashboardHomePageState {
                     maxHeight: 45,
                   ),
                   child: CachedNetworkImageWidget(
-                    key: ValueKey('small_logo_${item.id}_${item.logoImageUrl}_$index'),
+                    key: ValueKey(
+                        'small_logo_${item.id}_${item.logoImageUrl}_$index'),
                     imageUrl: item.logoImageUrl!,
                     fit: BoxFit.contain,
                     delayLoad: _shouldDelayImageLoad(), // 根据推荐内容来源决定是否延迟
@@ -507,12 +555,12 @@ extension DashboardHomePageHeroBuild on _DashboardHomePageState {
                   ),
                 ),
               ),
-            
+
             // 右下角标题（总是显示，不论是否有Logo）
             Positioned(
               right: 8,
               bottom: item.logoImageUrl != null && item.logoImageUrl!.isNotEmpty
-                ? 66
+                  ? 66
                   : 8,
               left: item.logoImageUrl != null && item.logoImageUrl!.isNotEmpty
                   ? 8

--- a/lib/themes/nipaplay/widgets/dashboard_home_page_build_hero.dart
+++ b/lib/themes/nipaplay/widgets/dashboard_home_page_build_hero.dart
@@ -135,7 +135,9 @@ extension DashboardHomePageHeroBuild on _DashboardHomePageState {
       {bool compact = false}) {
     final card = Container(
       key: ValueKey('hero_banner_${item.id}_${item.source.name}'), // 添加唯一key
-      margin: const EdgeInsets.symmetric(horizontal: 4),
+      margin: _isLargeScreenModeActive
+          ? EdgeInsets.zero
+          : const EdgeInsets.symmetric(horizontal: 4),
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(8),
       ),
@@ -151,7 +153,8 @@ extension DashboardHomePageHeroBuild on _DashboardHomePageState {
               children: [
                 Container(color: Colors.white),
                 CachedNetworkImageWidget(
-                  key: ValueKey('hero_img_${item.id}_${item.backgroundImageUrl}'),
+                  key: ValueKey(
+                      'hero_img_${item.id}_${item.backgroundImageUrl}'),
                   imageUrl: item.backgroundImageUrl!,
                   fit: BoxFit.cover,
                   width: double.infinity,
@@ -393,7 +396,8 @@ extension DashboardHomePageHeroBuild on _DashboardHomePageState {
 
   Widget _buildSmallRecommendationCard(RecommendedItem item, int index) {
     final card = Container(
-      key: ValueKey('small_card_${item.id}_${item.source.name}_$index'), // 添加唯一key包含索引
+      key: ValueKey(
+          'small_card_${item.id}_${item.source.name}_$index'), // 添加唯一key包含索引
       margin: const EdgeInsets.symmetric(horizontal: 2),
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(4),
@@ -426,8 +430,8 @@ extension DashboardHomePageHeroBuild on _DashboardHomePageState {
                   errorBuilder: (context, error) => Container(
                     color: Colors.white10,
                     child: const Center(
-                      child:
-                          Icon(Icons.broken_image, color: Colors.white30, size: 16),
+                      child: Icon(Icons.broken_image,
+                          color: Colors.white30, size: 16),
                     ),
                   ),
                 ),
@@ -522,8 +526,8 @@ extension DashboardHomePageHeroBuild on _DashboardHomePageState {
                   maxHeight: 45,
                 ),
                 child: CachedNetworkImageWidget(
-                  key:
-                      ValueKey('small_logo_${item.id}_${item.logoImageUrl}_$index'),
+                  key: ValueKey(
+                      'small_logo_${item.id}_${item.logoImageUrl}_$index'),
                   imageUrl: item.logoImageUrl!,
                   fit: BoxFit.contain,
                   delayLoad: _shouldDelayImageLoad(), // 根据推荐内容来源决定是否延迟
@@ -562,9 +566,12 @@ extension DashboardHomePageHeroBuild on _DashboardHomePageState {
           // 右下角标题（总是显示，不论是否有Logo）
           Positioned(
             right: 8,
-            bottom:
-                item.logoImageUrl != null && item.logoImageUrl!.isNotEmpty ? 66 : 8,
-            left: item.logoImageUrl != null && item.logoImageUrl!.isNotEmpty ? 8 : 8,
+            bottom: item.logoImageUrl != null && item.logoImageUrl!.isNotEmpty
+                ? 66
+                : 8,
+            left: item.logoImageUrl != null && item.logoImageUrl!.isNotEmpty
+                ? 8
+                : 8,
             child: Row(
               mainAxisSize: MainAxisSize.min,
               children: [

--- a/lib/themes/nipaplay/widgets/dashboard_home_page_build_hero.dart
+++ b/lib/themes/nipaplay/widgets/dashboard_home_page_build_hero.dart
@@ -133,408 +133,151 @@ extension DashboardHomePageHeroBuild on _DashboardHomePageState {
 
   Widget _buildMainHeroBannerItem(RecommendedItem item,
       {bool compact = false}) {
-    return NipaplayLargeScreenFocusableAction(
-      onActivate: () => _onRecommendedItemTap(item),
-      borderRadius: BorderRadius.circular(8),
-      child: Container(
-        key: ValueKey('hero_banner_${item.id}_${item.source.name}'), // 添加唯一key
-        margin: const EdgeInsets.symmetric(horizontal: 4),
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(8),
-        ),
-        clipBehavior: Clip.antiAlias,
-        child: Stack(
-          fit: StackFit.expand,
-          children: [
-            // 背景图 - 使用高效缓存组件
-            if (item.backgroundImageUrl != null &&
-                item.backgroundImageUrl!.isNotEmpty)
-              Stack(
-                fit: StackFit.expand,
-                children: [
-                  Container(color: Colors.white),
-                  CachedNetworkImageWidget(
-                    key: ValueKey(
-                        'hero_img_${item.id}_${item.backgroundImageUrl}'),
-                    imageUrl: item.backgroundImageUrl!,
-                    fit: BoxFit.cover,
-                    width: double.infinity,
-                    height: double.infinity,
-                    delayLoad: _shouldDelayImageLoad(), // 根据推荐内容来源决定是否延迟
-                    blurIfLowRes:
-                        item.source != RecommendedItemSource.dandanplay,
-                    forceBlur: item.source != RecommendedItemSource.dandanplay
-                        ? item.isLowRes
-                        : false,
-                    lowResBlurSigma: 40,
-                    lowResMinScale: 0.8,
-                    errorBuilder: (context, error) => Container(
-                      color: Colors.white10,
-                      child: const Center(
-                        child: Icon(Icons.broken_image, color: Colors.white30),
-                      ),
+    final card = Container(
+      key: ValueKey('hero_banner_${item.id}_${item.source.name}'), // 添加唯一key
+      margin: const EdgeInsets.symmetric(horizontal: 4),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(8),
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          // 背景图 - 使用高效缓存组件
+          if (item.backgroundImageUrl != null &&
+              item.backgroundImageUrl!.isNotEmpty)
+            Stack(
+              fit: StackFit.expand,
+              children: [
+                Container(color: Colors.white),
+                CachedNetworkImageWidget(
+                  key: ValueKey('hero_img_${item.id}_${item.backgroundImageUrl}'),
+                  imageUrl: item.backgroundImageUrl!,
+                  fit: BoxFit.cover,
+                  width: double.infinity,
+                  height: double.infinity,
+                  delayLoad: _shouldDelayImageLoad(), // 根据推荐内容来源决定是否延迟
+                  blurIfLowRes: item.source != RecommendedItemSource.dandanplay,
+                  forceBlur: item.source != RecommendedItemSource.dandanplay
+                      ? item.isLowRes
+                      : false,
+                  lowResBlurSigma: 40,
+                  lowResMinScale: 0.8,
+                  errorBuilder: (context, error) => Container(
+                    color: Colors.white10,
+                    child: const Center(
+                      child: Icon(Icons.broken_image, color: Colors.white30),
                     ),
                   ),
-                ],
-              )
-            else
-              Container(
-                decoration: BoxDecoration(
-                  color: Theme.of(context).brightness == Brightness.dark
-                      ? Colors.white10
-                      : Colors.black12,
                 ),
-              ),
-
-            // 遮罩层
+              ],
+            )
+          else
             Container(
               decoration: BoxDecoration(
-                gradient: LinearGradient(
-                  begin: Alignment.topCenter,
-                  end: Alignment.bottomCenter,
-                  colors: [
-                    Colors.transparent,
-                    Colors.black.withOpacity(0.7),
-                  ],
-                ),
+                color: Theme.of(context).brightness == Brightness.dark
+                    ? Colors.white10
+                    : Colors.black12,
               ),
             ),
 
-            // 右上角评分
-            if (item.rating != null)
-              Positioned(
-                top: 16,
-                right: 16,
-                child: ClipRRect(
-                  borderRadius: BorderRadius.circular(12),
-                  child: BackdropFilter(
-                    filter: ImageFilter.blur(
-                        sigmaX: context
-                                .watch<AppearanceSettingsProvider>()
-                                .enableWidgetBlurEffect
-                            ? 25
-                            : 0,
-                        sigmaY: context
-                                .watch<AppearanceSettingsProvider>()
-                                .enableWidgetBlurEffect
-                            ? 25
-                            : 0),
-                    child: Container(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 8, vertical: 4),
-                      decoration: BoxDecoration(
-                        color: Colors.white.withOpacity(0.2),
-                        borderRadius: BorderRadius.circular(12),
-                        border: Border.all(
-                          color: Colors.white.withOpacity(1.0),
-                          width: 1,
-                        ),
-                      ),
-                      child: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          const Icon(
-                            Icons.star_rounded,
-                            color: Colors.white,
-                            size: 16,
-                          ),
-                          const SizedBox(width: 4),
-                          Text(
-                            item.rating!.toStringAsFixed(1),
-                            style: const TextStyle(
-                              color: Colors.white,
-                              fontSize: 12,
-                              fontWeight: FontWeight.bold,
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                ),
+          // 遮罩层
+          Container(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+                colors: [
+                  Colors.transparent,
+                  Colors.black.withOpacity(0.7),
+                ],
               ),
+            ),
+          ),
 
-            // 左下角Logo - 使用高效缓存组件
-            if (item.logoImageUrl != null && item.logoImageUrl!.isNotEmpty)
-              Positioned(
-                left: 32,
-                bottom: 32,
-                child: ClipRect(
-                  child: Container(
-                    constraints: BoxConstraints(
-                      maxWidth: compact ? 120 : 200, // 手机端更小
-                      maxHeight: compact ? 50 : 80, // 手机端更小
-                    ),
-                    child: CachedNetworkImageWidget(
-                      key:
-                          ValueKey('hero_logo_${item.id}_${item.logoImageUrl}'),
-                      imageUrl: item.logoImageUrl!,
-                      delayLoad: _shouldDelayImageLoad(), // 根据推荐内容来源决定是否延迟
-                      fit: BoxFit.contain,
-                    ),
-                  ),
-                ),
-              )
-            else if (item.logoImageUrl != null)
-              Positioned(
-                left: 32,
-                bottom: 32,
-                child: ClipRect(
-                  child: Container(
-                    constraints: BoxConstraints(
-                      maxWidth: compact ? 120 : 200, // 手机端更小
-                      maxHeight: compact ? 50 : 80, // 手机端更小
-                    ),
-                    child: Image.network(
-                      item.logoImageUrl!,
-                      fit: BoxFit.contain,
-                      loadingBuilder: (context, child, loadingProgress) {
-                        if (loadingProgress == null) return child;
-                        return Container(
-                          width: compact ? 120 : 200,
-                          height: compact ? 50 : 80,
-                          color: Colors.transparent,
-                        );
-                      },
-                      errorBuilder: (context, error, stackTrace) => Container(
-                        width: compact ? 120 : 200,
-                        height: compact ? 50 : 80,
-                        color: Colors.transparent,
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-
-            // 左侧中间位置的标题和简介
+          // 右上角评分
+          if (item.rating != null)
             Positioned(
-              left: 16,
-              right: compact
-                  ? 16
-                  : MediaQuery.of(context).size.width * 0.3, // 手机上不预留右侧空间
-              top: 0,
-              bottom: 0,
-              child: Align(
-                alignment: Alignment.centerLeft, // 左对齐而不是居中
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    // 媒体名字（加粗显示）
-                    Row(
+              top: 16,
+              right: 16,
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(12),
+                child: BackdropFilter(
+                  filter: ImageFilter.blur(
+                      sigmaX: context
+                              .watch<AppearanceSettingsProvider>()
+                              .enableWidgetBlurEffect
+                          ? 25
+                          : 0,
+                      sigmaY: context
+                              .watch<AppearanceSettingsProvider>()
+                              .enableWidgetBlurEffect
+                          ? 25
+                          : 0),
+                  child: Container(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                    decoration: BoxDecoration(
+                      color: Colors.white.withOpacity(0.2),
+                      borderRadius: BorderRadius.circular(12),
+                      border: Border.all(
+                        color: Colors.white.withOpacity(1.0),
+                        width: 1,
+                      ),
+                    ),
+                    child: Row(
                       mainAxisSize: MainAxisSize.min,
                       children: [
-                        _buildServiceIcon(item.source, size: compact ? 22 : 24),
-                        const SizedBox(width: 8),
-                        Flexible(
-                          child: Text(
-                            item.title,
-                            locale: const Locale("zh-Hans", "zh"),
-                            style: TextStyle(
-                              color: Colors.white,
-                              fontSize: compact ? 22 : 24, // 手机端调整为20px，比18px稍大
-                              fontWeight: FontWeight.bold,
-                              shadows: const [
-                                Shadow(
-                                  color: Colors.black,
-                                  blurRadius: 8,
-                                ),
-                              ],
-                            ),
-                            maxLines: compact ? 3 : 2, // 手机端可以显示更多行
-                            overflow: TextOverflow.ellipsis,
+                        const Icon(
+                          Icons.star_rounded,
+                          color: Colors.white,
+                          size: 16,
+                        ),
+                        const SizedBox(width: 4),
+                        Text(
+                          item.rating!.toStringAsFixed(1),
+                          style: const TextStyle(
+                            color: Colors.white,
+                            fontSize: 12,
+                            fontWeight: FontWeight.bold,
                           ),
                         ),
                       ],
                     ),
-
-                    // 桌面端显示间距和简介，手机端不显示
-                    if (!compact) ...[
-                      const SizedBox(height: 12),
-
-                      // 剧情简介（只在桌面端显示）
-                      if (item.subtitle.isNotEmpty)
-                        Text(
-                          item.subtitle
-                              .replaceAll('<br>', ' ')
-                              .replaceAll('<br/>', ' ')
-                              .replaceAll('<br />', ' '),
-                          style: const TextStyle(
-                            color: Colors.white70,
-                            fontSize: 14,
-                            shadows: [
-                              Shadow(
-                                color: Colors.black,
-                                blurRadius: 4,
-                              ),
-                            ],
-                          ),
-                          maxLines: 2,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                    ],
-                  ],
-                ),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildSmallRecommendationCard(RecommendedItem item, int index) {
-    return NipaplayLargeScreenFocusableAction(
-      onActivate: () => _onRecommendedItemTap(item),
-      borderRadius: BorderRadius.circular(4),
-      child: Container(
-        key: ValueKey(
-            'small_card_${item.id}_${item.source.name}_$index'), // 添加唯一key包含索引
-        margin: const EdgeInsets.symmetric(horizontal: 2),
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(4),
-        ),
-        clipBehavior: Clip.antiAlias,
-        child: Stack(
-          fit: StackFit.expand,
-          children: [
-            // 背景图 - 使用高效缓存组件
-            if (item.backgroundImageUrl != null &&
-                item.backgroundImageUrl!.isNotEmpty)
-              Stack(
-                fit: StackFit.expand,
-                children: [
-                  Container(color: Colors.white),
-                  CachedNetworkImageWidget(
-                    key: ValueKey(
-                        'small_img_${item.id}_${item.backgroundImageUrl}_$index'),
-                    imageUrl: item.backgroundImageUrl!,
-                    fit: BoxFit.cover,
-                    delayLoad: _shouldDelayImageLoad(), // 根据推荐内容来源决定是否延迟
-                    width: double.infinity,
-                    height: double.infinity,
-                    blurIfLowRes:
-                        item.source != RecommendedItemSource.dandanplay,
-                    forceBlur: item.source != RecommendedItemSource.dandanplay
-                        ? item.isLowRes
-                        : false,
-                    lowResBlurSigma: 40,
-                    lowResMinScale: 0.8,
-                    errorBuilder: (context, error) => Container(
-                      color: Colors.white10,
-                      child: const Center(
-                        child: Icon(Icons.broken_image,
-                            color: Colors.white30, size: 16),
-                      ),
-                    ),
                   ),
-                ],
-              )
-            else
-              Container(
-                decoration: BoxDecoration(
-                  color: Theme.of(context).brightness == Brightness.dark
-                      ? Colors.white10
-                      : Colors.black12,
-                ),
-              ),
-
-            // 遮罩层
-            Container(
-              decoration: BoxDecoration(
-                gradient: LinearGradient(
-                  begin: Alignment.topCenter,
-                  end: Alignment.bottomCenter,
-                  colors: [
-                    Colors.transparent,
-                    Colors.black.withOpacity(0.7),
-                  ],
                 ),
               ),
             ),
 
-            // 右上角评分
-            if (item.rating != null)
-              Positioned(
-                top: 8,
-                right: 8,
-                child: ClipRRect(
-                  borderRadius: BorderRadius.circular(8),
-                  child: BackdropFilter(
-                    filter: ImageFilter.blur(
-                        sigmaX: context
-                                .watch<AppearanceSettingsProvider>()
-                                .enableWidgetBlurEffect
-                            ? 25
-                            : 0,
-                        sigmaY: context
-                                .watch<AppearanceSettingsProvider>()
-                                .enableWidgetBlurEffect
-                            ? 25
-                            : 0),
-                    child: Container(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 6, vertical: 2),
-                      decoration: BoxDecoration(
-                        color: Colors.white.withOpacity(0.2),
-                        borderRadius: BorderRadius.circular(8),
-                        border: Border.all(
-                          color: Colors.white.withOpacity(1.0),
-                          width: 1,
-                        ),
-                      ),
-                      child: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          const Icon(
-                            Icons.star_rounded,
-                            color: Colors.white,
-                            size: 12,
-                          ),
-                          const SizedBox(width: 2),
-                          Text(
-                            item.rating!.toStringAsFixed(1),
-                            style: const TextStyle(
-                              color: Colors.white,
-                              fontSize: 10,
-                              fontWeight: FontWeight.bold,
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-
-            // 左下角小Logo（如果有的话）
-            // Logo图片 - 使用高效缓存组件
-            if (item.logoImageUrl != null && item.logoImageUrl!.isNotEmpty)
-              Positioned(
-                left: 8,
-                bottom: 8,
+          // 左下角Logo - 使用高效缓存组件
+          if (item.logoImageUrl != null && item.logoImageUrl!.isNotEmpty)
+            Positioned(
+              left: 32,
+              bottom: 32,
+              child: ClipRect(
                 child: Container(
-                  constraints: const BoxConstraints(
-                    maxWidth: 120,
-                    maxHeight: 45,
+                  constraints: BoxConstraints(
+                    maxWidth: compact ? 120 : 200, // 手机端更小
+                    maxHeight: compact ? 50 : 80, // 手机端更小
                   ),
                   child: CachedNetworkImageWidget(
-                    key: ValueKey(
-                        'small_logo_${item.id}_${item.logoImageUrl}_$index'),
+                    key: ValueKey('hero_logo_${item.id}_${item.logoImageUrl}'),
                     imageUrl: item.logoImageUrl!,
-                    fit: BoxFit.contain,
                     delayLoad: _shouldDelayImageLoad(), // 根据推荐内容来源决定是否延迟
+                    fit: BoxFit.contain,
                   ),
                 ),
-              )
-            else if (item.logoImageUrl != null)
-              Positioned(
-                left: 8,
-                bottom: 8,
+              ),
+            )
+          else if (item.logoImageUrl != null)
+            Positioned(
+              left: 32,
+              bottom: 32,
+              child: ClipRect(
                 child: Container(
-                  constraints: const BoxConstraints(
-                    maxWidth: 120,
-                    maxHeight: 45,
+                  constraints: BoxConstraints(
+                    maxWidth: compact ? 120 : 200, // 手机端更小
+                    maxHeight: compact ? 50 : 80, // 手机端更小
                   ),
                   child: Image.network(
                     item.logoImageUrl!,
@@ -542,58 +285,329 @@ extension DashboardHomePageHeroBuild on _DashboardHomePageState {
                     loadingBuilder: (context, child, loadingProgress) {
                       if (loadingProgress == null) return child;
                       return Container(
-                        width: 120,
-                        height: 45,
+                        width: compact ? 120 : 200,
+                        height: compact ? 50 : 80,
                         color: Colors.transparent,
                       );
                     },
                     errorBuilder: (context, error, stackTrace) => Container(
-                      width: 120,
-                      height: 45,
+                      width: compact ? 120 : 200,
+                      height: compact ? 50 : 80,
                       color: Colors.transparent,
                     ),
                   ),
                 ),
               ),
+            ),
 
-            // 右下角标题（总是显示，不论是否有Logo）
-            Positioned(
-              right: 8,
-              bottom: item.logoImageUrl != null && item.logoImageUrl!.isNotEmpty
-                  ? 66
-                  : 8,
-              left: item.logoImageUrl != null && item.logoImageUrl!.isNotEmpty
-                  ? 8
-                  : 8,
-              child: Row(
+          // 左侧中间位置的标题和简介
+          Positioned(
+            left: 16,
+            right: compact
+                ? 16
+                : MediaQuery.of(context).size.width * 0.3, // 手机上不预留右侧空间
+            top: 0,
+            bottom: 0,
+            child: Align(
+              alignment: Alignment.centerLeft, // 左对齐而不是居中
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  _buildServiceIcon(item.source, size: 12),
-                  const SizedBox(width: 4),
-                  Flexible(
-                    child: Text(
-                      item.title,
-                      style: const TextStyle(
-                        color: Colors.white,
-                        fontSize: 12,
-                        fontWeight: FontWeight.bold,
-                        shadows: [
-                          Shadow(
-                            color: Colors.black,
-                            blurRadius: 4,
+                  // 媒体名字（加粗显示）
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      _buildServiceIcon(item.source, size: compact ? 22 : 24),
+                      const SizedBox(width: 8),
+                      Flexible(
+                        child: Text(
+                          item.title,
+                          locale: const Locale("zh-Hans", "zh"),
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: compact ? 22 : 24, // 手机端调整为20px，比18px稍大
+                            fontWeight: FontWeight.bold,
+                            shadows: const [
+                              Shadow(
+                                color: Colors.black,
+                                blurRadius: 8,
+                              ),
+                            ],
                           ),
-                        ],
+                          maxLines: compact ? 3 : 2, // 手机端可以显示更多行
+                          overflow: TextOverflow.ellipsis,
+                        ),
                       ),
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
-                    ),
+                    ],
                   ),
+
+                  // 桌面端显示间距和简介，手机端不显示
+                  if (!compact) ...[
+                    const SizedBox(height: 12),
+
+                    // 剧情简介（只在桌面端显示）
+                    if (item.subtitle.isNotEmpty)
+                      Text(
+                        item.subtitle
+                            .replaceAll('<br>', ' ')
+                            .replaceAll('<br/>', ' ')
+                            .replaceAll('<br />', ' '),
+                        style: const TextStyle(
+                          color: Colors.white70,
+                          fontSize: 14,
+                          shadows: [
+                            Shadow(
+                              color: Colors.black,
+                              blurRadius: 4,
+                            ),
+                          ],
+                        ),
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                  ],
                 ],
               ),
             ),
-          ],
-        ),
+          ),
+        ],
       ),
+    );
+
+    final tapCard = GestureDetector(
+      onTap: () => _onRecommendedItemTap(item),
+      child: card,
+    );
+
+    if (!_isLargeScreenModeActive) {
+      return tapCard;
+    }
+
+    return NipaplayLargeScreenFocusableAction(
+      onActivate: () => _onRecommendedItemTap(item),
+      borderRadius: BorderRadius.circular(8),
+      child: card,
+    );
+  }
+
+  Widget _buildSmallRecommendationCard(RecommendedItem item, int index) {
+    final card = Container(
+      key: ValueKey('small_card_${item.id}_${item.source.name}_$index'), // 添加唯一key包含索引
+      margin: const EdgeInsets.symmetric(horizontal: 2),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(4),
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          // 背景图 - 使用高效缓存组件
+          if (item.backgroundImageUrl != null &&
+              item.backgroundImageUrl!.isNotEmpty)
+            Stack(
+              fit: StackFit.expand,
+              children: [
+                Container(color: Colors.white),
+                CachedNetworkImageWidget(
+                  key: ValueKey(
+                      'small_img_${item.id}_${item.backgroundImageUrl}_$index'),
+                  imageUrl: item.backgroundImageUrl!,
+                  fit: BoxFit.cover,
+                  delayLoad: _shouldDelayImageLoad(), // 根据推荐内容来源决定是否延迟
+                  width: double.infinity,
+                  height: double.infinity,
+                  blurIfLowRes: item.source != RecommendedItemSource.dandanplay,
+                  forceBlur: item.source != RecommendedItemSource.dandanplay
+                      ? item.isLowRes
+                      : false,
+                  lowResBlurSigma: 40,
+                  lowResMinScale: 0.8,
+                  errorBuilder: (context, error) => Container(
+                    color: Colors.white10,
+                    child: const Center(
+                      child:
+                          Icon(Icons.broken_image, color: Colors.white30, size: 16),
+                    ),
+                  ),
+                ),
+              ],
+            )
+          else
+            Container(
+              decoration: BoxDecoration(
+                color: Theme.of(context).brightness == Brightness.dark
+                    ? Colors.white10
+                    : Colors.black12,
+              ),
+            ),
+
+          // 遮罩层
+          Container(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+                colors: [
+                  Colors.transparent,
+                  Colors.black.withOpacity(0.7),
+                ],
+              ),
+            ),
+          ),
+
+          // 右上角评分
+          if (item.rating != null)
+            Positioned(
+              top: 8,
+              right: 8,
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(8),
+                child: BackdropFilter(
+                  filter: ImageFilter.blur(
+                      sigmaX: context
+                              .watch<AppearanceSettingsProvider>()
+                              .enableWidgetBlurEffect
+                          ? 25
+                          : 0,
+                      sigmaY: context
+                              .watch<AppearanceSettingsProvider>()
+                              .enableWidgetBlurEffect
+                          ? 25
+                          : 0),
+                  child: Container(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                    decoration: BoxDecoration(
+                      color: Colors.white.withOpacity(0.2),
+                      borderRadius: BorderRadius.circular(8),
+                      border: Border.all(
+                        color: Colors.white.withOpacity(1.0),
+                        width: 1,
+                      ),
+                    ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        const Icon(
+                          Icons.star_rounded,
+                          color: Colors.white,
+                          size: 12,
+                        ),
+                        const SizedBox(width: 2),
+                        Text(
+                          item.rating!.toStringAsFixed(1),
+                          style: const TextStyle(
+                            color: Colors.white,
+                            fontSize: 10,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+
+          // 左下角小Logo（如果有的话）
+          // Logo图片 - 使用高效缓存组件
+          if (item.logoImageUrl != null && item.logoImageUrl!.isNotEmpty)
+            Positioned(
+              left: 8,
+              bottom: 8,
+              child: Container(
+                constraints: const BoxConstraints(
+                  maxWidth: 120,
+                  maxHeight: 45,
+                ),
+                child: CachedNetworkImageWidget(
+                  key:
+                      ValueKey('small_logo_${item.id}_${item.logoImageUrl}_$index'),
+                  imageUrl: item.logoImageUrl!,
+                  fit: BoxFit.contain,
+                  delayLoad: _shouldDelayImageLoad(), // 根据推荐内容来源决定是否延迟
+                ),
+              ),
+            )
+          else if (item.logoImageUrl != null)
+            Positioned(
+              left: 8,
+              bottom: 8,
+              child: Container(
+                constraints: const BoxConstraints(
+                  maxWidth: 120,
+                  maxHeight: 45,
+                ),
+                child: Image.network(
+                  item.logoImageUrl!,
+                  fit: BoxFit.contain,
+                  loadingBuilder: (context, child, loadingProgress) {
+                    if (loadingProgress == null) return child;
+                    return Container(
+                      width: 120,
+                      height: 45,
+                      color: Colors.transparent,
+                    );
+                  },
+                  errorBuilder: (context, error, stackTrace) => Container(
+                    width: 120,
+                    height: 45,
+                    color: Colors.transparent,
+                  ),
+                ),
+              ),
+            ),
+
+          // 右下角标题（总是显示，不论是否有Logo）
+          Positioned(
+            right: 8,
+            bottom:
+                item.logoImageUrl != null && item.logoImageUrl!.isNotEmpty ? 66 : 8,
+            left: item.logoImageUrl != null && item.logoImageUrl!.isNotEmpty ? 8 : 8,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                _buildServiceIcon(item.source, size: 12),
+                const SizedBox(width: 4),
+                Flexible(
+                  child: Text(
+                    item.title,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 12,
+                      fontWeight: FontWeight.bold,
+                      shadows: [
+                        Shadow(
+                          color: Colors.black,
+                          blurRadius: 4,
+                        ),
+                      ],
+                    ),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+
+    final tapCard = GestureDetector(
+      onTap: () => _onRecommendedItemTap(item),
+      child: card,
+    );
+
+    if (!_isLargeScreenModeActive) {
+      return tapCard;
+    }
+
+    return NipaplayLargeScreenFocusableAction(
+      onActivate: () => _onRecommendedItemTap(item),
+      borderRadius: BorderRadius.circular(4),
+      child: card,
     );
   }
 

--- a/lib/themes/nipaplay/widgets/dashboard_home_page_build_sections.dart
+++ b/lib/themes/nipaplay/widgets/dashboard_home_page_build_sections.dart
@@ -214,8 +214,9 @@ extension DashboardHomePageSectionsBuild on _DashboardHomePageState {
 
   Widget _buildContinueWatchingCard(WatchHistoryItem item,
       {bool compact = false}) {
-    return GestureDetector(
-      onTap: _isHistoryAutoMatching ? null : () => _onWatchHistoryItemTap(item),
+    return NipaplayLargeScreenFocusableAction(
+      onActivate:
+          _isHistoryAutoMatching ? null : () => _onWatchHistoryItemTap(item),
       child: SizedBox(
         key: ValueKey(
             'continue_${item.animeId ?? 0}_${item.filePath.hashCode}'), // 添加唯一key
@@ -320,11 +321,16 @@ extension DashboardHomePageSectionsBuild on _DashboardHomePageState {
   Widget _buildWatchHistoryButton() {
     return Tooltip(
       message: '观看记录',
-      child: _HoverScaleButton(
-        onTap: _showWatchHistoryDialog,
-        child: const Icon(
-          Icons.history_rounded,
-          size: 24,
+      child: NipaplayLargeScreenFocusableAction(
+        onActivate: _showWatchHistoryDialog,
+        borderRadius: BorderRadius.circular(8),
+        padding: const EdgeInsets.all(4),
+        child: const _HoverScaleButton(
+          onTap: null,
+          child: Icon(
+            Icons.history_rounded,
+            size: 24,
+          ),
         ),
       ),
     );
@@ -340,11 +346,16 @@ extension DashboardHomePageSectionsBuild on _DashboardHomePageState {
   Widget _buildContinueWatchingRefreshButton() {
     return Tooltip(
       message: '刷新继续播放',
-      child: _HoverScaleButton(
-        onTap: _onContinueWatchingRefreshPressed,
-        child: const Icon(
-          Icons.refresh_rounded,
-          size: 24,
+      child: NipaplayLargeScreenFocusableAction(
+        onActivate: _onContinueWatchingRefreshPressed,
+        borderRadius: BorderRadius.circular(8),
+        padding: const EdgeInsets.all(4),
+        child: const _HoverScaleButton(
+          onTap: null,
+          child: Icon(
+            Icons.refresh_rounded,
+            size: 24,
+          ),
         ),
       ),
     );
@@ -612,18 +623,22 @@ extension DashboardHomePageSectionsBuild on _DashboardHomePageState {
         : HorizontalAnimeCard.compactCardHeight;
 
     Widget buildCard(String? summary, {String? progress}) {
-      return SizedBox(
-        width: cardWidth,
-        height: cardHeight,
-        child: HorizontalAnimeCard(
-          key: ValueKey(uniqueId),
-          title: name,
-          imageUrl: imageUrl,
-          onTap: () => onItemTap(item),
-          source: sourceLabel,
-          rating: rating,
-          summary: summary,
-          progress: progress ?? _getWatchProgressForDashboard(item),
+      return NipaplayLargeScreenFocusableAction(
+        onActivate: () => onItemTap(item),
+        borderRadius: BorderRadius.circular(4),
+        child: SizedBox(
+          width: cardWidth,
+          height: cardHeight,
+          child: HorizontalAnimeCard(
+            key: ValueKey(uniqueId),
+            title: name,
+            imageUrl: imageUrl,
+            onTap: () => onItemTap(item),
+            source: sourceLabel,
+            rating: rating,
+            summary: summary,
+            progress: progress ?? _getWatchProgressForDashboard(item),
+          ),
         ),
       );
     }

--- a/lib/themes/nipaplay/widgets/dashboard_home_page_build_sections.dart
+++ b/lib/themes/nipaplay/widgets/dashboard_home_page_build_sections.dart
@@ -214,62 +214,68 @@ extension DashboardHomePageSectionsBuild on _DashboardHomePageState {
 
   Widget _buildContinueWatchingCard(WatchHistoryItem item,
       {bool compact = false}) {
-    return NipaplayLargeScreenFocusableAction(
-      onActivate:
-          _isHistoryAutoMatching ? null : () => _onWatchHistoryItemTap(item),
-      child: SizedBox(
-        key: ValueKey(
-            'continue_${item.animeId ?? 0}_${item.filePath.hashCode}'), // 添加唯一key
-        width: compact ? 220 : 280, // 手机更窄
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            // 图片容器
-            Container(
-              height: compact ? 110 : 158, // 进一步减少手机端高度
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(4),
-              ),
-              clipBehavior: Clip.antiAlias,
-              child: _getVideoThumbnail(item),
+    final onTap =
+        _isHistoryAutoMatching ? null : () => _onWatchHistoryItemTap(item);
+    final card = SizedBox(
+      key: ValueKey(
+          'continue_${item.animeId ?? 0}_${item.filePath.hashCode}'), // 添加唯一key
+      width: compact ? 220 : 280, // 手机更窄
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // 图片容器
+          Container(
+            height: compact ? 110 : 158, // 进一步减少手机端高度
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(4),
             ),
+            clipBehavior: Clip.antiAlias,
+            child: _getVideoThumbnail(item),
+          ),
 
-            const SizedBox(height: 8),
+          const SizedBox(height: 8),
 
-            // 媒体名称
-            Text(
-              item.animeName.isNotEmpty
-                  ? item.animeName
-                  : path.basename(item.filePath),
-              style: TextStyle(
-                color: Theme.of(context).brightness == Brightness.dark
-                    ? Colors.white
-                    : Colors.black,
-                fontSize: 16, // 增加字体大小
-                fontWeight: FontWeight.bold,
-              ),
-              maxLines: 2, // 增加显示行数
-              overflow: TextOverflow.ellipsis,
+          // 媒体名称
+          Text(
+            item.animeName.isNotEmpty
+                ? item.animeName
+                : path.basename(item.filePath),
+            style: TextStyle(
+              color: Theme.of(context).brightness == Brightness.dark
+                  ? Colors.white
+                  : Colors.black,
+              fontSize: 16, // 增加字体大小
+              fontWeight: FontWeight.bold,
             ),
+            maxLines: 2, // 增加显示行数
+            overflow: TextOverflow.ellipsis,
+          ),
 
-            const SizedBox(height: 4),
+          const SizedBox(height: 4),
 
-            // 进度和集数信息
-            Text(
-              "${(item.watchProgress * 100).toInt()}%${item.episodeTitle != null ? ' · ${item.episodeTitle}' : ''}",
-              style: TextStyle(
-                color: Theme.of(context).brightness == Brightness.dark
-                    ? Colors.white70
-                    : Colors.black87,
-                fontSize: 14, // 增加字体大小
-              ),
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
+          // 进度和集数信息
+          Text(
+            "${(item.watchProgress * 100).toInt()}%${item.episodeTitle != null ? ' · ${item.episodeTitle}' : ''}",
+            style: TextStyle(
+              color: Theme.of(context).brightness == Brightness.dark
+                  ? Colors.white70
+                  : Colors.black87,
+              fontSize: 14, // 增加字体大小
             ),
-          ],
-        ),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ],
       ),
     );
+    if (!_isLargeScreenModeActive) {
+      return GestureDetector(
+        onTap: onTap,
+        behavior: HitTestBehavior.opaque,
+        child: card,
+      );
+    }
+    return _wrapLargeScreenFocusable(child: card, onActivate: onTap);
   }
 
   void _showWatchHistoryDialog() {
@@ -319,19 +325,20 @@ extension DashboardHomePageSectionsBuild on _DashboardHomePageState {
   }
 
   Widget _buildWatchHistoryButton() {
+    final button = _HoverScaleButton(
+      onTap: _isLargeScreenModeActive ? null : _showWatchHistoryDialog,
+      child: Icon(
+        Icons.history_rounded,
+        size: 24,
+      ),
+    );
     return Tooltip(
       message: '观看记录',
-      child: NipaplayLargeScreenFocusableAction(
+      child: _wrapLargeScreenFocusable(
+        child: button,
         onActivate: _showWatchHistoryDialog,
         borderRadius: BorderRadius.circular(8),
         padding: const EdgeInsets.all(4),
-        child: const _HoverScaleButton(
-          onTap: null,
-          child: Icon(
-            Icons.history_rounded,
-            size: 24,
-          ),
-        ),
       ),
     );
   }
@@ -344,19 +351,21 @@ extension DashboardHomePageSectionsBuild on _DashboardHomePageState {
   }
 
   Widget _buildContinueWatchingRefreshButton() {
+    final button = _HoverScaleButton(
+      onTap:
+          _isLargeScreenModeActive ? null : _onContinueWatchingRefreshPressed,
+      child: Icon(
+        Icons.refresh_rounded,
+        size: 24,
+      ),
+    );
     return Tooltip(
       message: '刷新继续播放',
-      child: NipaplayLargeScreenFocusableAction(
+      child: _wrapLargeScreenFocusable(
+        child: button,
         onActivate: _onContinueWatchingRefreshPressed,
         borderRadius: BorderRadius.circular(8),
         padding: const EdgeInsets.all(4),
-        child: const _HoverScaleButton(
-          onTap: null,
-          child: Icon(
-            Icons.refresh_rounded,
-            size: 24,
-          ),
-        ),
       ),
     );
   }
@@ -623,23 +632,28 @@ extension DashboardHomePageSectionsBuild on _DashboardHomePageState {
         : HorizontalAnimeCard.compactCardHeight;
 
     Widget buildCard(String? summary, {String? progress}) {
-      return NipaplayLargeScreenFocusableAction(
-        onActivate: () => onItemTap(item),
-        borderRadius: BorderRadius.circular(4),
-        child: SizedBox(
-          width: cardWidth,
-          height: cardHeight,
-          child: HorizontalAnimeCard(
-            key: ValueKey(uniqueId),
-            title: name,
-            imageUrl: imageUrl,
-            onTap: () => onItemTap(item),
-            source: sourceLabel,
-            rating: rating,
-            summary: summary,
-            progress: progress ?? _getWatchProgressForDashboard(item),
-          ),
+      final onTap = () => onItemTap(item);
+      final card = SizedBox(
+        width: cardWidth,
+        height: cardHeight,
+        child: HorizontalAnimeCard(
+          key: ValueKey(uniqueId),
+          title: name,
+          imageUrl: imageUrl,
+          onTap: onTap,
+          source: sourceLabel,
+          rating: rating,
+          summary: summary,
+          progress: progress ?? _getWatchProgressForDashboard(item),
         ),
+      );
+      if (!_isLargeScreenModeActive) {
+        return card;
+      }
+      return _wrapLargeScreenFocusable(
+        child: card,
+        onActivate: onTap,
+        borderRadius: BorderRadius.circular(4),
       );
     }
 

--- a/lib/themes/nipaplay/widgets/dashboard_home_page_image_helpers.dart
+++ b/lib/themes/nipaplay/widgets/dashboard_home_page_image_helpers.dart
@@ -1,7 +1,8 @@
 part of dashboard_home_page;
 
 extension DashboardHomePageImageHelpers on _DashboardHomePageState {
-  Future<String?> _getHighQualityImage(int animeId, BangumiAnime animeDetail) async {
+  Future<String?> _getHighQualityImage(
+      int animeId, BangumiAnime animeDetail) async {
     try {
       // 优先尝试本地缓存中的 bangumiId/bangumiUrl，避免再请求弹弹play
       try {
@@ -14,13 +15,17 @@ extension DashboardHomePageImageHelpers on _DashboardHomePageState {
           final bangumi = data['bangumi'] as Map<String, dynamic>?;
           String? cachedBangumiId;
           // 1) 直接字段
-          if (bangumi != null && bangumi['bangumiId'] != null && bangumi['bangumiId'].toString().isNotEmpty) {
+          if (bangumi != null &&
+              bangumi['bangumiId'] != null &&
+              bangumi['bangumiId'].toString().isNotEmpty) {
             cachedBangumiId = bangumi['bangumiId'].toString();
           }
           // 2) 从 bangumiUrl 解析
           if (cachedBangumiId == null) {
-            final String? bangumiUrl = (bangumi?['bangumiUrl'] as String?) ?? (animeData?['bangumiUrl'] as String?);
-            if (bangumiUrl != null && bangumiUrl.contains('bangumi.tv/subject/')) {
+            final String? bangumiUrl = (bangumi?['bangumiUrl'] as String?) ??
+                (animeData?['bangumiUrl'] as String?);
+            if (bangumiUrl != null &&
+                bangumiUrl.contains('bangumi.tv/subject/')) {
               final RegExp regex = RegExp(r'bangumi\.tv/subject/(\d+)');
               final match = regex.firstMatch(bangumiUrl);
               if (match != null) {
@@ -29,7 +34,8 @@ extension DashboardHomePageImageHelpers on _DashboardHomePageState {
             }
           }
           if (cachedBangumiId != null && cachedBangumiId.isNotEmpty) {
-            final bangumiImageUrl = await _getBangumiHighQualityImage(cachedBangumiId);
+            final bangumiImageUrl =
+                await _getBangumiHighQualityImage(cachedBangumiId);
             if (bangumiImageUrl != null && bangumiImageUrl.isNotEmpty) {
               return bangumiImageUrl;
             }
@@ -39,7 +45,7 @@ extension DashboardHomePageImageHelpers on _DashboardHomePageState {
 
       // 首先尝试从弹弹play获取bangumi ID
       String? bangumiId = await _getBangumiIdFromDandanplay(animeId);
-      
+
       if (bangumiId != null && bangumiId.isNotEmpty) {
         // 如果获取到bangumi ID，尝试从Bangumi API获取高清图片
         final bangumiImageUrl = await _getBangumiHighQualityImage(bangumiId);
@@ -47,28 +53,29 @@ extension DashboardHomePageImageHelpers on _DashboardHomePageState {
           return bangumiImageUrl;
         }
       }
-      
+
       // 如果Bangumi API失败，回退到弹弹play的图片
       if (animeDetail.imageUrl.isNotEmpty) {
         return animeDetail.imageUrl;
       }
-      
+
       return null;
     } catch (_) {
       // 出错时回退到弹弹play的图片
       return animeDetail.imageUrl;
     }
   }
-  
+
   // 从弹弹play API获取bangumi ID
   Future<String?> _getBangumiIdFromDandanplay(int animeId) async {
     try {
       // 使用弹弹play的番剧详情API获取bangumi ID
-      final Map<String, dynamic> result = await DandanplayService.getBangumiDetails(animeId);
-      
+      final Map<String, dynamic> result =
+          await DandanplayService.getBangumiDetails(animeId);
+
       if (result['success'] == true && result['bangumi'] != null) {
         final bangumi = result['bangumi'] as Map<String, dynamic>;
-        
+
         // 检查是否有bangumiUrl，从中提取ID
         final String? bangumiUrl = bangumi['bangumiUrl'] as String?;
         if (bangumiUrl != null && bangumiUrl.contains('bangumi.tv/subject/')) {
@@ -80,7 +87,7 @@ extension DashboardHomePageImageHelpers on _DashboardHomePageState {
             return bangumiId;
           }
         }
-        
+
         // 也检查是否直接有bangumiId字段
         final dynamic directBangumiId = bangumi['bangumiId'];
         if (directBangumiId != null) {
@@ -90,28 +97,28 @@ extension DashboardHomePageImageHelpers on _DashboardHomePageState {
           }
         }
       }
-      
+
       return null;
     } catch (_) {
       return null;
     }
   }
-  
+
   // 从Bangumi API获取高清图片
   Future<String?> _getBangumiHighQualityImage(String bangumiId) async {
     try {
       // 使用Bangumi API的图片接口获取large尺寸的图片
       // GET /v0/subjects/{subject_id}/image?type=large
-      final String imageApiUrl = 'https://api.bgm.tv/v0/subjects/$bangumiId/image?type=large';
-      
-      
+      final String imageApiUrl =
+          'https://api.bgm.tv/v0/subjects/$bangumiId/image?type=large';
+
       final response = await http.head(
         WebRemoteAccessService.proxyUri(Uri.parse(imageApiUrl)),
         headers: {
           'User-Agent': 'NipaPlay/1.0',
         },
       ).timeout(const Duration(seconds: 5));
-      
+
       if (response.statusCode == 302) {
         // Bangumi API返回302重定向到实际图片URL
         final String? location = response.headers['location'];
@@ -122,7 +129,7 @@ extension DashboardHomePageImageHelpers on _DashboardHomePageState {
         // 有些情况下可能直接返回200
         return imageApiUrl;
       }
-      
+
       return null;
     } catch (_) {
       return null;
@@ -135,51 +142,57 @@ extension DashboardHomePageImageHelpers on _DashboardHomePageState {
     List<RecommendedItem> currentItems,
     List<int> indices,
   ) async {
-    
     if (candidates.isEmpty || currentItems.isEmpty || indices.isEmpty) {
       return;
     }
-    
+
     // 为每个候选项目升级图片
     final upgradeFutures = <Future<void>>[];
-    
-    for (int i = 0; i < candidates.length && i < currentItems.length && i < indices.length; i++) {
+
+    for (int i = 0;
+        i < candidates.length && i < currentItems.length && i < indices.length;
+        i++) {
       final candidate = candidates[i];
       final currentItem = currentItems[i];
       final targetIndex = indices[i];
-      upgradeFutures.add(_upgradeItemToHighQuality(candidate, currentItem, targetIndex));
+      upgradeFutures
+          .add(_upgradeItemToHighQuality(candidate, currentItem, targetIndex));
     }
-    
+
     // 异步处理所有升级，不阻塞UI
     unawaited(Future.wait(upgradeFutures, eagerError: false));
   }
-  
+
   // 升级单个项目为高清图片
-  Future<void> _upgradeItemToHighQuality(dynamic candidate, RecommendedItem currentItem, int index) async {
+  Future<void> _upgradeItemToHighQuality(
+      dynamic candidate, RecommendedItem currentItem, int index) async {
     try {
       RecommendedItem? upgradedItem;
-      
+
       if (candidate is JellyfinMediaItem) {
         // Jellyfin项目 - 获取高清图片和详细信息
         final jellyfinService = JellyfinService.instance;
-        
+
         // 并行获取背景图片、Logo图片和详细信息
         final results = await Future.wait([
-          _tryGetJellyfinImage(jellyfinService, candidate.id, ['Backdrop', 'Primary', 'Art', 'Banner']),
-          _tryGetJellyfinImage(jellyfinService, candidate.id, ['Logo', 'Thumb']),
+          _tryGetJellyfinImage(jellyfinService, candidate.id,
+              ['Backdrop', 'Primary', 'Art', 'Banner']),
+          _tryGetJellyfinImage(
+              jellyfinService, candidate.id, ['Logo', 'Thumb']),
           _getJellyfinItemSubtitle(jellyfinService, candidate),
         ]);
-        
+
         final backdropCandidate = results[0] as MapEntry<String, String>?;
         final logoCandidate = results[1] as MapEntry<String, String>?;
         final subtitle = results[2] as String?;
         final backdropUrl = backdropCandidate?.value;
         final logoUrl = logoCandidate?.value;
-        final normalizedBackdropUrl = _normalizeRecommendationImageUrl(backdropUrl);
+        final normalizedBackdropUrl =
+            _normalizeRecommendationImageUrl(backdropUrl);
         final normalizedLogoUrl = _normalizeRecommendationImageUrl(logoUrl);
-        
+
         // 如果获取到了更好的图片或信息，创建升级版本
-        if (normalizedBackdropUrl != currentItem.backgroundImageUrl || 
+        if (normalizedBackdropUrl != currentItem.backgroundImageUrl ||
             normalizedLogoUrl != currentItem.logoImageUrl ||
             subtitle != currentItem.subtitle) {
           upgradedItem = currentItem.copyWith(
@@ -188,31 +201,33 @@ extension DashboardHomePageImageHelpers on _DashboardHomePageState {
             logoImageUrl: normalizedLogoUrl,
             isLowRes: normalizedBackdropUrl == null
                 ? currentItem.isLowRes
-                : _shouldBlurLowResCover(imageType: backdropCandidate?.key, imageUrl: backdropUrl),
+                : _shouldBlurLowResCover(
+                    imageType: backdropCandidate?.key, imageUrl: backdropUrl),
           );
         }
-        
       } else if (candidate is EmbyMediaItem) {
         // Emby项目 - 获取高清图片和详细信息
         final embyService = EmbyService.instance;
-        
+
         // 并行获取背景图片、Logo图片和详细信息
         final results = await Future.wait([
-          _tryGetEmbyImage(embyService, candidate.id, ['Backdrop', 'Primary', 'Art', 'Banner']),
+          _tryGetEmbyImage(embyService, candidate.id,
+              ['Backdrop', 'Primary', 'Art', 'Banner']),
           _tryGetEmbyImage(embyService, candidate.id, ['Logo', 'Thumb']),
           _getEmbyItemSubtitle(embyService, candidate),
         ]);
-        
+
         final backdropCandidate = results[0] as MapEntry<String, String>?;
         final logoCandidate = results[1] as MapEntry<String, String>?;
         final subtitle = results[2] as String?;
         final backdropUrl = backdropCandidate?.value;
         final logoUrl = logoCandidate?.value;
-        final normalizedBackdropUrl = _normalizeRecommendationImageUrl(backdropUrl);
+        final normalizedBackdropUrl =
+            _normalizeRecommendationImageUrl(backdropUrl);
         final normalizedLogoUrl = _normalizeRecommendationImageUrl(logoUrl);
-        
+
         // 如果获取到了更好的图片或信息，创建升级版本
-        if (normalizedBackdropUrl != currentItem.backgroundImageUrl || 
+        if (normalizedBackdropUrl != currentItem.backgroundImageUrl ||
             normalizedLogoUrl != currentItem.logoImageUrl ||
             subtitle != currentItem.subtitle) {
           upgradedItem = currentItem.copyWith(
@@ -221,15 +236,15 @@ extension DashboardHomePageImageHelpers on _DashboardHomePageState {
             logoImageUrl: normalizedLogoUrl,
             isLowRes: normalizedBackdropUrl == null
                 ? currentItem.isLowRes
-                : _shouldBlurLowResCover(imageType: backdropCandidate?.key, imageUrl: backdropUrl),
+                : _shouldBlurLowResCover(
+                    imageType: backdropCandidate?.key, imageUrl: backdropUrl),
           );
         }
-        
       } else if (candidate is WatchHistoryItem) {
         // 本地媒体库项目 - 获取高清图片和详细信息
         String? highQualityImageUrl;
         String? detailedSubtitle;
-        
+
         if (_isValidAnimeId(candidate.animeId)) {
           final animeId = candidate.animeId!;
           try {
@@ -238,7 +253,9 @@ extension DashboardHomePageImageHelpers on _DashboardHomePageState {
             final persisted = prefs.getString(
                 '${_DashboardHomePageState._localPrefsKeyPrefix}$animeId');
 
-            final persistedLooksHQ = persisted != null && persisted.isNotEmpty && _looksHighQualityUrl(persisted);
+            final persistedLooksHQ = persisted != null &&
+                persisted.isNotEmpty &&
+                _looksHighQualityUrl(persisted);
 
             if (persistedLooksHQ) {
               highQualityImageUrl = persisted;
@@ -254,14 +271,17 @@ extension DashboardHomePageImageHelpers on _DashboardHomePageState {
                       .replaceAll('<br />', ' ')
                       .replaceAll('```', '')
                   : null;
-              
+
               // 获取高清图片
               debugPrint('[Bangumi] 拉取高清封面(本地): animeId=$animeId');
-              highQualityImageUrl = await _getHighQualityImage(animeId, animeDetail);
-              debugPrint('[Bangumi] 高清封面结果(本地): animeId=$animeId url=$highQualityImageUrl');
+              highQualityImageUrl =
+                  await _getHighQualityImage(animeId, animeDetail);
+              debugPrint(
+                  '[Bangumi] 高清封面结果(本地): animeId=$animeId url=$highQualityImageUrl');
 
               // 将获取到的高清图持久化，避免后续重复请求
-              if (highQualityImageUrl != null && highQualityImageUrl.isNotEmpty) {
+              if (highQualityImageUrl != null &&
+                  highQualityImageUrl.isNotEmpty) {
                 _localImageCache[animeId] = highQualityImageUrl;
                 try {
                   await prefs.setString(
@@ -273,10 +293,9 @@ extension DashboardHomePageImageHelpers on _DashboardHomePageState {
                 highQualityImageUrl = persisted;
               }
             }
-          } catch (_) {
-          }
+          } catch (_) {}
         }
-        
+
         // 如果获取到了更好的图片或信息，创建升级版本
         final normalizedHighQualityUrl =
             _normalizeRecommendationImageUrl(highQualityImageUrl);
@@ -285,9 +304,10 @@ extension DashboardHomePageImageHelpers on _DashboardHomePageState {
           upgradedItem = currentItem.copyWith(
             subtitle: detailedSubtitle,
             backgroundImageUrl: normalizedHighQualityUrl,
-            isLowRes: normalizedHighQualityUrl != null && highQualityImageUrl != null
-                ? !_looksHighQualityUrl(highQualityImageUrl)
-                : currentItem.isLowRes,
+            isLowRes:
+                normalizedHighQualityUrl != null && highQualityImageUrl != null
+                    ? !_looksHighQualityUrl(highQualityImageUrl)
+                    : currentItem.isLowRes,
           );
         }
       } else if (candidate is DandanplayRemoteAnimeGroup) {
@@ -295,13 +315,16 @@ extension DashboardHomePageImageHelpers on _DashboardHomePageState {
         if (_isValidAnimeId(candidate.animeId)) {
           final animeId = candidate.animeId!;
           try {
-            debugPrint('[Dandan封面] 尝试升级: animeId=$animeId current=${currentItem.backgroundImageUrl}');
+            debugPrint(
+                '[Dandan封面] 尝试升级: animeId=$animeId current=${currentItem.backgroundImageUrl}');
             final prefs = await SharedPreferences.getInstance();
             final persisted = prefs.getString(
                 '${_DashboardHomePageState._localPrefsKeyPrefix}$animeId');
-            
+
             String? hqUrl;
-            if (persisted != null && persisted.isNotEmpty && _looksHighQualityUrl(persisted)) {
+            if (persisted != null &&
+                persisted.isNotEmpty &&
+                _looksHighQualityUrl(persisted)) {
               debugPrint('[Dandan封面] 命中持久化高清: animeId=$animeId url=$persisted');
               hqUrl = persisted;
             } else {
@@ -310,9 +333,10 @@ extension DashboardHomePageImageHelpers on _DashboardHomePageState {
               final detail = await bangumiService.getAnimeDetails(animeId);
               debugPrint('[Bangumi] 拉取高清封面(弹弹play): animeId=$animeId');
               hqUrl = await _getHighQualityImage(animeId, detail);
-              debugPrint('[Bangumi] 高清封面结果(弹弹play): animeId=$animeId url=$hqUrl');
+              debugPrint(
+                  '[Bangumi] 高清封面结果(弹弹play): animeId=$animeId url=$hqUrl');
               debugPrint('[Dandan封面] Bangumi高清结果: animeId=$animeId url=$hqUrl');
-              
+
               if (hqUrl != null && hqUrl.isNotEmpty) {
                 try {
                   await prefs.setString(
@@ -321,23 +345,25 @@ extension DashboardHomePageImageHelpers on _DashboardHomePageState {
                 } catch (_) {}
               }
             }
-            
+
             final normalizedHqUrl = _normalizeRecommendationImageUrl(hqUrl);
             if (normalizedHqUrl != null &&
                 normalizedHqUrl != currentItem.backgroundImageUrl) {
-              debugPrint('[Dandan封面] 升级生效: animeId=$animeId url=$normalizedHqUrl');
+              debugPrint(
+                  '[Dandan封面] 升级生效: animeId=$animeId url=$normalizedHqUrl');
               upgradedItem = currentItem.copyWith(
                 backgroundImageUrl: normalizedHqUrl,
-                isLowRes: hqUrl != null ? !_looksHighQualityUrl(hqUrl) : currentItem.isLowRes,
+                isLowRes: hqUrl != null
+                    ? !_looksHighQualityUrl(hqUrl)
+                    : currentItem.isLowRes,
               );
             } else {
               debugPrint('[Dandan封面] 无需升级: animeId=$animeId');
             }
-          } catch (_) {
-          }
+          } catch (_) {}
         }
       }
-      
+
       // 如果有升级版本，更新UI
       if (upgradedItem != null && mounted) {
         setState(() {
@@ -345,13 +371,10 @@ extension DashboardHomePageImageHelpers on _DashboardHomePageState {
             _recommendedItems[index] = upgradedItem!;
           }
         });
-        
+
         // CachedNetworkImageWidget 会自动处理图片预加载和缓存
-        
       }
-      
-    } catch (_) {
-    }
+    } catch (_) {}
   }
 
   // 经验性判断一个图片URL是否"看起来"是高清图
@@ -360,7 +383,9 @@ extension DashboardHomePageImageHelpers on _DashboardHomePageState {
     if (lower.contains('/api/v1/image/')) {
       return false;
     }
-    if (lower.contains('bgm.tv') || lower.contains('type=large') || lower.contains('original')) {
+    if (lower.contains('bgm.tv') ||
+        lower.contains('type=large') ||
+        lower.contains('original')) {
       return true;
     }
     if (lower.contains('medium') || lower.contains('small')) {
@@ -398,13 +423,16 @@ extension DashboardHomePageImageHelpers on _DashboardHomePageState {
     if (lower.contains('/api/v1/image/')) {
       return false;
     }
-    if (lower.contains('bgm.tv') || lower.contains('type=large') || lower.contains('original')) {
+    if (lower.contains('bgm.tv') ||
+        lower.contains('type=large') ||
+        lower.contains('original')) {
       return true;
     }
     if (lower.contains('medium') || lower.contains('small')) {
       return false;
     }
-    final widthMatch = RegExp(r'[?&](?:width|maxwidth)=(\d+)').firstMatch(lower);
+    final widthMatch =
+        RegExp(r'[?&](?:width|maxwidth)=(\d+)').firstMatch(lower);
     if (widthMatch != null) {
       final w = int.tryParse(widthMatch.group(1)!);
       if (w != null && w >= 1000) return true;
@@ -423,13 +451,13 @@ extension DashboardHomePageImageHelpers on _DashboardHomePageState {
     for (final imageType in imageTypes) {
       try {
         final url = imageType == 'Backdrop'
-            ? service.getImageUrl(itemId, type: imageType, width: 1920, height: 1080, quality: 95)
+            ? service.getImageUrl(itemId,
+                type: imageType, width: 1920, height: 1080, quality: 95)
             : service.getImageUrl(itemId, type: imageType);
         if (url.isNotEmpty) {
           candidates.add(MapEntry(imageType, url));
         }
-      } catch (_) {
-      }
+      } catch (_) {}
     }
 
     if (candidates.isEmpty) {
@@ -461,13 +489,13 @@ extension DashboardHomePageImageHelpers on _DashboardHomePageState {
     for (final imageType in imageTypes) {
       try {
         final url = imageType == 'Backdrop'
-            ? service.getImageUrl(itemId, type: imageType, width: 1920, height: 1080, quality: 95)
+            ? service.getImageUrl(itemId,
+                type: imageType, width: 1920, height: 1080, quality: 95)
             : service.getImageUrl(itemId, type: imageType);
         if (url.isNotEmpty) {
           candidates.add(MapEntry(imageType, url));
         }
-      } catch (_) {
-      }
+      } catch (_) {}
     }
 
     if (candidates.isEmpty) {
@@ -496,13 +524,15 @@ extension DashboardHomePageImageHelpers on _DashboardHomePageState {
       final response = await http
           .head(WebRemoteAccessService.proxyUri(Uri.parse(url)))
           .timeout(
-        const Duration(seconds: 2),
-        onTimeout: () => throw TimeoutException('图片验证超时', const Duration(seconds: 2)),
-      );
+            const Duration(seconds: 2),
+            onTimeout: () =>
+                throw TimeoutException('图片验证超时', const Duration(seconds: 2)),
+          );
 
       if (response.statusCode != 200) return false;
       final contentType = response.headers['content-type'];
-      if (contentType == null || !contentType.startsWith('image/')) return false;
+      if (contentType == null || !contentType.startsWith('image/'))
+        return false;
 
       final contentLength = response.headers['content-length'];
       if (contentLength != null) {
@@ -516,46 +546,55 @@ extension DashboardHomePageImageHelpers on _DashboardHomePageState {
   }
 
   // 辅助方法：获取Jellyfin项目简介
-  Future<String> _getJellyfinItemSubtitle(JellyfinService service, JellyfinMediaItem item) async {
+  Future<String> _getJellyfinItemSubtitle(
+      JellyfinService service, JellyfinMediaItem item) async {
     try {
       final detail = await service.getMediaItemDetails(item.id);
-      return detail.overview?.isNotEmpty == true ? detail.overview!
-          .replaceAll('<br>', ' ')
-          .replaceAll('<br/>', ' ')
-          .replaceAll('<br />', ' ') : '暂无简介信息';
+      return detail.overview?.isNotEmpty == true
+          ? detail.overview!
+              .replaceAll('<br>', ' ')
+              .replaceAll('<br/>', ' ')
+              .replaceAll('<br />', ' ')
+          : '暂无简介信息';
     } catch (_) {
-      return item.overview?.isNotEmpty == true ? item.overview!
-          .replaceAll('<br>', ' ')
-          .replaceAll('<br/>', ' ')
-          .replaceAll('<br />', ' ') : '暂无简介信息';
+      return item.overview?.isNotEmpty == true
+          ? item.overview!
+              .replaceAll('<br>', ' ')
+              .replaceAll('<br/>', ' ')
+              .replaceAll('<br />', ' ')
+          : '暂无简介信息';
     }
   }
 
   // 辅助方法：获取Emby项目简介
-  Future<String> _getEmbyItemSubtitle(EmbyService service, EmbyMediaItem item) async {
+  Future<String> _getEmbyItemSubtitle(
+      EmbyService service, EmbyMediaItem item) async {
     try {
       final detail = await service.getMediaItemDetails(item.id);
-      return detail.overview?.isNotEmpty == true ? detail.overview!
-          .replaceAll('<br>', ' ')
-          .replaceAll('<br/>', ' ')
-          .replaceAll('<br />', ' ') : '暂无简介信息';
+      return detail.overview?.isNotEmpty == true
+          ? detail.overview!
+              .replaceAll('<br>', ' ')
+              .replaceAll('<br/>', ' ')
+              .replaceAll('<br />', ' ')
+          : '暂无简介信息';
     } catch (_) {
-      return item.overview?.isNotEmpty == true ? item.overview!
-          .replaceAll('<br>', ' ')
-          .replaceAll('<br/>', ' ')
-          .replaceAll('<br />', ' ') : '暂无简介信息';
+      return item.overview?.isNotEmpty == true
+          ? item.overview!
+              .replaceAll('<br>', ' ')
+              .replaceAll('<br/>', ' ')
+              .replaceAll('<br />', ' ')
+          : '暂无简介信息';
     }
   }
 
-
-  
   // 构建滚动按钮
   Widget _buildScrollButtons(ScrollController controller, double itemWidth) {
     return AnimatedBuilder(
       animation: controller,
       builder: (context, child) {
         // 如果没有绑定或内容不足以滚动，直接不显示整个区域
-        if (!controller.hasClients || controller.position.maxScrollExtent <= 0) {
+        if (!controller.hasClients ||
+            controller.position.maxScrollExtent <= 0) {
           return const SizedBox.shrink();
         }
 
@@ -596,7 +635,7 @@ extension DashboardHomePageImageHelpers on _DashboardHomePageState {
       },
     );
   }
-  
+
   // 构建单个滚动按钮
   Widget _buildScrollButton({
     required IconData icon,
@@ -606,46 +645,52 @@ extension DashboardHomePageImageHelpers on _DashboardHomePageState {
   }) {
     return Tooltip(
       message: message,
-      child: _HoverScaleButton(
-        enabled: enabled,
-        onTap: onTap,
-        child: Icon(
-          icon,
-          size: 24, // 与标题字体大小一致
+      child: NipaplayLargeScreenFocusableAction(
+        onActivate: enabled ? onTap : null,
+        borderRadius: BorderRadius.circular(8),
+        padding: const EdgeInsets.all(4),
+        child: _HoverScaleButton(
+          enabled: enabled,
+          onTap: onTap,
+          child: Icon(
+            icon,
+            size: 24, // 与标题字体大小一致
+          ),
         ),
       ),
     );
   }
-  
+
   // 滚动到上一页
   void _scrollToPrevious(ScrollController controller, double itemWidth) {
     final screenWidth = MediaQuery.of(context).size.width;
     final visibleWidth = screenWidth - 32; // 减去左右边距
     final itemsPerPage = (visibleWidth / itemWidth).floor();
     final scrollDistance = itemsPerPage * itemWidth;
-    
+
     final targetOffset = math.max(0.0, controller.offset - scrollDistance);
-    
+
     controller.animateTo(
       targetOffset,
       duration: const Duration(milliseconds: 300),
       curve: Curves.easeInOut,
     );
   }
-  
+
   // 滚动到下一页
   void _scrollToNext(ScrollController controller, double itemWidth) {
     final screenWidth = MediaQuery.of(context).size.width;
     final visibleWidth = screenWidth - 32; // 减去左右边距
     final itemsPerPage = (visibleWidth / itemWidth).floor();
     final scrollDistance = itemsPerPage * itemWidth;
-    
+
     final targetOffset = controller.offset + scrollDistance;
     final maxScrollExtent = controller.position.maxScrollExtent;
-    
+
     // 如果目标位置超过了最大滚动范围，就滚动到最大位置
-    final finalTargetOffset = targetOffset > maxScrollExtent ? maxScrollExtent : targetOffset;
-    
+    final finalTargetOffset =
+        targetOffset > maxScrollExtent ? maxScrollExtent : targetOffset;
+
     controller.animateTo(
       finalTargetOffset,
       duration: const Duration(milliseconds: 300),

--- a/lib/themes/nipaplay/widgets/dashboard_home_page_image_helpers.dart
+++ b/lib/themes/nipaplay/widgets/dashboard_home_page_image_helpers.dart
@@ -643,20 +643,22 @@ extension DashboardHomePageImageHelpers on _DashboardHomePageState {
     required String message,
     bool enabled = true,
   }) {
+    final resolvedOnTap = enabled ? onTap : null;
+    final button = _HoverScaleButton(
+      enabled: enabled,
+      onTap: _isLargeScreenModeActive ? null : resolvedOnTap,
+      child: Icon(
+        icon,
+        size: 24, // 与标题字体大小一致
+      ),
+    );
     return Tooltip(
       message: message,
-      child: NipaplayLargeScreenFocusableAction(
-        onActivate: enabled ? onTap : null,
+      child: _wrapLargeScreenFocusable(
+        child: button,
+        onActivate: resolvedOnTap,
         borderRadius: BorderRadius.circular(8),
         padding: const EdgeInsets.all(4),
-        child: _HoverScaleButton(
-          enabled: enabled,
-          onTap: onTap,
-          child: Icon(
-            icon,
-            size: 24, // 与标题字体大小一致
-          ),
-        ),
       ),
     );
   }

--- a/lib/themes/nipaplay/widgets/dashboard_home_page_random_recommendations.dart
+++ b/lib/themes/nipaplay/widgets/dashboard_home_page_random_recommendations.dart
@@ -71,7 +71,8 @@ extension DashboardHomePageRandomRecommendations on _DashboardHomePageState {
         final batch = tags.sublist(start, math.min(start + 5, tags.length));
         final futures = batch.map((tag) async {
           try {
-            final result = await SearchService.instance.searchAnimeByTags([tag]);
+            final result =
+                await SearchService.instance.searchAnimeByTags([tag]);
             return _RandomTagSearchResult(tag, result.animes);
           } catch (e) {
             debugPrint('随机推荐标签搜索失败: $tag, error: $e');
@@ -107,7 +108,8 @@ extension DashboardHomePageRandomRecommendations on _DashboardHomePageState {
 
           if (selected != null) {
             usedAnimeIds.add(selected.animeId);
-            items.add(RandomRecommendationItem(tag: entry.tag, anime: selected));
+            items
+                .add(RandomRecommendationItem(tag: entry.tag, anime: selected));
           }
 
           if (items.length >= 5) break;
@@ -172,9 +174,10 @@ extension DashboardHomePageRandomRecommendations on _DashboardHomePageState {
         ),
         const SizedBox(height: 16),
         SizedBox(
-          height: context.watch<AppearanceSettingsProvider>().showAnimeCardSummary
-              ? HorizontalAnimeCard.detailedListHeight
-              : HorizontalAnimeCard.compactListHeight,
+          height:
+              context.watch<AppearanceSettingsProvider>().showAnimeCardSummary
+                  ? HorizontalAnimeCard.detailedListHeight
+                  : HorizontalAnimeCard.compactListHeight,
           child: ListView.builder(
             controller: scrollController,
             scrollDirection: Axis.horizontal,
@@ -215,14 +218,18 @@ extension DashboardHomePageRandomRecommendations on _DashboardHomePageState {
       height: showSummary
           ? HorizontalAnimeCard.detailedCardHeight
           : HorizontalAnimeCard.compactCardHeight,
-      child: HorizontalAnimeCard(
-        key: ValueKey('random_${anime.animeId}_${item.tag.hashCode}'),
-        title: anime.animeTitle,
-        imageUrl: anime.imageUrl ?? '',
-        onTap: () => ThemedAnimeDetail.show(context, anime.animeId),
-        source: sourceLabel,
-        rating: anime.rating > 0 ? anime.rating : null,
-        summary: summary,
+      child: NipaplayLargeScreenFocusableAction(
+        onActivate: () => ThemedAnimeDetail.show(context, anime.animeId),
+        borderRadius: BorderRadius.circular(4),
+        child: HorizontalAnimeCard(
+          key: ValueKey('random_${anime.animeId}_${item.tag.hashCode}'),
+          title: anime.animeTitle,
+          imageUrl: anime.imageUrl ?? '',
+          onTap: () => ThemedAnimeDetail.show(context, anime.animeId),
+          source: sourceLabel,
+          rating: anime.rating > 0 ? anime.rating : null,
+          summary: summary,
+        ),
       ),
     );
   }

--- a/lib/themes/nipaplay/widgets/dashboard_home_page_random_recommendations.dart
+++ b/lib/themes/nipaplay/widgets/dashboard_home_page_random_recommendations.dart
@@ -211,26 +211,31 @@ extension DashboardHomePageRandomRecommendations on _DashboardHomePageState {
     final showSummary =
         context.watch<AppearanceSettingsProvider>().showAnimeCardSummary;
 
-    return SizedBox(
+    final onTap = () => ThemedAnimeDetail.show(context, anime.animeId);
+    final card = SizedBox(
       width: showSummary
           ? HorizontalAnimeCard.detailedCardWidth
           : HorizontalAnimeCard.compactCardWidth,
       height: showSummary
           ? HorizontalAnimeCard.detailedCardHeight
           : HorizontalAnimeCard.compactCardHeight,
-      child: NipaplayLargeScreenFocusableAction(
-        onActivate: () => ThemedAnimeDetail.show(context, anime.animeId),
-        borderRadius: BorderRadius.circular(4),
-        child: HorizontalAnimeCard(
-          key: ValueKey('random_${anime.animeId}_${item.tag.hashCode}'),
-          title: anime.animeTitle,
-          imageUrl: anime.imageUrl ?? '',
-          onTap: () => ThemedAnimeDetail.show(context, anime.animeId),
-          source: sourceLabel,
-          rating: anime.rating > 0 ? anime.rating : null,
-          summary: summary,
-        ),
+      child: HorizontalAnimeCard(
+        key: ValueKey('random_${anime.animeId}_${item.tag.hashCode}'),
+        title: anime.animeTitle,
+        imageUrl: anime.imageUrl ?? '',
+        onTap: onTap,
+        source: sourceLabel,
+        rating: anime.rating > 0 ? anime.rating : null,
+        summary: summary,
       ),
+    );
+    if (!_isLargeScreenModeActive) {
+      return card;
+    }
+    return _wrapLargeScreenFocusable(
+      child: card,
+      onActivate: onTap,
+      borderRadius: BorderRadius.circular(4),
     );
   }
 

--- a/lib/themes/nipaplay/widgets/directional_focus_scope.dart
+++ b/lib/themes/nipaplay/widgets/directional_focus_scope.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class NipaplayDirectionalFocusScope extends StatelessWidget {
+  const NipaplayDirectionalFocusScope({
+    super.key,
+    required this.child,
+  });
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Shortcuts(
+      shortcuts: const <ShortcutActivator, Intent>{
+        SingleActivator(LogicalKeyboardKey.arrowUp):
+            DirectionalFocusIntent(TraversalDirection.up),
+        SingleActivator(LogicalKeyboardKey.arrowDown):
+            DirectionalFocusIntent(TraversalDirection.down),
+        SingleActivator(LogicalKeyboardKey.arrowLeft):
+            DirectionalFocusIntent(TraversalDirection.left),
+        SingleActivator(LogicalKeyboardKey.arrowRight):
+            DirectionalFocusIntent(TraversalDirection.right),
+      },
+      child: Actions(
+        actions: <Type, Action<Intent>>{
+          DirectionalFocusIntent: CallbackAction<DirectionalFocusIntent>(
+            onInvoke: (intent) {
+              final primaryFocus = FocusManager.instance.primaryFocus;
+              if (primaryFocus != null) {
+                primaryFocus.focusInDirection(intent.direction);
+              } else {
+                FocusScope.of(context).nextFocus();
+              }
+              return null;
+            },
+          ),
+        },
+        child: FocusTraversalGroup(
+          policy: ReadingOrderTraversalPolicy(),
+          child: FocusScope(
+            autofocus: true,
+            child: child,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/themes/nipaplay/widgets/directional_focus_scope.dart
+++ b/lib/themes/nipaplay/widgets/directional_focus_scope.dart
@@ -1,13 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+typedef NipaplayFocusBoundaryCallback = void Function(
+    TraversalDirection direction);
+
 class NipaplayDirectionalFocusScope extends StatelessWidget {
   const NipaplayDirectionalFocusScope({
     super.key,
     required this.child,
+    this.onBoundaryReached,
   });
 
   final Widget child;
+  final NipaplayFocusBoundaryCallback? onBoundaryReached;
 
   @override
   Widget build(BuildContext context) {
@@ -27,10 +32,16 @@ class NipaplayDirectionalFocusScope extends StatelessWidget {
           DirectionalFocusIntent: CallbackAction<DirectionalFocusIntent>(
             onInvoke: (intent) {
               final primaryFocus = FocusManager.instance.primaryFocus;
+              bool moved = false;
               if (primaryFocus != null) {
-                primaryFocus.focusInDirection(intent.direction);
+                moved = primaryFocus.focusInDirection(intent.direction);
               } else {
-                FocusScope.of(context).nextFocus();
+                moved = FocusScope.of(context).nextFocus();
+              }
+              if (!moved &&
+                  (intent.direction == TraversalDirection.up ||
+                      intent.direction == TraversalDirection.down)) {
+                onBoundaryReached?.call(intent.direction);
               }
               return null;
             },

--- a/lib/themes/nipaplay/widgets/large_screen_anime_detail_page.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_anime_detail_page.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
@@ -18,7 +19,6 @@ import 'package:nipaplay/themes/nipaplay/widgets/large_screen_home_scope.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/large_screen_input_controls.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/large_screen_top_status_overlay.dart';
 
-const double _kLargeScreenDetailPanelRadius = 14;
 const double _kLargeScreenEpisodeCardWidth = 250;
 const double _kLargeScreenEpisodeCardGap = 10;
 const double _kLargeScreenEpisodeRailHeight = 172;
@@ -135,6 +135,14 @@ class _NipaplayLargeScreenAnimeDetailPageState
       return max;
     }
     return value;
+  }
+
+  String _coverImageUrl(BangumiAnime anime) {
+    String imageUrl = widget.sharedSummary?.imageUrl ?? anime.imageUrl;
+    if (kIsWeb) {
+      imageUrl = WebRemoteAccessService.imageProxyUrl(imageUrl) ?? imageUrl;
+    }
+    return imageUrl;
   }
 
   String _plainSummary(String? raw) {
@@ -701,10 +709,7 @@ class _NipaplayLargeScreenAnimeDetailPageState
     final secondary = isDarkMode ? Colors.white70 : Colors.black54;
     final muted = isDarkMode ? Colors.white60 : Colors.black54;
 
-    String imageUrl = widget.sharedSummary?.imageUrl ?? anime.imageUrl;
-    if (kIsWeb) {
-      imageUrl = WebRemoteAccessService.imageProxyUrl(imageUrl) ?? imageUrl;
-    }
+    final imageUrl = _coverImageUrl(anime);
 
     final summary = _plainSummary(
       widget.sharedSummary?.summary?.isNotEmpty == true
@@ -1174,6 +1179,9 @@ class _NipaplayLargeScreenAnimeDetailPageState
     final Color dividerColor = isDark ? Colors.white12 : Colors.black12;
     final mediaPadding = MediaQuery.of(context).padding;
 
+    final anime = _anime;
+    final coverImageUrl = anime == null ? '' : _coverImageUrl(anime);
+
     final body = _isLoading
         ? const Center(child: CircularProgressIndicator())
         : (_error != null
@@ -1214,20 +1222,52 @@ class _NipaplayLargeScreenAnimeDetailPageState
               Positioned.fill(
                 child: Padding(
                   padding: EdgeInsets.fromLTRB(
-                    14,
+                    0,
                     kNipaplayLargeScreenBottomHintHeight,
-                    14,
+                    0,
                     kNipaplayLargeScreenBottomHintHeight + mediaPadding.bottom,
                   ),
                   child: Container(
                     decoration: BoxDecoration(
                       color: surfaceColor,
-                      borderRadius:
-                          BorderRadius.circular(_kLargeScreenDetailPanelRadius),
                       border: Border.all(color: dividerColor, width: 1),
                     ),
                     clipBehavior: Clip.antiAlias,
-                    child: body,
+                    child: Stack(
+                      children: [
+                        if (coverImageUrl.isNotEmpty)
+                          Positioned.fill(
+                            child: ImageFiltered(
+                              imageFilter:
+                                  ui.ImageFilter.blur(sigmaX: 40, sigmaY: 40),
+                              child: Opacity(
+                                opacity: isDark ? 0.25 : 0.35,
+                                child: CachedNetworkImageWidget(
+                                  imageUrl: coverImageUrl,
+                                  fit: BoxFit.cover,
+                                  shouldCompress: false,
+                                  loadMode: CachedImageLoadMode.hybrid,
+                                ),
+                              ),
+                            ),
+                          ),
+                        Positioned.fill(
+                          child: Container(
+                            decoration: BoxDecoration(
+                              gradient: LinearGradient(
+                                begin: Alignment.topCenter,
+                                end: Alignment.bottomCenter,
+                                colors: [
+                                  surfaceColor.withValues(alpha: 0.12),
+                                  surfaceColor.withValues(alpha: 0.42),
+                                ],
+                              ),
+                            ),
+                          ),
+                        ),
+                        Positioned.fill(child: body),
+                      ],
+                    ),
                   ),
                 ),
               ),

--- a/lib/themes/nipaplay/widgets/large_screen_anime_detail_page.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_anime_detail_page.dart
@@ -1286,6 +1286,7 @@ class _NipaplayLargeScreenAnimeDetailPageState
                 child: NipaplayLargeScreenBottomHintOverlay(
                   isDarkMode: isDark,
                   onToggleMenu: () => Navigator.of(context).maybePop(),
+                  menuLabel: '返回',
                 ),
               ),
             ],

--- a/lib/themes/nipaplay/widgets/large_screen_anime_detail_page.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_anime_detail_page.dart
@@ -1,0 +1,1257 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'package:nipaplay/models/bangumi_model.dart';
+import 'package:nipaplay/models/playable_item.dart';
+import 'package:nipaplay/models/shared_remote_library.dart';
+import 'package:nipaplay/models/watch_history_model.dart';
+import 'package:nipaplay/services/bangumi_service.dart';
+import 'package:nipaplay/services/dandanplay_service.dart';
+import 'package:nipaplay/services/playback_service.dart';
+import 'package:nipaplay/services/web_remote_access_service.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/cached_network_image_widget.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_bottom_hint_overlay.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_focusable_action.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_home_scope.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_input_controls.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_top_status_overlay.dart';
+
+const double _kLargeScreenDetailPanelRadius = 14;
+const double _kLargeScreenEpisodeCardWidth = 250;
+const double _kLargeScreenEpisodeCardGap = 10;
+const double _kLargeScreenEpisodeRailHeight = 172;
+
+class NipaplayLargeScreenAnimeDetailPage extends StatefulWidget {
+  const NipaplayLargeScreenAnimeDetailPage({
+    super.key,
+    required this.animeId,
+    this.sharedSummary,
+    this.sharedEpisodeLoader,
+    this.sharedEpisodeBuilder,
+    this.sharedSourceLabel,
+  });
+
+  final int animeId;
+  final SharedRemoteAnimeSummary? sharedSummary;
+  final Future<List<SharedRemoteEpisode>> Function()? sharedEpisodeLoader;
+  final PlayableItem Function(SharedRemoteEpisode episode)? sharedEpisodeBuilder;
+  final String? sharedSourceLabel;
+
+  @override
+  State<NipaplayLargeScreenAnimeDetailPage> createState() =>
+      _NipaplayLargeScreenAnimeDetailPageState();
+}
+
+class _NipaplayLargeScreenAnimeDetailPageState
+    extends State<NipaplayLargeScreenAnimeDetailPage> {
+  final FocusNode _inputFocusNode = FocusNode(
+    debugLabel: 'large_screen_anime_detail_input',
+  );
+  final FocusNode _closeFocusNode = FocusNode(
+    debugLabel: 'large_screen_anime_detail_close',
+  );
+  final FocusNode _favoriteFocusNode = FocusNode(
+    debugLabel: 'large_screen_anime_detail_favorite',
+  );
+  final FocusNode _sortFocusNode = FocusNode(
+    debugLabel: 'large_screen_anime_detail_sort',
+  );
+  final ScrollController _episodeScrollController = ScrollController();
+
+  List<FocusNode> _episodeFocusNodes = <FocusNode>[];
+
+  BangumiAnime? _anime;
+  bool _isLoading = true;
+  String? _error;
+
+  bool _isEpisodeListReversed = false;
+  bool _isEpisodeAreaActive = false;
+  int _selectedControlIndex = 0;
+  int _selectedEpisodeIndex = 0;
+
+  final Map<int, WatchHistoryItem?> _episodeHistoryMap =
+      <int, WatchHistoryItem?>{};
+  final Map<int, bool> _dandanplayWatchStatus = <int, bool>{};
+
+  final Map<int, SharedRemoteEpisode> _sharedEpisodeMap =
+      <int, SharedRemoteEpisode>{};
+  final Map<int, PlayableItem> _sharedPlayableMap = <int, PlayableItem>{};
+
+  bool _isLoadingSharedEpisodes = false;
+  String? _sharedEpisodesError;
+  bool _isFavorited = false;
+  bool _isTogglingFavorite = false;
+
+  @override
+  void initState() {
+    super.initState();
+    FocusManager.instance.addEarlyKeyEventHandler(_handleEarlyKeyEvent);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _inputFocusNode.requestFocus();
+    });
+    _loadPageData();
+  }
+
+  @override
+  void dispose() {
+    FocusManager.instance.removeEarlyKeyEventHandler(_handleEarlyKeyEvent);
+    _disposeEpisodeFocusNodes();
+    _episodeScrollController.dispose();
+    _inputFocusNode.dispose();
+    _closeFocusNode.dispose();
+    _favoriteFocusNode.dispose();
+    _sortFocusNode.dispose();
+    super.dispose();
+  }
+
+  List<EpisodeData> get _displayEpisodes {
+    final episodes = _anime?.episodeList ?? const <EpisodeData>[];
+    if (_isEpisodeListReversed) {
+      return episodes.reversed.toList(growable: false);
+    }
+    return episodes;
+  }
+
+  List<FocusNode> get _controlFocusNodes {
+    if (DandanplayService.isLoggedIn) {
+      return <FocusNode>[_closeFocusNode, _favoriteFocusNode, _sortFocusNode];
+    }
+    return <FocusNode>[_closeFocusNode, _sortFocusNode];
+  }
+
+  int get _sortControlIndex => _controlFocusNodes.length - 1;
+
+  int _clampInt(int value, int min, int max) {
+    if (max < min) {
+      return min;
+    }
+    if (value < min) {
+      return min;
+    }
+    if (value > max) {
+      return max;
+    }
+    return value;
+  }
+
+  String _plainSummary(String? raw) {
+    return (raw ?? '暂无简介')
+        .replaceAll('<br>', ' ')
+        .replaceAll('<br/>', ' ')
+        .replaceAll('<br />', ' ')
+        .replaceAll('```', '')
+        .trim();
+  }
+
+  void _disposeEpisodeFocusNodes() {
+    for (final node in _episodeFocusNodes) {
+      node.dispose();
+    }
+    _episodeFocusNodes = <FocusNode>[];
+  }
+
+  void _rebuildEpisodeFocusNodes({int? keepEpisodeId}) {
+    _disposeEpisodeFocusNodes();
+    final episodes = _displayEpisodes;
+    _episodeFocusNodes = List<FocusNode>.generate(
+      episodes.length,
+      (index) => FocusNode(
+        debugLabel: 'large_screen_anime_detail_episode_${episodes[index].id}',
+      ),
+      growable: false,
+    );
+
+    if (episodes.isEmpty) {
+      _selectedEpisodeIndex = 0;
+      _isEpisodeAreaActive = false;
+      return;
+    }
+
+    if (keepEpisodeId != null) {
+      final matchedIndex = episodes.indexWhere((e) => e.id == keepEpisodeId);
+      if (matchedIndex >= 0) {
+        _selectedEpisodeIndex = matchedIndex;
+      }
+    }
+    _selectedEpisodeIndex = _clampInt(
+      _selectedEpisodeIndex,
+      0,
+      episodes.length - 1,
+    );
+  }
+
+  Future<void> _loadPageData() async {
+    setState(() {
+      _isLoading = true;
+      _error = null;
+      _anime = null;
+      _episodeHistoryMap.clear();
+      _dandanplayWatchStatus.clear();
+    });
+
+    try {
+      final anime = await _fetchAnimeDetails();
+      if (!mounted) return;
+
+      setState(() {
+        _anime = anime;
+        _isLoading = false;
+      });
+
+      final selectedEpisodeId = _currentSelectedEpisodeId();
+      _rebuildEpisodeFocusNodes(keepEpisodeId: selectedEpisodeId);
+
+      await Future.wait<void>(<Future<void>>[
+        _loadEpisodeHistories(anime),
+        _loadDandanplayUserState(anime),
+        _loadSharedEpisodes(),
+      ]);
+
+      if (!mounted) return;
+      _selectedControlIndex = _clampInt(
+        _selectedControlIndex,
+        0,
+        _controlFocusNodes.length - 1,
+      );
+      _requestCurrentSelectionFocus();
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _error = e.toString();
+        _isLoading = false;
+      });
+      _requestControlFocus(0);
+    }
+  }
+
+  Future<BangumiAnime> _fetchAnimeDetails() async {
+    if (kIsWeb) {
+      final apiUri =
+          WebRemoteAccessService.apiUri('/api/bangumi/detail/${widget.animeId}');
+      if (apiUri == null) {
+        throw Exception('未配置远程访问地址');
+      }
+      final response = await http.get(apiUri);
+      if (response.statusCode != 200) {
+        throw Exception('详情加载失败: ${response.statusCode}');
+      }
+      final decoded = json.decode(utf8.decode(response.bodyBytes));
+      if (decoded is! Map<String, dynamic>) {
+        throw Exception('详情数据格式错误');
+      }
+      return BangumiAnime.fromJson(decoded);
+    }
+
+    return BangumiService.instance.getAnimeDetails(widget.animeId);
+  }
+
+  Future<void> _loadEpisodeHistories(BangumiAnime anime) async {
+    final episodes = anime.episodeList ?? const <EpisodeData>[];
+    if (episodes.isEmpty) {
+      if (!mounted) return;
+      setState(() {
+        _episodeHistoryMap.clear();
+      });
+      return;
+    }
+
+    final futures = episodes.map((episode) async {
+      final history = await WatchHistoryManager.getHistoryItemByEpisode(
+        anime.id,
+        episode.id,
+      );
+      return MapEntry<int, WatchHistoryItem?>(episode.id, history);
+    }).toList(growable: false);
+
+    final result = await Future.wait(futures);
+    if (!mounted) return;
+    setState(() {
+      _episodeHistoryMap
+        ..clear()
+        ..addEntries(result);
+    });
+  }
+
+  Future<void> _loadDandanplayUserState(BangumiAnime anime) async {
+    if (!DandanplayService.isLoggedIn) {
+      if (!mounted) return;
+      setState(() {
+        _dandanplayWatchStatus.clear();
+        _isFavorited = false;
+      });
+      return;
+    }
+
+    final episodes = anime.episodeList ?? const <EpisodeData>[];
+    final episodeIds = episodes
+        .where((episode) => episode.id > 0)
+        .map((episode) => episode.id)
+        .toList(growable: false);
+
+    try {
+      final results = await Future.wait<dynamic>(<Future<dynamic>>[
+        episodeIds.isEmpty
+            ? Future<Map<int, bool>>.value(<int, bool>{})
+            : DandanplayService.getEpisodesWatchStatus(episodeIds),
+        DandanplayService.isAnimeFavorited(anime.id),
+      ]);
+
+      if (!mounted) return;
+      setState(() {
+        _dandanplayWatchStatus
+          ..clear()
+          ..addAll((results[0] as Map<int, bool>));
+        _isFavorited = results[1] as bool;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _dandanplayWatchStatus.clear();
+      });
+    }
+  }
+
+  Future<void> _loadSharedEpisodes() async {
+    if (widget.sharedEpisodeLoader == null || widget.sharedEpisodeBuilder == null) {
+      return;
+    }
+
+    setState(() {
+      _isLoadingSharedEpisodes = true;
+      _sharedEpisodesError = null;
+      _sharedEpisodeMap.clear();
+      _sharedPlayableMap.clear();
+    });
+
+    try {
+      final episodes = await widget.sharedEpisodeLoader!.call();
+      if (!mounted) return;
+      setState(() {
+        for (final episode in episodes) {
+          final episodeId = episode.episodeId;
+          if (episodeId == null) {
+            continue;
+          }
+          _sharedEpisodeMap[episodeId] = episode;
+          _sharedPlayableMap[episodeId] = widget.sharedEpisodeBuilder!(episode);
+        }
+        _isLoadingSharedEpisodes = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _sharedEpisodeMap.clear();
+        _sharedPlayableMap.clear();
+        _sharedEpisodesError = e.toString();
+        _isLoadingSharedEpisodes = false;
+      });
+    }
+  }
+
+  void _showMessage(String text) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        SnackBar(
+          content: Text(text, locale: const Locale('zh-Hans', 'zh')),
+          duration: const Duration(milliseconds: 1800),
+        ),
+      );
+  }
+
+  int? _currentSelectedEpisodeId() {
+    final episodes = _displayEpisodes;
+    if (episodes.isEmpty) {
+      return null;
+    }
+    final index = _clampInt(_selectedEpisodeIndex, 0, episodes.length - 1);
+    return episodes[index].id;
+  }
+
+  Future<void> _toggleFavorite() async {
+    final anime = _anime;
+    if (anime == null) return;
+
+    if (!DandanplayService.isLoggedIn) {
+      _showMessage('请先登录弹弹play账号');
+      return;
+    }
+
+    if (_isTogglingFavorite) {
+      return;
+    }
+
+    setState(() {
+      _isTogglingFavorite = true;
+    });
+
+    try {
+      if (_isFavorited) {
+        await DandanplayService.removeFavorite(anime.id);
+      } else {
+        await DandanplayService.addFavorite(
+          animeId: anime.id,
+          favoriteStatus: 'favorited',
+        );
+      }
+      if (!mounted) return;
+      setState(() {
+        _isFavorited = !_isFavorited;
+      });
+      _showMessage(_isFavorited ? '已添加到收藏' : '已取消收藏');
+    } catch (e) {
+      _showMessage('收藏状态更新失败: $e');
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isTogglingFavorite = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _playEpisode(EpisodeData episode) async {
+    final anime = _anime;
+    if (anime == null) return;
+
+    final sharedEpisode = _sharedEpisodeMap[episode.id];
+    final sharedPlayable = _sharedPlayableMap[episode.id];
+    final sharedPlayableAvailable =
+        sharedEpisode != null && sharedPlayable != null && sharedEpisode.fileExists;
+
+    if (sharedPlayableAvailable) {
+      await PlaybackService().play(sharedPlayable);
+      if (!mounted) return;
+      Navigator.of(context).maybePop();
+      return;
+    }
+
+    final history = _episodeHistoryMap[episode.id];
+    if (history == null || history.filePath.isEmpty) {
+      _showMessage('媒体库中找不到此剧集的视频文件');
+      return;
+    }
+
+    final playableItem = PlayableItem(
+      videoPath: history.filePath,
+      title: anime.nameCn,
+      subtitle: episode.title,
+      animeId: anime.id,
+      episodeId: episode.id,
+      historyItem: history,
+    );
+
+    await PlaybackService().play(playableItem);
+    if (!mounted) return;
+    Navigator.of(context).maybePop();
+  }
+
+  void _requestControlFocus(int index) {
+    final controlNodes = _controlFocusNodes;
+    if (controlNodes.isEmpty) return;
+    final targetIndex = _clampInt(index, 0, controlNodes.length - 1);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      controlNodes[targetIndex].requestFocus();
+    });
+  }
+
+  void _requestEpisodeFocus(int index) {
+    if (_episodeFocusNodes.isEmpty) return;
+    final targetIndex = _clampInt(index, 0, _episodeFocusNodes.length - 1);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _episodeFocusNodes[targetIndex].requestFocus();
+    });
+  }
+
+  void _requestCurrentSelectionFocus() {
+    _selectedControlIndex = _clampInt(
+      _selectedControlIndex,
+      0,
+      _controlFocusNodes.length - 1,
+    );
+    if (_isEpisodeAreaActive && _episodeFocusNodes.isNotEmpty) {
+      _selectedEpisodeIndex = _clampInt(
+        _selectedEpisodeIndex,
+        0,
+        _episodeFocusNodes.length - 1,
+      );
+      _requestEpisodeFocus(_selectedEpisodeIndex);
+      _scrollToEpisodeIndex(_selectedEpisodeIndex, animate: false);
+      return;
+    }
+    _requestControlFocus(_selectedControlIndex);
+  }
+
+  void _scrollToEpisodeIndex(int index, {required bool animate}) {
+    if (!_episodeScrollController.hasClients || _episodeFocusNodes.isEmpty) {
+      return;
+    }
+    final targetIndex = _clampInt(index, 0, _episodeFocusNodes.length - 1);
+    final targetOffset =
+        targetIndex * (_kLargeScreenEpisodeCardWidth + _kLargeScreenEpisodeCardGap);
+
+    final clamped = targetOffset.clamp(
+      _episodeScrollController.position.minScrollExtent,
+      _episodeScrollController.position.maxScrollExtent,
+    );
+
+    if (animate) {
+      _episodeScrollController.animateTo(
+        clamped,
+        duration: const Duration(milliseconds: 160),
+        curve: Curves.easeOut,
+      );
+      return;
+    }
+    _episodeScrollController.jumpTo(clamped);
+  }
+
+  void _setControlSelection(int index) {
+    final max = _controlFocusNodes.length - 1;
+    if (max < 0) return;
+    setState(() {
+      _isEpisodeAreaActive = false;
+      _selectedControlIndex = _clampInt(index, 0, max);
+    });
+    _requestControlFocus(_selectedControlIndex);
+  }
+
+  void _setEpisodeSelection(int index, {bool animateScroll = true}) {
+    if (_episodeFocusNodes.isEmpty) return;
+    setState(() {
+      _isEpisodeAreaActive = true;
+      _selectedEpisodeIndex =
+          _clampInt(index, 0, _episodeFocusNodes.length - 1);
+    });
+    _requestEpisodeFocus(_selectedEpisodeIndex);
+    _scrollToEpisodeIndex(_selectedEpisodeIndex, animate: animateScroll);
+  }
+
+  void _moveHorizontal(int delta) {
+    if (_isEpisodeAreaActive) {
+      _setEpisodeSelection(_selectedEpisodeIndex + delta);
+      return;
+    }
+    _setControlSelection(_selectedControlIndex + delta);
+  }
+
+  void _moveVertical(int delta) {
+    if (_isEpisodeAreaActive) {
+      if (delta < 0) {
+        _setControlSelection(_selectedControlIndex);
+      }
+      return;
+    }
+
+    if (delta > 0 && _episodeFocusNodes.isNotEmpty) {
+      _setEpisodeSelection(_selectedEpisodeIndex);
+    }
+  }
+
+  void _activateControlAt(int index) {
+    final hasFavorite = DandanplayService.isLoggedIn;
+    if (index == 0) {
+      Navigator.of(context).maybePop();
+      return;
+    }
+
+    if (hasFavorite && index == 1) {
+      _toggleFavorite();
+      return;
+    }
+
+    _toggleEpisodeOrder();
+  }
+
+  void _activateCurrentSelection() {
+    if (_isEpisodeAreaActive && _episodeFocusNodes.isNotEmpty) {
+      final episodes = _displayEpisodes;
+      if (episodes.isEmpty) return;
+      final index = _clampInt(_selectedEpisodeIndex, 0, episodes.length - 1);
+      _playEpisode(episodes[index]);
+      return;
+    }
+
+    _selectedControlIndex = _clampInt(
+      _selectedControlIndex,
+      0,
+      _controlFocusNodes.length - 1,
+    );
+    _activateControlAt(_selectedControlIndex);
+  }
+
+  void _toggleEpisodeOrder() {
+    final selectedEpisodeId = _currentSelectedEpisodeId();
+    setState(() {
+      _isEpisodeListReversed = !_isEpisodeListReversed;
+    });
+    _rebuildEpisodeFocusNodes(keepEpisodeId: selectedEpisodeId);
+    if (_isEpisodeAreaActive && _episodeFocusNodes.isNotEmpty) {
+      _requestEpisodeFocus(_selectedEpisodeIndex);
+      _scrollToEpisodeIndex(_selectedEpisodeIndex, animate: false);
+      return;
+    }
+    _requestControlFocus(_sortControlIndex);
+  }
+
+  bool _isCurrentRouteActive() {
+    final route = ModalRoute.of(context);
+    if (route == null) {
+      return true;
+    }
+    return route.isCurrent;
+  }
+
+  KeyEventResult _handleEarlyKeyEvent(KeyEvent event) {
+    if (!mounted || !_isCurrentRouteActive()) {
+      return KeyEventResult.ignored;
+    }
+    return _handleInputCommandEvent(event);
+  }
+
+  KeyEventResult _handleInputKeyEvent(FocusNode node, KeyEvent event) {
+    return _handleInputCommandEvent(event);
+  }
+
+  KeyEventResult _handleInputCommandEvent(KeyEvent event) {
+    final command = NipaplayLargeScreenInputControls.fromKeyEvent(event);
+    if (command == null) {
+      return KeyEventResult.ignored;
+    }
+
+    switch (command) {
+      case NipaplayLargeScreenInputCommand.toggleMenu:
+        Navigator.of(context).maybePop();
+        return KeyEventResult.handled;
+      case NipaplayLargeScreenInputCommand.navigateLeft:
+        _moveHorizontal(-1);
+        return KeyEventResult.handled;
+      case NipaplayLargeScreenInputCommand.navigateRight:
+        _moveHorizontal(1);
+        return KeyEventResult.handled;
+      case NipaplayLargeScreenInputCommand.navigateUp:
+        _moveVertical(-1);
+        return KeyEventResult.handled;
+      case NipaplayLargeScreenInputCommand.navigateDown:
+        _moveVertical(1);
+        return KeyEventResult.handled;
+      case NipaplayLargeScreenInputCommand.activate:
+        _activateCurrentSelection();
+        return KeyEventResult.handled;
+    }
+  }
+
+  Widget _buildControlButton({
+    required FocusNode focusNode,
+    required IconData icon,
+    required String label,
+    required int controlIndex,
+    required VoidCallback onPressed,
+    bool showLoading = false,
+    Color? iconColor,
+  }) {
+    return NipaplayLargeScreenFocusableAction(
+      focusNode: focusNode,
+      borderRadius: BorderRadius.circular(8),
+      onActivate: () {
+        _setControlSelection(controlIndex);
+        onPressed();
+      },
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (showLoading)
+              SizedBox(
+                width: 16,
+                height: 16,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2,
+                  valueColor: AlwaysStoppedAnimation<Color>(
+                    iconColor ?? Colors.white,
+                  ),
+                ),
+              )
+            else
+              Icon(icon, size: 17, color: iconColor),
+            const SizedBox(width: 6),
+            Text(
+              label,
+              locale: const Locale('zh-Hans', 'zh'),
+              style: const TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeroInfoSection(BangumiAnime anime, bool isDarkMode) {
+    final textColor = isDarkMode ? Colors.white : Colors.black87;
+    final secondary = isDarkMode ? Colors.white70 : Colors.black54;
+    final muted = isDarkMode ? Colors.white60 : Colors.black54;
+
+    String imageUrl = widget.sharedSummary?.imageUrl ?? anime.imageUrl;
+    if (kIsWeb) {
+      imageUrl = WebRemoteAccessService.imageProxyUrl(imageUrl) ?? imageUrl;
+    }
+
+    final summary = _plainSummary(
+      widget.sharedSummary?.summary?.isNotEmpty == true
+          ? widget.sharedSummary!.summary
+          : anime.summary,
+    );
+
+    final episodes = _displayEpisodes;
+    final watchedCount = episodes
+        .where((episode) => _dandanplayWatchStatus[episode.id] == true)
+        .length;
+    final playableCount = episodes.where((episode) {
+      final history = _episodeHistoryMap[episode.id];
+      if (history != null && history.filePath.isNotEmpty) {
+        return true;
+      }
+      final sharedEpisode = _sharedEpisodeMap[episode.id];
+      return sharedEpisode != null && sharedEpisode.fileExists;
+    }).length;
+
+    final metaLines = <String>[
+      if (anime.airDate != null && anime.airDate!.isNotEmpty)
+        '首播: ${anime.airDate}',
+      if (anime.typeDescription != null && anime.typeDescription!.isNotEmpty)
+        '类型: ${anime.typeDescription}',
+      '剧集: ${episodes.length}',
+      '可播放: $playableCount',
+      if (DandanplayService.isLoggedIn) '已看: $watchedCount',
+    ];
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 14, 16, 10),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          ClipRRect(
+            borderRadius: BorderRadius.circular(10),
+            child: imageUrl.isNotEmpty
+                ? CachedNetworkImageWidget(
+                    imageUrl: imageUrl,
+                    width: 190,
+                    height: 268,
+                    fit: BoxFit.cover,
+                    loadMode: CachedImageLoadMode.legacy,
+                  )
+                : Container(
+                    width: 190,
+                    height: 268,
+                    color: textColor.withValues(alpha: 0.08),
+                    alignment: Alignment.center,
+                    child: Icon(
+                      Icons.image_not_supported_outlined,
+                      color: muted,
+                      size: 32,
+                    ),
+                  ),
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            anime.nameCn,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              color: textColor,
+                              fontSize: 22,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          const SizedBox(height: 4),
+                          Text(
+                            anime.name,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              color: secondary,
+                              fontSize: 13,
+                            ),
+                          ),
+                          if (widget.sharedSourceLabel != null) ...[
+                            const SizedBox(height: 8),
+                            Row(
+                              children: [
+                                Icon(
+                                  Icons.cloud_outlined,
+                                  size: 14,
+                                  color: secondary,
+                                ),
+                                const SizedBox(width: 4),
+                                Text(
+                                  widget.sharedSourceLabel!,
+                                  style: TextStyle(
+                                    color: secondary,
+                                    fontSize: 11,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
+                    _buildControlButton(
+                      focusNode: _closeFocusNode,
+                      icon: Icons.close_rounded,
+                      label: '关闭',
+                      controlIndex: 0,
+                      onPressed: () => Navigator.of(context).maybePop(),
+                    ),
+                    const SizedBox(width: 6),
+                    if (DandanplayService.isLoggedIn) ...[
+                      _buildControlButton(
+                        focusNode: _favoriteFocusNode,
+                        icon: _isFavorited
+                            ? Icons.favorite_rounded
+                            : Icons.favorite_border_rounded,
+                        iconColor: _isFavorited ? Colors.red : null,
+                        label: _isFavorited ? '已收藏' : '收藏',
+                        controlIndex: 1,
+                        onPressed: _toggleFavorite,
+                        showLoading: _isTogglingFavorite,
+                      ),
+                      const SizedBox(width: 6),
+                    ],
+                    _buildControlButton(
+                      focusNode: _sortFocusNode,
+                      icon: Icons.swap_horiz_rounded,
+                      label: _isEpisodeListReversed ? '倒序' : '正序',
+                      controlIndex: _sortControlIndex,
+                      onPressed: _toggleEpisodeOrder,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 10),
+                Text(
+                  summary,
+                  maxLines: 6,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    color: textColor.withValues(alpha: 0.92),
+                    fontSize: 13,
+                    height: 1.45,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: metaLines
+                      .map(
+                        (line) => Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 10,
+                            vertical: 5,
+                          ),
+                          decoration: BoxDecoration(
+                            color: textColor.withValues(alpha: 0.08),
+                            borderRadius: BorderRadius.circular(999),
+                            border: Border.all(
+                              color: textColor.withValues(alpha: 0.14),
+                              width: 1,
+                            ),
+                          ),
+                          child: Text(
+                            line,
+                            locale: const Locale('zh-Hans', 'zh'),
+                            style: TextStyle(
+                              color: textColor.withValues(alpha: 0.9),
+                              fontSize: 11,
+                              fontWeight: FontWeight.w500,
+                            ),
+                          ),
+                        ),
+                      )
+                      .toList(growable: false),
+                ),
+                if (anime.tags != null && anime.tags!.isNotEmpty) ...[
+                  const SizedBox(height: 10),
+                  Wrap(
+                    spacing: 6,
+                    runSpacing: 6,
+                    children: anime.tags!
+                        .take(12)
+                        .map(
+                          (tag) => Container(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 8,
+                              vertical: 4,
+                            ),
+                            decoration: BoxDecoration(
+                              color: textColor.withValues(alpha: 0.05),
+                              borderRadius: BorderRadius.circular(999),
+                              border: Border.all(
+                                color: textColor.withValues(alpha: 0.12),
+                                width: 1,
+                              ),
+                            ),
+                            child: Text(
+                              tag,
+                              locale: const Locale('zh-Hans', 'zh'),
+                              style: TextStyle(
+                                color: textColor.withValues(alpha: 0.82),
+                                fontSize: 10,
+                                fontWeight: FontWeight.w500,
+                              ),
+                            ),
+                          ),
+                        )
+                        .toList(growable: false),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEpisodeCard({
+    required EpisodeData episode,
+    required int index,
+    required bool isDarkMode,
+  }) {
+    final textColor = isDarkMode ? Colors.white : Colors.black87;
+    final mutedColor = isDarkMode ? Colors.white60 : Colors.black54;
+
+    final history = _episodeHistoryMap[episode.id];
+    final isWatched = _dandanplayWatchStatus[episode.id] == true;
+    final sharedEpisode = _sharedEpisodeMap[episode.id];
+    final hasSharedPlayable = sharedEpisode != null && sharedEpisode.fileExists;
+
+    String progressLabel = '';
+    Color progressColor = mutedColor;
+    if (history != null && history.watchProgress > 0.01) {
+      progressLabel = '${(history.watchProgress * 100).toStringAsFixed(0)}%';
+      progressColor = isDarkMode ? Colors.orangeAccent : const Color(0xFFB45309);
+    } else if (hasSharedPlayable) {
+      progressLabel = '共享媒体';
+      progressColor = isDarkMode ? Colors.lightBlueAccent : const Color(0xFF1565C0);
+    }
+
+    return NipaplayLargeScreenFocusableAction(
+      focusNode: _episodeFocusNodes[index],
+      borderRadius: BorderRadius.circular(10),
+      onActivate: () {
+        _setEpisodeSelection(index);
+        _playEpisode(episode);
+      },
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(10, 10, 10, 8),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'EP ${index + 1}',
+              style: TextStyle(
+                color: mutedColor,
+                fontSize: 11,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            const SizedBox(height: 6),
+            Text(
+              episode.title,
+              locale: const Locale('zh-Hans', 'zh'),
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                color: textColor,
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
+                height: 1.3,
+              ),
+            ),
+            const Spacer(),
+            Row(
+              children: [
+                Icon(
+                  isWatched
+                      ? Icons.check_circle_rounded
+                      : Icons.play_circle_outline_rounded,
+                  size: 16,
+                  color: isWatched
+                      ? (isDarkMode
+                          ? Colors.greenAccent
+                          : const Color(0xFF2E7D32))
+                      : mutedColor,
+                ),
+                const SizedBox(width: 6),
+                if (isWatched)
+                  Text(
+                    '已看',
+                    locale: const Locale('zh-Hans', 'zh'),
+                    style: TextStyle(
+                      color: isDarkMode
+                          ? Colors.greenAccent
+                          : const Color(0xFF2E7D32),
+                      fontSize: 11,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  )
+                else
+                  Text(
+                    '未看',
+                    locale: const Locale('zh-Hans', 'zh'),
+                    style: TextStyle(
+                      color: mutedColor,
+                      fontSize: 11,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+              ],
+            ),
+            if (progressLabel.isNotEmpty) ...[
+              const SizedBox(height: 4),
+              Text(
+                progressLabel,
+                locale: const Locale('zh-Hans', 'zh'),
+                style: TextStyle(
+                  color: progressColor,
+                  fontSize: 11,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildEpisodeRail(BangumiAnime anime, bool isDarkMode) {
+    final episodes = _displayEpisodes;
+    final mutedColor = isDarkMode ? Colors.white60 : Colors.black54;
+
+    if (_isLoadingSharedEpisodes) {
+      return const SizedBox(
+        height: _kLargeScreenEpisodeRailHeight,
+        child: Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    if (_sharedEpisodesError != null) {
+      return SizedBox(
+        height: _kLargeScreenEpisodeRailHeight,
+        child: Center(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Text(
+              _sharedEpisodesError!,
+              style: TextStyle(color: mutedColor),
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ),
+      );
+    }
+
+    if (episodes.isEmpty) {
+      return SizedBox(
+        height: _kLargeScreenEpisodeRailHeight,
+        child: Center(
+          child: Text(
+            '暂无剧集信息',
+            locale: const Locale('zh-Hans', 'zh'),
+            style: TextStyle(color: mutedColor),
+          ),
+        ),
+      );
+    }
+
+    return SizedBox(
+      height: _kLargeScreenEpisodeRailHeight,
+      child: ListView.separated(
+        controller: _episodeScrollController,
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        itemCount: episodes.length,
+        separatorBuilder: (_, __) => const SizedBox(width: _kLargeScreenEpisodeCardGap),
+        itemBuilder: (context, index) {
+          return SizedBox(
+            width: _kLargeScreenEpisodeCardWidth,
+            child: _buildEpisodeCard(
+              episode: episodes[index],
+              index: index,
+              isDarkMode: isDarkMode,
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildLoadedBody(BangumiAnime anime) {
+    final bool isDarkMode = Theme.of(context).brightness == Brightness.dark;
+    final Color dividerColor = isDarkMode ? Colors.white12 : Colors.black12;
+    final episodes = _displayEpisodes;
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return SingleChildScrollView(
+          child: ConstrainedBox(
+            constraints: BoxConstraints(minHeight: constraints.maxHeight),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                _buildHeroInfoSection(anime, isDarkMode),
+                Container(
+                  decoration: BoxDecoration(
+                    border: Border(
+                      top: BorderSide(
+                        color: dividerColor,
+                        width: 1,
+                      ),
+                    ),
+                  ),
+                  padding: const EdgeInsets.fromLTRB(16, 10, 16, 8),
+                  child: Row(
+                    children: [
+                      Text(
+                        '剧集 ${episodes.length} 集',
+                        locale: const Locale('zh-Hans', 'zh'),
+                        style: TextStyle(
+                          color: isDarkMode ? Colors.white70 : Colors.black54,
+                          fontSize: 12,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      const Spacer(),
+                      Text(
+                        '↑/↓ 切换区域  ←/→ 选集  Enter 播放',
+                        locale: const Locale('zh-Hans', 'zh'),
+                        style: TextStyle(
+                          color: isDarkMode ? Colors.white54 : Colors.black45,
+                          fontSize: 11,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                _buildEpisodeRail(anime, isDarkMode),
+                const SizedBox(height: 10),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final Color surfaceColor =
+        isDark ? const Color(0xFF1E1E1E) : const Color(0xFFF2F2F2);
+    final Color dividerColor = isDark ? Colors.white12 : Colors.black12;
+    final mediaPadding = MediaQuery.of(context).padding;
+
+    final body = _isLoading
+        ? const Center(child: CircularProgressIndicator())
+        : (_error != null
+            ? Center(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      _error!,
+                      textAlign: TextAlign.center,
+                      style: TextStyle(
+                        color: isDark ? Colors.white70 : Colors.black54,
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    _buildControlButton(
+                      focusNode: _closeFocusNode,
+                      icon: Icons.refresh_rounded,
+                      label: '重试',
+                      controlIndex: 0,
+                      onPressed: _loadPageData,
+                    ),
+                  ],
+                ),
+              )
+            : _buildLoadedBody(_anime!));
+
+    return NipaplayLargeScreenHomeScope(
+      child: Focus(
+        focusNode: _inputFocusNode,
+        autofocus: true,
+        canRequestFocus: true,
+        onKeyEvent: _handleInputKeyEvent,
+        child: Scaffold(
+          backgroundColor: Colors.transparent,
+          body: Stack(
+            children: [
+              Positioned.fill(
+                child: Padding(
+                  padding: EdgeInsets.fromLTRB(
+                    14,
+                    kNipaplayLargeScreenBottomHintHeight,
+                    14,
+                    kNipaplayLargeScreenBottomHintHeight + mediaPadding.bottom,
+                  ),
+                  child: Container(
+                    decoration: BoxDecoration(
+                      color: surfaceColor,
+                      borderRadius:
+                          BorderRadius.circular(_kLargeScreenDetailPanelRadius),
+                      border: Border.all(color: dividerColor, width: 1),
+                    ),
+                    clipBehavior: Clip.antiAlias,
+                    child: body,
+                  ),
+                ),
+              ),
+              Positioned(
+                left: 0,
+                right: 0,
+                top: 0,
+                child: NipaplayLargeScreenTopStatusOverlay(
+                  isDarkMode: isDark,
+                ),
+              ),
+              Positioned(
+                left: 0,
+                right: 0,
+                bottom: 0,
+                child: NipaplayLargeScreenBottomHintOverlay(
+                  isDarkMode: isDark,
+                  onToggleMenu: () => Navigator.of(context).maybePop(),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/themes/nipaplay/widgets/large_screen_bottom_hint_overlay.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_bottom_hint_overlay.dart
@@ -1,0 +1,68 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+
+const double kNipaplayLargeScreenBottomHintHeight = 40;
+
+class NipaplayLargeScreenBottomHintOverlay extends StatelessWidget {
+  const NipaplayLargeScreenBottomHintOverlay({
+    super.key,
+    required this.isDarkMode,
+    required this.onToggleMenu,
+  });
+
+  final bool isDarkMode;
+  final VoidCallback onToggleMenu;
+
+  @override
+  Widget build(BuildContext context) {
+    final Color iconColor = isDarkMode ? Colors.white : Colors.black87;
+    final Color textColor = isDarkMode ? Colors.white : Colors.black87;
+    final Color backgroundTint = isDarkMode
+        ? Colors.black.withValues(alpha: 0.18)
+        : Colors.white.withValues(alpha: 0.14);
+
+    return SizedBox(
+      height: kNipaplayLargeScreenBottomHintHeight,
+      child: ClipRect(
+        child: BackdropFilter(
+          filter: ImageFilter.blur(sigmaX: 25, sigmaY: 25),
+          child: ColoredBox(
+            color: backgroundTint,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: InkWell(
+                  onTap: onToggleMenu,
+                  borderRadius: BorderRadius.zero,
+                  splashFactory: NoSplash.splashFactory,
+                  overlayColor: WidgetStateProperty.all(Colors.transparent),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        Icons.menu_rounded,
+                        size: 22,
+                        color: iconColor,
+                      ),
+                      const SizedBox(width: 8),
+                      Text(
+                        '菜单',
+                        style: TextStyle(
+                          color: textColor,
+                          fontSize: 17,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/themes/nipaplay/widgets/large_screen_bottom_hint_overlay.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_bottom_hint_overlay.dart
@@ -9,10 +9,16 @@ class NipaplayLargeScreenBottomHintOverlay extends StatelessWidget {
     super.key,
     required this.isDarkMode,
     required this.onToggleMenu,
+    this.onOpenSettings,
+    this.menuLabel = '菜单',
+    this.settingsLabel = '设置',
   });
 
   final bool isDarkMode;
   final VoidCallback onToggleMenu;
+  final VoidCallback? onOpenSettings;
+  final String menuLabel;
+  final String settingsLabel;
 
   @override
   Widget build(BuildContext context) {
@@ -27,41 +33,70 @@ class NipaplayLargeScreenBottomHintOverlay extends StatelessWidget {
       child: ClipRect(
         child: BackdropFilter(
           filter: ImageFilter.blur(sigmaX: 25, sigmaY: 25),
-          child: ColoredBox(
-            color: backgroundTint,
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: Align(
-                alignment: Alignment.centerLeft,
-                child: InkWell(
-                  onTap: onToggleMenu,
-                  borderRadius: BorderRadius.zero,
-                  splashFactory: NoSplash.splashFactory,
-                  overlayColor: WidgetStateProperty.all(Colors.transparent),
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Icon(
-                        Icons.menu_rounded,
-                        size: 22,
-                        color: iconColor,
+            child: ColoredBox(
+              color: backgroundTint,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    InkWell(
+                      onTap: onToggleMenu,
+                      borderRadius: BorderRadius.zero,
+                      splashFactory: NoSplash.splashFactory,
+                      overlayColor: WidgetStateProperty.all(Colors.transparent),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(
+                            Icons.menu_rounded,
+                            size: 22,
+                            color: iconColor,
+                          ),
+                          const SizedBox(width: 8),
+                          Text(
+                            menuLabel,
+                            style: TextStyle(
+                              color: textColor,
+                              fontSize: 17,
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                        ],
                       ),
-                      const SizedBox(width: 8),
-                      Text(
-                        '菜单',
-                        style: TextStyle(
-                          color: textColor,
-                          fontSize: 17,
-                          fontWeight: FontWeight.w700,
+                    ),
+                    if (onOpenSettings != null)
+                      InkWell(
+                        onTap: onOpenSettings,
+                        borderRadius: BorderRadius.zero,
+                        splashFactory: NoSplash.splashFactory,
+                        overlayColor:
+                            WidgetStateProperty.all(Colors.transparent),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Icon(
+                              Icons.settings_rounded,
+                              size: 22,
+                              color: iconColor,
+                            ),
+                            const SizedBox(width: 8),
+                            Text(
+                              settingsLabel,
+                              style: TextStyle(
+                                color: textColor,
+                                fontSize: 17,
+                                fontWeight: FontWeight.w700,
+                              ),
+                            ),
+                          ],
                         ),
                       ),
-                    ],
-                  ),
+                  ],
                 ),
               ),
             ),
           ),
-        ),
       ),
     );
   }

--- a/lib/themes/nipaplay/widgets/large_screen_editable_slider.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_editable_slider.dart
@@ -1,0 +1,220 @@
+import 'package:fluent_ui/fluent_ui.dart' as fluent;
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_mode_scope.dart';
+
+class NipaplayLargeScreenEditableSlider extends StatefulWidget {
+  const NipaplayLargeScreenEditableSlider({
+    super.key,
+    required this.value,
+    required this.min,
+    required this.max,
+    required this.onChanged,
+    this.divisions,
+    this.label,
+    this.onChangeStart,
+    this.onChangeEnd,
+  });
+
+  final double value;
+  final double min;
+  final double max;
+  final int? divisions;
+  final String? label;
+  final ValueChanged<double>? onChanged;
+  final ValueChanged<double>? onChangeStart;
+  final ValueChanged<double>? onChangeEnd;
+
+  static int _editingCount = 0;
+
+  static bool get isAnyEditing => _editingCount > 0;
+
+  @override
+  State<NipaplayLargeScreenEditableSlider> createState() =>
+      _NipaplayLargeScreenEditableSliderState();
+}
+
+class _NipaplayLargeScreenEditableSliderState
+    extends State<NipaplayLargeScreenEditableSlider> {
+  bool _isEditing = false;
+  bool _hasFocus = false;
+  double? _editingStartValue;
+
+  bool get _canEdit {
+    return widget.onChanged != null && widget.max > widget.min;
+  }
+
+  double get _step {
+    final divisions = widget.divisions;
+    if (divisions != null && divisions > 0) {
+      return (widget.max - widget.min) / divisions;
+    }
+    return (widget.max - widget.min) / 20;
+  }
+
+  void _beginEditing() {
+    if (!_canEdit || _isEditing) {
+      return;
+    }
+    widget.onChangeStart?.call(widget.value);
+    setState(() {
+      _setEditingState(true);
+      _editingStartValue = widget.value;
+    });
+  }
+
+  void _cancelEditing() {
+    if (!_isEditing) {
+      return;
+    }
+    final startValue = _editingStartValue;
+    if (startValue != null && widget.onChanged != null) {
+      widget.onChanged!(startValue.clamp(widget.min, widget.max).toDouble());
+    }
+    widget.onChangeEnd?.call(startValue ?? widget.value);
+    setState(() {
+      _setEditingState(false);
+      _editingStartValue = null;
+    });
+  }
+
+  void _setEditingState(bool value) {
+    if (_isEditing == value) {
+      return;
+    }
+    _isEditing = value;
+    if (value) {
+      NipaplayLargeScreenEditableSlider._editingCount++;
+    } else if (NipaplayLargeScreenEditableSlider._editingCount > 0) {
+      NipaplayLargeScreenEditableSlider._editingCount--;
+    }
+  }
+
+  void _adjustValue(bool increase) {
+    if (!_canEdit) {
+      return;
+    }
+    final step = _step;
+    if (step <= 0) {
+      return;
+    }
+    final nextValue = (widget.value + (increase ? step : -step))
+        .clamp(widget.min, widget.max)
+        .toDouble();
+    widget.onChanged?.call(nextValue);
+  }
+
+  @override
+  void dispose() {
+    if (_isEditing && NipaplayLargeScreenEditableSlider._editingCount > 0) {
+      NipaplayLargeScreenEditableSlider._editingCount--;
+    }
+    super.dispose();
+  }
+
+  KeyEventResult _handleKeyEvent(FocusNode node, KeyEvent event) {
+    if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
+      return KeyEventResult.ignored;
+    }
+
+    final key = event.logicalKey;
+    final isEnter = key == LogicalKeyboardKey.enter ||
+        key == LogicalKeyboardKey.numpadEnter ||
+        key == LogicalKeyboardKey.select ||
+        key == LogicalKeyboardKey.gameButtonA;
+    final isEscape = key == LogicalKeyboardKey.escape ||
+        key == LogicalKeyboardKey.goBack ||
+        key == LogicalKeyboardKey.gameButtonB;
+    final isLeft = key == LogicalKeyboardKey.arrowLeft;
+    final isRight = key == LogicalKeyboardKey.arrowRight;
+    final isUp = key == LogicalKeyboardKey.arrowUp;
+    final isDown = key == LogicalKeyboardKey.arrowDown;
+
+    if (!_isEditing) {
+      if (isEnter) {
+        _beginEditing();
+        return KeyEventResult.handled;
+      }
+      return KeyEventResult.ignored;
+    }
+
+    if (isEscape) {
+      _cancelEditing();
+      return KeyEventResult.handled;
+    }
+
+    if (isLeft || isDown) {
+      _adjustValue(false);
+      return KeyEventResult.handled;
+    }
+
+    if (isRight || isUp) {
+      _adjustValue(true);
+      return KeyEventResult.handled;
+    }
+
+    return KeyEventResult.ignored;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isLargeScreenModeActive =
+        NipaplayLargeScreenModeScope.isActiveOf(context);
+    final normalizedValue = widget.value.clamp(widget.min, widget.max).toDouble();
+    final slider = fluent.Slider(
+      value: normalizedValue,
+      min: widget.min,
+      max: widget.max,
+      divisions: widget.divisions,
+      onChangeStart: widget.onChangeStart,
+      onChangeEnd: widget.onChangeEnd,
+      onChanged: widget.onChanged,
+      label: widget.label,
+    );
+
+    if (!isLargeScreenModeActive) {
+      return slider;
+    }
+
+    final colorScheme = Theme.of(context).colorScheme;
+    final borderColor = _isEditing
+        ? const Color(0xFFFF2E55)
+        : (_hasFocus ? colorScheme.onSurface.withValues(alpha: 0.5) : Colors.transparent);
+
+    return Actions(
+      actions: <Type, Action<Intent>>{
+        ActivateIntent: CallbackAction<ActivateIntent>(
+          onInvoke: (intent) {
+            _beginEditing();
+            return null;
+          },
+        ),
+      },
+      child: Focus(
+        onFocusChange: (focused) {
+          if (_hasFocus == focused) {
+            return;
+          }
+          setState(() {
+            _hasFocus = focused;
+            if (!focused) {
+              _setEditingState(false);
+              _editingStartValue = null;
+            }
+          });
+        },
+        onKeyEvent: _handleKeyEvent,
+        descendantsAreFocusable: false,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 120),
+          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(color: borderColor, width: 1.2),
+          ),
+          child: slider,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/themes/nipaplay/widgets/large_screen_focusable_action.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_focusable_action.dart
@@ -24,6 +24,7 @@ class NipaplayLargeScreenFocusableAction extends StatefulWidget {
     super.key,
     required this.child,
     this.onActivate,
+    this.focusNode,
     this.autofocus = false,
     this.borderRadius = BorderRadius.zero,
     this.padding,
@@ -32,6 +33,7 @@ class NipaplayLargeScreenFocusableAction extends StatefulWidget {
 
   final Widget child;
   final VoidCallback? onActivate;
+  final FocusNode? focusNode;
   final bool autofocus;
   final BorderRadius borderRadius;
   final EdgeInsetsGeometry? padding;
@@ -59,6 +61,7 @@ class _NipaplayLargeScreenFocusableActionState
         isDarkMode ? style.contentColorDark : style.contentColorLight;
 
     return FocusableActionDetector(
+      focusNode: widget.focusNode,
       autofocus: widget.autofocus,
       onShowFocusHighlight: (value) {
         if (_isFocused == value) return;

--- a/lib/themes/nipaplay/widgets/large_screen_focusable_action.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_focusable_action.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class NipaplayLargeScreenFocusableStyle {
+  const NipaplayLargeScreenFocusableStyle({
+    this.focusStrokeColor = const Color(0xFFFF2E55),
+    this.focusStrokeWidth = 2,
+    this.idleBackgroundDark = const Color(0x0AFFFFFF),
+    this.idleBackgroundLight = const Color(0x08000000),
+    this.contentColorDark = Colors.white,
+    this.contentColorLight = Colors.black87,
+  });
+
+  final Color focusStrokeColor;
+  final double focusStrokeWidth;
+  final Color idleBackgroundDark;
+  final Color idleBackgroundLight;
+  final Color contentColorDark;
+  final Color contentColorLight;
+}
+
+class NipaplayLargeScreenFocusableAction extends StatefulWidget {
+  const NipaplayLargeScreenFocusableAction({
+    super.key,
+    required this.child,
+    this.onActivate,
+    this.autofocus = false,
+    this.borderRadius = BorderRadius.zero,
+    this.padding,
+    this.style = const NipaplayLargeScreenFocusableStyle(),
+  });
+
+  final Widget child;
+  final VoidCallback? onActivate;
+  final bool autofocus;
+  final BorderRadius borderRadius;
+  final EdgeInsetsGeometry? padding;
+  final NipaplayLargeScreenFocusableStyle style;
+
+  @override
+  State<NipaplayLargeScreenFocusableAction> createState() =>
+      _NipaplayLargeScreenFocusableActionState();
+}
+
+class _NipaplayLargeScreenFocusableActionState
+    extends State<NipaplayLargeScreenFocusableAction> {
+  bool _isFocused = false;
+  bool _isHovered = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDarkMode = Theme.of(context).brightness == Brightness.dark;
+    final style = widget.style;
+    final Color idleOverlay =
+        isDarkMode ? style.idleBackgroundDark : style.idleBackgroundLight;
+    final bool isActive = _isFocused || _isHovered;
+    final Color backgroundColor = idleOverlay;
+    final Color contentColor =
+        isDarkMode ? style.contentColorDark : style.contentColorLight;
+
+    return FocusableActionDetector(
+      autofocus: widget.autofocus,
+      onShowFocusHighlight: (value) {
+        if (_isFocused == value) return;
+        setState(() {
+          _isFocused = value;
+        });
+      },
+      onShowHoverHighlight: (value) {
+        if (_isHovered == value) return;
+        setState(() {
+          _isHovered = value;
+        });
+      },
+      shortcuts: const <ShortcutActivator, Intent>{
+        SingleActivator(LogicalKeyboardKey.enter): ActivateIntent(),
+        SingleActivator(LogicalKeyboardKey.numpadEnter): ActivateIntent(),
+        SingleActivator(LogicalKeyboardKey.select): ActivateIntent(),
+      },
+      actions: <Type, Action<Intent>>{
+        ActivateIntent: CallbackAction<ActivateIntent>(
+          onInvoke: (_) {
+            widget.onActivate?.call();
+            return null;
+          },
+        ),
+      },
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: widget.onActivate,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 120),
+          curve: Curves.easeOut,
+          padding: widget.padding,
+          decoration: BoxDecoration(
+            color: backgroundColor,
+            borderRadius: widget.borderRadius,
+          ),
+          foregroundDecoration: BoxDecoration(
+            borderRadius: widget.borderRadius,
+            border: Border.all(
+              color: isActive ? style.focusStrokeColor : Colors.transparent,
+              width: style.focusStrokeWidth,
+              strokeAlign: BorderSide.strokeAlignInside,
+            ),
+          ),
+          child: IconTheme.merge(
+            data: IconThemeData(color: contentColor),
+            child: DefaultTextStyle.merge(
+              style: TextStyle(color: contentColor),
+              child: widget.child,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/themes/nipaplay/widgets/large_screen_home_page.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_home_page.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+import 'package:nipaplay/pages/dashboard_home_page.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/directional_focus_scope.dart';
+
+class NipaplayLargeScreenHomePage extends StatelessWidget {
+  const NipaplayLargeScreenHomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const NipaplayDirectionalFocusScope(
+      child: DashboardHomePage(),
+    );
+  }
+}

--- a/lib/themes/nipaplay/widgets/large_screen_home_page.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_home_page.dart
@@ -1,14 +1,45 @@
 import 'package:flutter/material.dart';
 import 'package:nipaplay/pages/dashboard_home_page.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/directional_focus_scope.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_home_scope.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_navigation_intents.dart';
 
 class NipaplayLargeScreenHomePage extends StatelessWidget {
   const NipaplayLargeScreenHomePage({super.key});
 
+  void _handleBoundaryScroll(
+      BuildContext context, TraversalDirection direction) {
+    final focusContext = FocusManager.instance.primaryFocus?.context;
+    final scrollController =
+        PrimaryScrollController.maybeOf(focusContext ?? context);
+    if (scrollController == null || !scrollController.hasClients) {
+      return;
+    }
+    final target = direction == TraversalDirection.up
+        ? scrollController.position.minScrollExtent
+        : scrollController.position.maxScrollExtent;
+    scrollController.jumpTo(target);
+  }
+
   @override
   Widget build(BuildContext context) {
-    return const NipaplayDirectionalFocusScope(
-      child: DashboardHomePage(),
+    return NipaplayLargeScreenHomeScope(
+      child: Actions(
+        actions: <Type, Action<Intent>>{
+          NipaplayScrollBoundaryIntent:
+              CallbackAction<NipaplayScrollBoundaryIntent>(
+            onInvoke: (intent) {
+              _handleBoundaryScroll(context, intent.direction);
+              return null;
+            },
+          ),
+        },
+        child: NipaplayDirectionalFocusScope(
+          onBoundaryReached: (direction) =>
+              _handleBoundaryScroll(context, direction),
+          child: const DashboardHomePage(),
+        ),
+      ),
     );
   }
 }

--- a/lib/themes/nipaplay/widgets/large_screen_home_scope.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_home_scope.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/widgets.dart';
+
+class NipaplayLargeScreenHomeScope extends InheritedWidget {
+  const NipaplayLargeScreenHomeScope({
+    super.key,
+    required super.child,
+  });
+
+  static bool isActive(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<
+            NipaplayLargeScreenHomeScope>() !=
+        null;
+  }
+
+  @override
+  bool updateShouldNotify(covariant NipaplayLargeScreenHomeScope oldWidget) {
+    return false;
+  }
+}

--- a/lib/themes/nipaplay/widgets/large_screen_input_controls.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_input_controls.dart
@@ -4,6 +4,8 @@ enum NipaplayLargeScreenInputCommand {
   toggleMenu,
   navigateUp,
   navigateDown,
+  navigateLeft,
+  navigateRight,
   activate,
 }
 
@@ -31,6 +33,14 @@ class NipaplayLargeScreenInputControls {
     LogicalKeyboardKey.gameButtonA,
   };
 
+  static final Set<LogicalKeyboardKey> _navigateLeftKeys = {
+    LogicalKeyboardKey.arrowLeft,
+  };
+
+  static final Set<LogicalKeyboardKey> _navigateRightKeys = {
+    LogicalKeyboardKey.arrowRight,
+  };
+
   static NipaplayLargeScreenInputCommand? fromKeyEvent(KeyEvent event) {
     if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
       return null;
@@ -45,6 +55,12 @@ class NipaplayLargeScreenInputControls {
     }
     if (_navigateDownKeys.contains(key)) {
       return NipaplayLargeScreenInputCommand.navigateDown;
+    }
+    if (_navigateLeftKeys.contains(key)) {
+      return NipaplayLargeScreenInputCommand.navigateLeft;
+    }
+    if (_navigateRightKeys.contains(key)) {
+      return NipaplayLargeScreenInputCommand.navigateRight;
     }
     if (_activateKeys.contains(key)) {
       return NipaplayLargeScreenInputCommand.activate;

--- a/lib/themes/nipaplay/widgets/large_screen_input_controls.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_input_controls.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/services.dart';
+
+enum NipaplayLargeScreenInputCommand {
+  toggleMenu,
+  navigateUp,
+  navigateDown,
+  activate,
+}
+
+class NipaplayLargeScreenInputControls {
+  const NipaplayLargeScreenInputControls._();
+
+  static final Set<LogicalKeyboardKey> _toggleMenuKeys = {
+    LogicalKeyboardKey.escape,
+    LogicalKeyboardKey.gameButtonSelect,
+    LogicalKeyboardKey.gameButtonStart,
+  };
+
+  static final Set<LogicalKeyboardKey> _navigateUpKeys = {
+    LogicalKeyboardKey.arrowUp,
+  };
+
+  static final Set<LogicalKeyboardKey> _navigateDownKeys = {
+    LogicalKeyboardKey.arrowDown,
+  };
+
+  static final Set<LogicalKeyboardKey> _activateKeys = {
+    LogicalKeyboardKey.enter,
+    LogicalKeyboardKey.numpadEnter,
+    LogicalKeyboardKey.select,
+    LogicalKeyboardKey.gameButtonA,
+  };
+
+  static NipaplayLargeScreenInputCommand? fromKeyEvent(KeyEvent event) {
+    if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
+      return null;
+    }
+
+    final key = event.logicalKey;
+    if (_toggleMenuKeys.contains(key)) {
+      return NipaplayLargeScreenInputCommand.toggleMenu;
+    }
+    if (_navigateUpKeys.contains(key)) {
+      return NipaplayLargeScreenInputCommand.navigateUp;
+    }
+    if (_navigateDownKeys.contains(key)) {
+      return NipaplayLargeScreenInputCommand.navigateDown;
+    }
+    if (_activateKeys.contains(key)) {
+      return NipaplayLargeScreenInputCommand.activate;
+    }
+    return null;
+  }
+}

--- a/lib/themes/nipaplay/widgets/large_screen_mode_actions.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_mode_actions.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:nipaplay/l10n/l10n.dart';
-import 'package:nipaplay/themes/nipaplay/widgets/large_screen_side_panel.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/menu_button.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/system_resource_display.dart';
 import 'package:nipaplay/utils/theme_notifier.dart';
@@ -50,25 +49,13 @@ class NipaplayLargeScreenModeActionsOverlay extends StatelessWidget {
         : null;
 
     if (isLargeScreenLayoutActive) {
-      return Stack(
-        children: [
-          Positioned(
-            left: 0,
-            bottom: 0,
-            child: _LargeModeActionPanel(
-              isDarkMode: isDarkMode,
-              onToggleLargeScreen: onToggleLargeScreen,
-              onToggleThemeFromOrigin: onToggleThemeFromOrigin,
-              onOpenSettings: onOpenSettings,
-            ),
-          ),
-          if (windowButtons != null)
-            Positioned(
-              top: topPadding,
-              right: rightPadding,
-              child: windowButtons,
-            ),
-        ],
+      if (windowButtons == null) {
+        return const SizedBox.shrink();
+      }
+      return Positioned(
+        top: topPadding,
+        right: rightPadding,
+        child: windowButtons,
       );
     }
 
@@ -92,111 +79,6 @@ class NipaplayLargeScreenModeActionsOverlay extends StatelessWidget {
             const SizedBox(width: 8),
             windowButtons,
           ],
-        ],
-      ),
-    );
-  }
-}
-
-class _LargeModeActionPanel extends StatelessWidget {
-  const _LargeModeActionPanel({
-    required this.isDarkMode,
-    required this.onToggleLargeScreen,
-    required this.onToggleThemeFromOrigin,
-    required this.onOpenSettings,
-  });
-
-  final bool isDarkMode;
-  final VoidCallback onToggleLargeScreen;
-  final Future<void> Function(Offset globalOrigin)? onToggleThemeFromOrigin;
-  final VoidCallback onOpenSettings;
-
-  @override
-  Widget build(BuildContext context) {
-    final String themeActionLabel = isDarkMode
-        ? context.l10n.toggleToLightMode
-        : context.l10n.toggleToDarkMode;
-    final IconData themeActionIcon = isDarkMode
-        ? Icons.nightlight_rounded
-        : Icons.light_mode_rounded;
-
-    return NipaplayLargeScreenSidePanel(
-      isDarkMode: isDarkMode,
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          NipaplayLargeScreenSidePanelItem(
-            isSelected: false,
-            activeColor: const Color(0xFFFF2E55),
-            inactiveColor: isDarkMode ? Colors.white60 : Colors.black54,
-            onTap: onToggleLargeScreen,
-            child: Row(
-              children: const [
-                Icon(Icons.view_day_rounded, size: 20),
-                SizedBox(width: 8),
-                Expanded(
-                  child: Text(
-                    '退出大屏幕模式',
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ),
-          NipaplayLargeScreenSidePanelItem(
-            isSelected: false,
-            activeColor: const Color(0xFFFF2E55),
-            inactiveColor: isDarkMode ? Colors.white60 : Colors.black54,
-            onTap: () => _toggleTheme(
-              context,
-              onToggleFromOrigin: onToggleThemeFromOrigin,
-            ),
-            child: Row(
-              children: [
-                Icon(themeActionIcon, size: 20),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: Text(
-                    themeActionLabel,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: const TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ),
-          NipaplayLargeScreenSidePanelItem(
-            isSelected: false,
-            activeColor: const Color(0xFFFF2E55),
-            inactiveColor: isDarkMode ? Colors.white60 : Colors.black54,
-            onTap: onOpenSettings,
-            child: Row(
-              children: [
-                const Icon(Icons.settings_rounded, size: 20),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: Text(
-                    context.l10n.settingsLabel,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: const TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ),
         ],
       ),
     );

--- a/lib/themes/nipaplay/widgets/large_screen_mode_actions.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_mode_actions.dart
@@ -1,0 +1,519 @@
+import 'package:flutter/material.dart';
+import 'package:nipaplay/l10n/l10n.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_side_panel.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/menu_button.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/system_resource_display.dart';
+import 'package:nipaplay/utils/theme_notifier.dart';
+import 'package:provider/provider.dart';
+
+const double kNipaplayWindowCaptionHeight = 28;
+
+class NipaplayLargeScreenModeActionsOverlay extends StatelessWidget {
+  const NipaplayLargeScreenModeActionsOverlay({
+    super.key,
+    required this.isDarkMode,
+    required this.isLargeScreenLayoutActive,
+    required this.topPadding,
+    required this.rightPadding,
+    required this.showWindowsButtons,
+    required this.isMaximized,
+    required this.onToggleLargeScreen,
+    required this.onToggleThemeFromOrigin,
+    required this.onOpenSettings,
+    required this.onMinimize,
+    required this.onMaximizeRestore,
+    required this.onClose,
+  });
+
+  final bool isDarkMode;
+  final bool isLargeScreenLayoutActive;
+  final double topPadding;
+  final double rightPadding;
+  final bool showWindowsButtons;
+  final bool isMaximized;
+  final VoidCallback onToggleLargeScreen;
+  final Future<void> Function(Offset globalOrigin)? onToggleThemeFromOrigin;
+  final VoidCallback onOpenSettings;
+  final VoidCallback onMinimize;
+  final VoidCallback onMaximizeRestore;
+  final VoidCallback onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    final windowButtons = showWindowsButtons
+        ? buildWindowsWindowControlButtons(
+            isMaximized: isMaximized,
+            onMinimize: onMinimize,
+            onMaximizeRestore: onMaximizeRestore,
+            onClose: onClose,
+          )
+        : null;
+
+    if (isLargeScreenLayoutActive) {
+      return Stack(
+        children: [
+          Positioned(
+            left: 0,
+            bottom: 0,
+            child: _LargeModeActionPanel(
+              isDarkMode: isDarkMode,
+              onToggleLargeScreen: onToggleLargeScreen,
+              onToggleThemeFromOrigin: onToggleThemeFromOrigin,
+              onOpenSettings: onOpenSettings,
+            ),
+          ),
+          if (windowButtons != null)
+            Positioned(
+              top: topPadding,
+              right: rightPadding,
+              child: windowButtons,
+            ),
+        ],
+      );
+    }
+
+    return Positioned(
+      top: topPadding,
+      right: rightPadding,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const SystemResourceDisplay(),
+          const SizedBox(width: 8),
+          _NormalModeActionButtons(
+            isDarkMode: isDarkMode,
+            isLargeScreenLayoutActive: isLargeScreenLayoutActive,
+            onToggleLargeScreen: onToggleLargeScreen,
+            onToggleThemeFromOrigin: onToggleThemeFromOrigin,
+            onOpenSettings: onOpenSettings,
+          ),
+          if (windowButtons != null) ...[
+            const SizedBox(width: 8),
+            windowButtons,
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _LargeModeActionPanel extends StatelessWidget {
+  const _LargeModeActionPanel({
+    required this.isDarkMode,
+    required this.onToggleLargeScreen,
+    required this.onToggleThemeFromOrigin,
+    required this.onOpenSettings,
+  });
+
+  final bool isDarkMode;
+  final VoidCallback onToggleLargeScreen;
+  final Future<void> Function(Offset globalOrigin)? onToggleThemeFromOrigin;
+  final VoidCallback onOpenSettings;
+
+  @override
+  Widget build(BuildContext context) {
+    final String themeActionLabel = isDarkMode
+        ? context.l10n.toggleToLightMode
+        : context.l10n.toggleToDarkMode;
+    final IconData themeActionIcon = isDarkMode
+        ? Icons.nightlight_rounded
+        : Icons.light_mode_rounded;
+
+    return NipaplayLargeScreenSidePanel(
+      isDarkMode: isDarkMode,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          NipaplayLargeScreenSidePanelItem(
+            isSelected: false,
+            activeColor: const Color(0xFFFF2E55),
+            inactiveColor: isDarkMode ? Colors.white60 : Colors.black54,
+            onTap: onToggleLargeScreen,
+            child: Row(
+              children: const [
+                Icon(Icons.view_day_rounded, size: 20),
+                SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    '退出大屏幕模式',
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          NipaplayLargeScreenSidePanelItem(
+            isSelected: false,
+            activeColor: const Color(0xFFFF2E55),
+            inactiveColor: isDarkMode ? Colors.white60 : Colors.black54,
+            onTap: () => _toggleTheme(
+              context,
+              onToggleFromOrigin: onToggleThemeFromOrigin,
+            ),
+            child: Row(
+              children: [
+                Icon(themeActionIcon, size: 20),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    themeActionLabel,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          NipaplayLargeScreenSidePanelItem(
+            isSelected: false,
+            activeColor: const Color(0xFFFF2E55),
+            inactiveColor: isDarkMode ? Colors.white60 : Colors.black54,
+            onTap: onOpenSettings,
+            child: Row(
+              children: [
+                const Icon(Icons.settings_rounded, size: 20),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    context.l10n.settingsLabel,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class LargeScreenModeToggleIconButton extends StatefulWidget {
+  const LargeScreenModeToggleIconButton({
+    super.key,
+    required this.isActive,
+    required this.onPressed,
+  });
+
+  final bool isActive;
+  final VoidCallback onPressed;
+
+  @override
+  State<LargeScreenModeToggleIconButton> createState() =>
+      _LargeScreenModeToggleIconButtonState();
+}
+
+class _LargeScreenModeToggleIconButtonState
+    extends State<LargeScreenModeToggleIconButton> {
+  bool _isHovered = false;
+  bool _isPressed = false;
+
+  void _setHovered(bool value) {
+    if (_isHovered == value) return;
+    setState(() {
+      _isHovered = value;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isDarkMode = Theme.of(context).brightness == Brightness.dark;
+    final bool isActive = widget.isActive;
+    final double scale = _isPressed ? 0.92 : (_isHovered ? 1.1 : 1.0);
+    final Color iconColor = isActive
+        ? const Color(0xFFFF2E55)
+        : (_isHovered
+            ? const Color(0xFFFF2E55)
+            : (isDarkMode ? Colors.white : Colors.black87));
+    final icon = isActive ? Icons.view_day_rounded : Icons.view_sidebar_rounded;
+
+    return Tooltip(
+      message: isActive ? '退出大屏幕模式' : '大屏幕模式',
+      child: MouseRegion(
+        onEnter: (_) => _setHovered(true),
+        onExit: (_) => _setHovered(false),
+        child: GestureDetector(
+          onTapDown: (_) => setState(() => _isPressed = true),
+          onTapUp: (_) => setState(() => _isPressed = false),
+          onTapCancel: () => setState(() => _isPressed = false),
+          onTap: widget.onPressed,
+          child: AnimatedScale(
+            scale: scale,
+            duration: const Duration(milliseconds: 120),
+            child: Icon(
+              icon,
+              size: 22,
+              color: iconColor,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _NormalModeActionButtons extends StatelessWidget {
+  const _NormalModeActionButtons({
+    required this.isDarkMode,
+    required this.isLargeScreenLayoutActive,
+    required this.onToggleLargeScreen,
+    required this.onToggleThemeFromOrigin,
+    required this.onOpenSettings,
+  });
+
+  final bool isDarkMode;
+  final bool isLargeScreenLayoutActive;
+  final VoidCallback onToggleLargeScreen;
+  final Future<void> Function(Offset globalOrigin)? onToggleThemeFromOrigin;
+  final VoidCallback onOpenSettings;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox(
+          height: kNipaplayWindowCaptionHeight,
+          child: Center(
+            child: Image.asset(
+              'assets/logo2.png',
+              height: 24,
+              fit: BoxFit.contain,
+              color: isDarkMode ? Colors.white : Colors.black,
+              colorBlendMode: BlendMode.srcIn,
+            ),
+          ),
+        ),
+        const SizedBox(width: 8),
+        SizedBox(
+          height: kNipaplayWindowCaptionHeight,
+          child: Center(
+            child: LargeScreenModeToggleIconButton(
+              isActive: isLargeScreenLayoutActive,
+              onPressed: onToggleLargeScreen,
+            ),
+          ),
+        ),
+        const SizedBox(width: 8),
+        SizedBox(
+          height: kNipaplayWindowCaptionHeight,
+          child: Center(
+            child: _ThemeToggleIconButton(
+              onToggleFromOrigin: onToggleThemeFromOrigin,
+            ),
+          ),
+        ),
+        const SizedBox(width: 8),
+        SizedBox(
+          height: kNipaplayWindowCaptionHeight,
+          child: Center(
+            child: _SettingsIconButton(
+              onPressed: onOpenSettings,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ThemeToggleIconButton extends StatefulWidget {
+  const _ThemeToggleIconButton({this.onToggleFromOrigin});
+
+  final Future<void> Function(Offset globalOrigin)? onToggleFromOrigin;
+
+  @override
+  State<_ThemeToggleIconButton> createState() => _ThemeToggleIconButtonState();
+}
+
+class _ThemeToggleIconButtonState extends State<_ThemeToggleIconButton> {
+  bool _isHovered = false;
+  bool _isPressed = false;
+
+  void _setHovered(bool value) {
+    if (_isHovered == value) return;
+    setState(() {
+      _isHovered = value;
+    });
+  }
+
+  void _setPressed(bool value) {
+    if (_isPressed == value) return;
+    setState(() {
+      _isPressed = value;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isDarkMode = Theme.of(context).brightness == Brightness.dark;
+    final double scale = _isPressed ? 0.92 : (_isHovered ? 1.1 : 1.0);
+    final Color iconColor = _isHovered
+        ? const Color(0xFFFF2E55)
+        : (isDarkMode ? Colors.white : Colors.black87);
+    final icon =
+        isDarkMode ? Icons.nightlight_rounded : Icons.light_mode_rounded;
+    final tooltip = isDarkMode
+        ? context.l10n.toggleToLightMode
+        : context.l10n.toggleToDarkMode;
+
+    return Tooltip(
+      message: tooltip,
+      child: MouseRegion(
+        onEnter: (_) => _setHovered(true),
+        onExit: (_) => _setHovered(false),
+        child: GestureDetector(
+          onTapDown: (_) => setState(() => _isPressed = true),
+          onTapUp: (_) => _setPressed(false),
+          onTapCancel: () => _setPressed(false),
+          onTap: () => _toggleTheme(
+            context,
+            onToggleFromOrigin: widget.onToggleFromOrigin,
+          ),
+          child: AnimatedScale(
+            scale: scale,
+            duration: const Duration(milliseconds: 120),
+            child: AnimatedSwitcher(
+              duration: const Duration(milliseconds: 320),
+              switchInCurve: Curves.easeOutCubic,
+              switchOutCurve: Curves.easeInCubic,
+              transitionBuilder: (child, animation) {
+                return FadeTransition(
+                  opacity: animation,
+                  child: ScaleTransition(
+                    scale:
+                        Tween<double>(begin: 0.85, end: 1.0).animate(animation),
+                    child: RotationTransition(
+                      turns: Tween<double>(begin: 0.9, end: 1.0)
+                          .animate(animation),
+                      child: child,
+                    ),
+                  ),
+                );
+              },
+              child: Icon(
+                icon,
+                key: ValueKey<bool>(isDarkMode),
+                size: 22,
+                color: iconColor,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SettingsIconButton extends StatefulWidget {
+  const _SettingsIconButton({required this.onPressed});
+
+  final VoidCallback onPressed;
+
+  @override
+  State<_SettingsIconButton> createState() => _SettingsIconButtonState();
+}
+
+class _SettingsIconButtonState extends State<_SettingsIconButton> {
+  bool _isHovered = false;
+  bool _isPressed = false;
+
+  void _setHovered(bool value) {
+    if (_isHovered == value) return;
+    setState(() {
+      _isHovered = value;
+    });
+  }
+
+  void _setPressed(bool value) {
+    if (_isPressed == value) return;
+    setState(() {
+      _isPressed = value;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isDarkMode = Theme.of(context).brightness == Brightness.dark;
+    final double scale = _isPressed ? 0.92 : (_isHovered ? 1.1 : 1.0);
+    final Color iconColor = _isHovered
+        ? const Color(0xFFFF2E55)
+        : (isDarkMode ? Colors.white : Colors.black87);
+
+    return Tooltip(
+      message: context.l10n.settingsLabel,
+      child: MouseRegion(
+        onEnter: (_) => _setHovered(true),
+        onExit: (_) => _setHovered(false),
+        child: GestureDetector(
+          onTapDown: (_) => _setPressed(true),
+          onTapUp: (_) => _setPressed(false),
+          onTapCancel: () => _setPressed(false),
+          onTap: widget.onPressed,
+          child: AnimatedScale(
+            scale: scale,
+            duration: const Duration(milliseconds: 120),
+            child: Icon(
+              Icons.settings_rounded,
+              size: 22,
+              color: iconColor,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+void _toggleTheme(
+  BuildContext context, {
+  Future<void> Function(Offset globalOrigin)? onToggleFromOrigin,
+}) {
+  if (onToggleFromOrigin != null) {
+    final renderObject = context.findRenderObject();
+    if (renderObject is RenderBox && renderObject.hasSize) {
+      final origin = renderObject.localToGlobal(renderObject.size.center(Offset.zero));
+      onToggleFromOrigin(origin);
+      return;
+    }
+  }
+
+  final isDarkMode = Theme.of(context).brightness == Brightness.dark;
+  context.read<ThemeNotifier>().themeMode =
+      isDarkMode ? ThemeMode.light : ThemeMode.dark;
+}
+
+Widget buildWindowsWindowControlButtons({
+  required bool isMaximized,
+  required VoidCallback onMinimize,
+  required VoidCallback onMaximizeRestore,
+  required VoidCallback onClose,
+}) {
+  return SizedBox(
+    height: kNipaplayWindowCaptionHeight,
+    child: Center(
+      child: WindowControlButtons(
+        isMaximized: isMaximized,
+        onMinimize: onMinimize,
+        onMaximizeRestore: onMaximizeRestore,
+        onClose: onClose,
+      ),
+    ),
+  );
+}

--- a/lib/themes/nipaplay/widgets/large_screen_mode_actions.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_mode_actions.dart
@@ -16,7 +16,7 @@ class NipaplayLargeScreenModeActionsOverlay extends StatelessWidget {
     required this.rightPadding,
     required this.showWindowsButtons,
     required this.isMaximized,
-    required this.onToggleLargeScreen,
+    this.onToggleLargeScreen,
     required this.onToggleThemeFromOrigin,
     required this.onOpenSettings,
     required this.onMinimize,
@@ -30,7 +30,7 @@ class NipaplayLargeScreenModeActionsOverlay extends StatelessWidget {
   final double rightPadding;
   final bool showWindowsButtons;
   final bool isMaximized;
-  final VoidCallback onToggleLargeScreen;
+  final VoidCallback? onToggleLargeScreen;
   final Future<void> Function(Offset globalOrigin)? onToggleThemeFromOrigin;
   final VoidCallback onOpenSettings;
   final VoidCallback onMinimize;
@@ -153,14 +153,14 @@ class _NormalModeActionButtons extends StatelessWidget {
   const _NormalModeActionButtons({
     required this.isDarkMode,
     required this.isLargeScreenLayoutActive,
-    required this.onToggleLargeScreen,
+    this.onToggleLargeScreen,
     required this.onToggleThemeFromOrigin,
     required this.onOpenSettings,
   });
 
   final bool isDarkMode;
   final bool isLargeScreenLayoutActive;
-  final VoidCallback onToggleLargeScreen;
+  final VoidCallback? onToggleLargeScreen;
   final Future<void> Function(Offset globalOrigin)? onToggleThemeFromOrigin;
   final VoidCallback onOpenSettings;
 
@@ -183,16 +183,18 @@ class _NormalModeActionButtons extends StatelessWidget {
           ),
         ),
         const SizedBox(width: 8),
-        SizedBox(
-          height: kNipaplayWindowCaptionHeight,
-          child: Center(
-            child: LargeScreenModeToggleIconButton(
-              isActive: isLargeScreenLayoutActive,
-              onPressed: onToggleLargeScreen,
+        if (onToggleLargeScreen != null) ...[
+          SizedBox(
+            height: kNipaplayWindowCaptionHeight,
+            child: Center(
+              child: LargeScreenModeToggleIconButton(
+                isActive: isLargeScreenLayoutActive,
+                onPressed: onToggleLargeScreen!,
+              ),
             ),
           ),
-        ),
-        const SizedBox(width: 8),
+          const SizedBox(width: 8),
+        ],
         SizedBox(
           height: kNipaplayWindowCaptionHeight,
           child: Center(
@@ -370,7 +372,8 @@ void _toggleTheme(
   if (onToggleFromOrigin != null) {
     final renderObject = context.findRenderObject();
     if (renderObject is RenderBox && renderObject.hasSize) {
-      final origin = renderObject.localToGlobal(renderObject.size.center(Offset.zero));
+      final origin =
+          renderObject.localToGlobal(renderObject.size.center(Offset.zero));
       onToggleFromOrigin(origin);
       return;
     }

--- a/lib/themes/nipaplay/widgets/large_screen_mode_preferences.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_mode_preferences.dart
@@ -1,0 +1,17 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class LargeScreenModePreferences {
+  LargeScreenModePreferences._();
+
+  static const String key = 'nipaplay_use_large_screen_layout';
+
+  static Future<bool> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(key) ?? false;
+  }
+
+  static Future<void> save(bool enabled) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(key, enabled);
+  }
+}

--- a/lib/themes/nipaplay/widgets/large_screen_mode_scope.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_mode_scope.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/widgets.dart';
+
+class NipaplayLargeScreenModeScope extends InheritedWidget {
+  const NipaplayLargeScreenModeScope({
+    super.key,
+    required this.isActive,
+    required super.child,
+  });
+
+  final bool isActive;
+
+  static bool isActiveOf(BuildContext context) {
+    return context
+            .dependOnInheritedWidgetOfExactType<NipaplayLargeScreenModeScope>()
+            ?.isActive ==
+        true;
+  }
+
+  @override
+  bool updateShouldNotify(covariant NipaplayLargeScreenModeScope oldWidget) {
+    return isActive != oldWidget.isActive;
+  }
+}

--- a/lib/themes/nipaplay/widgets/large_screen_navigation_intents.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_navigation_intents.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/widgets.dart';
+
+class NipaplayScrollBoundaryIntent extends Intent {
+  const NipaplayScrollBoundaryIntent(this.direction);
+
+  final TraversalDirection direction;
+}

--- a/lib/themes/nipaplay/widgets/large_screen_network_status.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_network_status.dart
@@ -1,0 +1,14 @@
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_network_status_stub.dart'
+    if (dart.library.io)
+        'package:nipaplay/themes/nipaplay/widgets/large_screen_network_status_io.dart'
+    as impl;
+
+enum LargeScreenNetworkKind {
+  unavailable,
+  wifi,
+  cellular,
+}
+
+Future<LargeScreenNetworkKind> detectLargeScreenNetworkKind() {
+  return impl.detectLargeScreenNetworkKind();
+}

--- a/lib/themes/nipaplay/widgets/large_screen_network_status_io.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_network_status_io.dart
@@ -1,0 +1,32 @@
+import 'dart:io';
+
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_network_status.dart';
+
+Future<LargeScreenNetworkKind> detectLargeScreenNetworkKind() async {
+  try {
+    final interfaces = await NetworkInterface.list(
+      includeLinkLocal: true,
+      type: InternetAddressType.any,
+    );
+
+    for (final interface in interfaces) {
+      final name = interface.name.toLowerCase();
+      if (name.contains('wlan') ||
+          name.contains('wifi') ||
+          name.contains('wi-fi') ||
+          name.contains('en0')) {
+        return LargeScreenNetworkKind.wifi;
+      }
+    }
+
+    for (final interface in interfaces) {
+      if (interface.addresses.isNotEmpty) {
+        return LargeScreenNetworkKind.cellular;
+      }
+    }
+  } catch (_) {
+    return LargeScreenNetworkKind.unavailable;
+  }
+
+  return LargeScreenNetworkKind.unavailable;
+}

--- a/lib/themes/nipaplay/widgets/large_screen_network_status_stub.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_network_status_stub.dart
@@ -1,0 +1,5 @@
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_network_status.dart';
+
+Future<LargeScreenNetworkKind> detectLargeScreenNetworkKind() async {
+  return LargeScreenNetworkKind.unavailable;
+}

--- a/lib/themes/nipaplay/widgets/large_screen_scaffold_layout.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_scaffold_layout.dart
@@ -3,6 +3,7 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/large_screen_bottom_hint_overlay.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/large_screen_input_controls.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_settings_panel.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/large_screen_tab_panel.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/large_screen_top_status_overlay.dart';
 
@@ -38,8 +39,13 @@ class _NipaplayLargeScreenScaffoldLayoutState
   late final FocusNode _inputFocusNode;
   late final ValueNotifier<NipaplayLargeScreenTabPanelCommand?>
       _tabPanelCommand;
+  late final ValueNotifier<NipaplayLargeScreenSettingsPanelCommand?>
+      _settingsPanelCommand;
   bool _isTabPanelVisible = false;
+  bool _isSettingsPanelVisible = false;
   int _focusedMenuIndex = 0;
+  int _focusedSettingsIndex = 0;
+  int _settingsEntryCount = 0;
 
   int get _menuItemCount {
     final int actionCount = [
@@ -55,6 +61,8 @@ class _NipaplayLargeScreenScaffoldLayoutState
     super.initState();
     _inputFocusNode = FocusNode(debugLabel: 'nipaplay_large_screen_input');
     _tabPanelCommand = ValueNotifier<NipaplayLargeScreenTabPanelCommand?>(null);
+    _settingsPanelCommand =
+        ValueNotifier<NipaplayLargeScreenSettingsPanelCommand?>(null);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) {
         return;
@@ -65,6 +73,7 @@ class _NipaplayLargeScreenScaffoldLayoutState
 
   @override
   void dispose() {
+    _settingsPanelCommand.dispose();
     _tabPanelCommand.dispose();
     _inputFocusNode.dispose();
     super.dispose();
@@ -84,6 +93,9 @@ class _NipaplayLargeScreenScaffoldLayoutState
   }
 
   void _toggleTabPanel() {
+    if (_isSettingsPanelVisible) {
+      _closeSettingsPanel();
+    }
     setState(() {
       final bool nextVisible = !_isTabPanelVisible;
       _isTabPanelVisible = nextVisible;
@@ -108,11 +120,45 @@ class _NipaplayLargeScreenScaffoldLayoutState
     _ensureContentFocus();
   }
 
+  void _toggleSettingsPanel() {
+    if (_isTabPanelVisible) {
+      _closeTabPanel();
+    }
+    setState(() {
+      _isSettingsPanelVisible = !_isSettingsPanelVisible;
+      if (_isSettingsPanelVisible) {
+        _focusedSettingsIndex = _clampSettingsIndex(_focusedSettingsIndex);
+      }
+    });
+    if (_isSettingsPanelVisible) {
+      _inputFocusNode.requestFocus();
+    } else {
+      _ensureContentFocus();
+    }
+  }
+
+  void _closeSettingsPanel() {
+    if (!_isSettingsPanelVisible) {
+      return;
+    }
+    setState(() {
+      _isSettingsPanelVisible = false;
+    });
+    _ensureContentFocus();
+  }
+
   int _clampMenuIndex(int index) {
     if (_menuItemCount <= 0) {
       return 0;
     }
     return index.clamp(0, _menuItemCount - 1);
+  }
+
+  int _clampSettingsIndex(int index) {
+    if (_settingsEntryCount <= 0) {
+      return 0;
+    }
+    return index.clamp(0, _settingsEntryCount - 1);
   }
 
   void _moveMenuFocus(int delta) {
@@ -138,6 +184,12 @@ class _NipaplayLargeScreenScaffoldLayoutState
     // Activation is delegated to the panel to keep input logic decoupled from UI/actions.
     _tabPanelCommand.value = null;
     _tabPanelCommand.value = NipaplayLargeScreenTabPanelCommand.activateFocused;
+  }
+
+  void _dispatchSettingsPanelCommand(
+      NipaplayLargeScreenSettingsPanelCommand command) {
+    _settingsPanelCommand.value = null;
+    _settingsPanelCommand.value = command;
   }
 
   void _jumpContentScrollBoundary(TraversalDirection direction) {
@@ -208,6 +260,39 @@ class _NipaplayLargeScreenScaffoldLayoutState
       return KeyEventResult.ignored;
     }
 
+    if (_isSettingsPanelVisible) {
+      switch (command) {
+        case NipaplayLargeScreenInputCommand.toggleMenu:
+          _closeSettingsPanel();
+          return KeyEventResult.handled;
+        case NipaplayLargeScreenInputCommand.navigateUp:
+          _dispatchSettingsPanelCommand(
+            NipaplayLargeScreenSettingsPanelCommand.navigateUp,
+          );
+          return KeyEventResult.handled;
+        case NipaplayLargeScreenInputCommand.navigateDown:
+          _dispatchSettingsPanelCommand(
+            NipaplayLargeScreenSettingsPanelCommand.navigateDown,
+          );
+          return KeyEventResult.handled;
+        case NipaplayLargeScreenInputCommand.navigateLeft:
+          _dispatchSettingsPanelCommand(
+            NipaplayLargeScreenSettingsPanelCommand.navigateLeft,
+          );
+          return KeyEventResult.handled;
+        case NipaplayLargeScreenInputCommand.navigateRight:
+          _dispatchSettingsPanelCommand(
+            NipaplayLargeScreenSettingsPanelCommand.navigateRight,
+          );
+          return KeyEventResult.handled;
+        case NipaplayLargeScreenInputCommand.activate:
+          _dispatchSettingsPanelCommand(
+            NipaplayLargeScreenSettingsPanelCommand.activateFocused,
+          );
+          return KeyEventResult.handled;
+      }
+    }
+
     switch (command) {
       case NipaplayLargeScreenInputCommand.toggleMenu:
         _toggleTabPanel();
@@ -256,6 +341,7 @@ class _NipaplayLargeScreenScaffoldLayoutState
   @override
   Widget build(BuildContext context) {
     final mediaPadding = MediaQuery.of(context).padding;
+    final bool showPanelBackdrop = _isTabPanelVisible || _isSettingsPanelVisible;
 
     return Focus(
       focusNode: _inputFocusNode,
@@ -279,11 +365,17 @@ class _NipaplayLargeScreenScaffoldLayoutState
               ),
             ),
           ),
-          if (_isTabPanelVisible)
+          if (showPanelBackdrop)
             Positioned.fill(
               child: GestureDetector(
                 behavior: HitTestBehavior.translucent,
-                onTap: _closeTabPanel,
+                onTap: () {
+                  if (_isSettingsPanelVisible) {
+                    _closeSettingsPanel();
+                    return;
+                  }
+                  _closeTabPanel();
+                },
                 child: ClipRect(
                   child: BackdropFilter(
                     filter: ImageFilter.blur(sigmaX: 25, sigmaY: 25),
@@ -322,7 +414,46 @@ class _NipaplayLargeScreenScaffoldLayoutState
                 onTabActivated: _closeTabPanel,
                 onToggleLargeScreen: widget.onToggleLargeScreen,
                 onToggleThemeFromOrigin: widget.onToggleThemeFromOrigin,
-                onOpenSettings: widget.onOpenSettings,
+                onOpenSettings: _toggleSettingsPanel,
+              ),
+            ),
+          ),
+          AnimatedPositioned(
+            duration: const Duration(milliseconds: 240),
+            curve: Curves.easeOutCubic,
+            right: _isSettingsPanelVisible
+                ? 0
+                : -kNipaplayLargeScreenSettingsPanelWidth,
+            top: 0,
+            bottom: 0,
+            child: IgnorePointer(
+              ignoring: !_isSettingsPanelVisible,
+              child: SizedBox(
+                width: kNipaplayLargeScreenSettingsPanelWidth,
+                child: NipaplayLargeScreenSettingsPanel(
+                  isDarkMode: widget.isDarkMode,
+                  focusedIndex: _focusedSettingsIndex,
+                  commandNotifier: _settingsPanelCommand,
+                  onFocusedIndexChanged: (index) {
+                    if (_focusedSettingsIndex == index) {
+                      return;
+                    }
+                    setState(() {
+                      _focusedSettingsIndex = _clampSettingsIndex(index);
+                    });
+                  },
+                  onEntryCountChanged: (count) {
+                    if (_settingsEntryCount == count) {
+                      return;
+                    }
+                    setState(() {
+                      _settingsEntryCount = count;
+                      _focusedSettingsIndex =
+                          _clampSettingsIndex(_focusedSettingsIndex);
+                    });
+                  },
+                  onRequestClose: _closeSettingsPanel,
+                ),
               ),
             ),
           ),
@@ -341,6 +472,7 @@ class _NipaplayLargeScreenScaffoldLayoutState
             child: NipaplayLargeScreenBottomHintOverlay(
               isDarkMode: widget.isDarkMode,
               onToggleMenu: _toggleTabPanel,
+              onOpenSettings: _toggleSettingsPanel,
             ),
           ),
         ],

--- a/lib/themes/nipaplay/widgets/large_screen_scaffold_layout.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_scaffold_layout.dart
@@ -91,7 +91,11 @@ class _NipaplayLargeScreenScaffoldLayoutState
         _focusedMenuIndex = _clampMenuIndex(widget.currentIndex);
       }
     });
-    _inputFocusNode.requestFocus();
+    if (_isTabPanelVisible) {
+      _inputFocusNode.requestFocus();
+    } else {
+      _ensureContentFocus();
+    }
   }
 
   void _closeTabPanel() {
@@ -101,7 +105,7 @@ class _NipaplayLargeScreenScaffoldLayoutState
     setState(() {
       _isTabPanelVisible = false;
     });
-    _inputFocusNode.requestFocus();
+    _ensureContentFocus();
   }
 
   int _clampMenuIndex(int index) {
@@ -136,6 +140,39 @@ class _NipaplayLargeScreenScaffoldLayoutState
     _tabPanelCommand.value = NipaplayLargeScreenTabPanelCommand.activateFocused;
   }
 
+  bool _moveContentFocus(TraversalDirection direction) {
+    final focusScope = FocusScope.of(context);
+    final focusedChild = focusScope.focusedChild;
+    if (focusedChild == null || focusedChild == _inputFocusNode) {
+      return focusScope.nextFocus();
+    }
+    return focusedChild.focusInDirection(direction);
+  }
+
+  bool _activateContentFocus() {
+    final focused = FocusManager.instance.primaryFocus;
+    if (focused == null || focused == _inputFocusNode) {
+      return false;
+    }
+    final nodeContext = focused.context;
+    if (nodeContext == null) {
+      return false;
+    }
+    return Actions.maybeInvoke<ActivateIntent>(
+          nodeContext,
+          const ActivateIntent(),
+        ) !=
+        null;
+  }
+
+  void _ensureContentFocus() {
+    final focusScope = FocusScope.of(context);
+    if (focusScope.focusedChild == null ||
+        focusScope.focusedChild == _inputFocusNode) {
+      focusScope.nextFocus();
+    }
+  }
+
   KeyEventResult _handleInputKeyEvent(FocusNode node, KeyEvent event) {
     final command = NipaplayLargeScreenInputControls.fromKeyEvent(event);
     if (command == null) {
@@ -147,23 +184,43 @@ class _NipaplayLargeScreenScaffoldLayoutState
         _toggleTabPanel();
         return KeyEventResult.handled;
       case NipaplayLargeScreenInputCommand.navigateUp:
-        if (!_isTabPanelVisible) {
-          return KeyEventResult.ignored;
+        if (_isTabPanelVisible) {
+          _moveMenuFocus(-1);
+          return KeyEventResult.handled;
         }
-        _moveMenuFocus(-1);
-        return KeyEventResult.handled;
+        return _moveContentFocus(TraversalDirection.up)
+            ? KeyEventResult.handled
+            : KeyEventResult.ignored;
       case NipaplayLargeScreenInputCommand.navigateDown:
-        if (!_isTabPanelVisible) {
-          return KeyEventResult.ignored;
+        if (_isTabPanelVisible) {
+          _moveMenuFocus(1);
+          return KeyEventResult.handled;
         }
-        _moveMenuFocus(1);
-        return KeyEventResult.handled;
+        return _moveContentFocus(TraversalDirection.down)
+            ? KeyEventResult.handled
+            : KeyEventResult.ignored;
+      case NipaplayLargeScreenInputCommand.navigateLeft:
+        if (_isTabPanelVisible) {
+          return KeyEventResult.handled;
+        }
+        return _moveContentFocus(TraversalDirection.left)
+            ? KeyEventResult.handled
+            : KeyEventResult.ignored;
+      case NipaplayLargeScreenInputCommand.navigateRight:
+        if (_isTabPanelVisible) {
+          return KeyEventResult.handled;
+        }
+        return _moveContentFocus(TraversalDirection.right)
+            ? KeyEventResult.handled
+            : KeyEventResult.ignored;
       case NipaplayLargeScreenInputCommand.activate:
-        if (!_isTabPanelVisible) {
-          return KeyEventResult.ignored;
+        if (_isTabPanelVisible) {
+          _activateFocusedMenuItem();
+          return KeyEventResult.handled;
         }
-        _activateFocusedMenuItem();
-        return KeyEventResult.handled;
+        return _activateContentFocus()
+            ? KeyEventResult.handled
+            : KeyEventResult.ignored;
     }
   }
 

--- a/lib/themes/nipaplay/widgets/large_screen_scaffold_layout.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_scaffold_layout.dart
@@ -1,8 +1,11 @@
+import 'dart:ui';
+
 import 'package:flutter/material.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_bottom_hint_overlay.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/large_screen_tab_panel.dart';
 import 'package:nipaplay/utils/globals.dart' as globals;
 
-class NipaplayLargeScreenScaffoldLayout extends StatelessWidget {
+class NipaplayLargeScreenScaffoldLayout extends StatefulWidget {
   const NipaplayLargeScreenScaffoldLayout({
     super.key,
     required this.currentIndex,
@@ -10,6 +13,9 @@ class NipaplayLargeScreenScaffoldLayout extends StatelessWidget {
     required this.tabPage,
     required this.tabController,
     required this.content,
+    this.onToggleLargeScreen,
+    this.onToggleThemeFromOrigin,
+    this.onOpenSettings,
   });
 
   final int currentIndex;
@@ -17,6 +23,33 @@ class NipaplayLargeScreenScaffoldLayout extends StatelessWidget {
   final List<Widget> tabPage;
   final TabController tabController;
   final Widget content;
+  final VoidCallback? onToggleLargeScreen;
+  final Future<void> Function(Offset globalOrigin)? onToggleThemeFromOrigin;
+  final VoidCallback? onOpenSettings;
+
+  @override
+  State<NipaplayLargeScreenScaffoldLayout> createState() =>
+      _NipaplayLargeScreenScaffoldLayoutState();
+}
+
+class _NipaplayLargeScreenScaffoldLayoutState
+    extends State<NipaplayLargeScreenScaffoldLayout> {
+  bool _isTabPanelVisible = false;
+
+  void _toggleTabPanel() {
+    setState(() {
+      _isTabPanelVisible = !_isTabPanelVisible;
+    });
+  }
+
+  void _closeTabPanel() {
+    if (!_isTabPanelVisible) {
+      return;
+    }
+    setState(() {
+      _isTabPanelVisible = false;
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -33,18 +66,53 @@ class NipaplayLargeScreenScaffoldLayout extends StatelessWidget {
               14,
               14 + mediaPadding.bottom,
             ),
-            child: content,
+            child: widget.content,
+          ),
+        ),
+        if (_isTabPanelVisible)
+          Positioned.fill(
+            child: GestureDetector(
+              behavior: HitTestBehavior.translucent,
+              onTap: _closeTabPanel,
+              child: ClipRect(
+                child: BackdropFilter(
+                  filter: ImageFilter.blur(sigmaX: 25, sigmaY: 25),
+                  child: ColoredBox(
+                    color: widget.isDarkMode
+                        ? Colors.black.withValues(alpha: 0.16)
+                        : Colors.white.withValues(alpha: 0.08),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        AnimatedPositioned(
+          duration: const Duration(milliseconds: 240),
+          curve: Curves.easeOutCubic,
+          left: _isTabPanelVisible ? 0 : -kNipaplayLargeScreenTabPanelWidth,
+          top: 0,
+          bottom: 0,
+          child: IgnorePointer(
+            ignoring: !_isTabPanelVisible,
+            child: NipaplayLargeScreenTabPanel(
+              currentIndex: widget.currentIndex,
+              isDarkMode: widget.isDarkMode,
+              tabPage: widget.tabPage,
+              tabController: widget.tabController,
+              onTabActivated: _closeTabPanel,
+              onToggleLargeScreen: widget.onToggleLargeScreen,
+              onToggleThemeFromOrigin: widget.onToggleThemeFromOrigin,
+              onOpenSettings: widget.onOpenSettings,
+            ),
           ),
         ),
         Positioned(
           left: 0,
-          top: 0,
+          right: 0,
           bottom: 0,
-          child: NipaplayLargeScreenTabPanel(
-            currentIndex: currentIndex,
-            isDarkMode: isDarkMode,
-            tabPage: tabPage,
-            tabController: tabController,
+          child: NipaplayLargeScreenBottomHintOverlay(
+            isDarkMode: widget.isDarkMode,
+            onToggleMenu: _toggleTabPanel,
           ),
         ),
       ],

--- a/lib/themes/nipaplay/widgets/large_screen_scaffold_layout.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_scaffold_layout.dart
@@ -2,6 +2,7 @@ import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/large_screen_bottom_hint_overlay.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_input_controls.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/large_screen_tab_panel.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/large_screen_top_status_overlay.dart';
 
@@ -34,12 +35,63 @@ class NipaplayLargeScreenScaffoldLayout extends StatefulWidget {
 
 class _NipaplayLargeScreenScaffoldLayoutState
     extends State<NipaplayLargeScreenScaffoldLayout> {
+  late final FocusNode _inputFocusNode;
+  late final ValueNotifier<NipaplayLargeScreenTabPanelCommand?>
+      _tabPanelCommand;
   bool _isTabPanelVisible = false;
+  int _focusedMenuIndex = 0;
+
+  int get _menuItemCount {
+    final int actionCount = [
+      widget.onToggleLargeScreen,
+      widget.onToggleThemeFromOrigin,
+      widget.onOpenSettings,
+    ].where((callback) => callback != null).length;
+    return widget.tabPage.length + actionCount;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _inputFocusNode = FocusNode(debugLabel: 'nipaplay_large_screen_input');
+    _tabPanelCommand = ValueNotifier<NipaplayLargeScreenTabPanelCommand?>(null);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) {
+        return;
+      }
+      _inputFocusNode.requestFocus();
+    });
+  }
+
+  @override
+  void dispose() {
+    _tabPanelCommand.dispose();
+    _inputFocusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didUpdateWidget(covariant NipaplayLargeScreenScaffoldLayout oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (_menuItemCount == 0) {
+      _focusedMenuIndex = 0;
+      return;
+    }
+    final int maxIndex = _menuItemCount - 1;
+    if (_focusedMenuIndex > maxIndex || _focusedMenuIndex < 0) {
+      _focusedMenuIndex = _focusedMenuIndex.clamp(0, maxIndex);
+    }
+  }
 
   void _toggleTabPanel() {
     setState(() {
-      _isTabPanelVisible = !_isTabPanelVisible;
+      final bool nextVisible = !_isTabPanelVisible;
+      _isTabPanelVisible = nextVisible;
+      if (nextVisible) {
+        _focusedMenuIndex = _clampMenuIndex(widget.currentIndex);
+      }
     });
+    _inputFocusNode.requestFocus();
   }
 
   void _closeTabPanel() {
@@ -49,84 +101,164 @@ class _NipaplayLargeScreenScaffoldLayoutState
     setState(() {
       _isTabPanelVisible = false;
     });
+    _inputFocusNode.requestFocus();
+  }
+
+  int _clampMenuIndex(int index) {
+    if (_menuItemCount <= 0) {
+      return 0;
+    }
+    return index.clamp(0, _menuItemCount - 1);
+  }
+
+  void _moveMenuFocus(int delta) {
+    if (!_isTabPanelVisible) {
+      return;
+    }
+    final int count = _menuItemCount;
+    if (count <= 0) {
+      return;
+    }
+    setState(() {
+      _focusedMenuIndex = (_focusedMenuIndex + delta) % count;
+      if (_focusedMenuIndex < 0) {
+        _focusedMenuIndex += count;
+      }
+    });
+  }
+
+  void _activateFocusedMenuItem() {
+    if (!_isTabPanelVisible) {
+      return;
+    }
+    // Activation is delegated to the panel to keep input logic decoupled from UI/actions.
+    _tabPanelCommand.value = null;
+    _tabPanelCommand.value = NipaplayLargeScreenTabPanelCommand.activateFocused;
+  }
+
+  KeyEventResult _handleInputKeyEvent(FocusNode node, KeyEvent event) {
+    final command = NipaplayLargeScreenInputControls.fromKeyEvent(event);
+    if (command == null) {
+      return KeyEventResult.ignored;
+    }
+
+    switch (command) {
+      case NipaplayLargeScreenInputCommand.toggleMenu:
+        _toggleTabPanel();
+        return KeyEventResult.handled;
+      case NipaplayLargeScreenInputCommand.navigateUp:
+        if (!_isTabPanelVisible) {
+          return KeyEventResult.ignored;
+        }
+        _moveMenuFocus(-1);
+        return KeyEventResult.handled;
+      case NipaplayLargeScreenInputCommand.navigateDown:
+        if (!_isTabPanelVisible) {
+          return KeyEventResult.ignored;
+        }
+        _moveMenuFocus(1);
+        return KeyEventResult.handled;
+      case NipaplayLargeScreenInputCommand.activate:
+        if (!_isTabPanelVisible) {
+          return KeyEventResult.ignored;
+        }
+        _activateFocusedMenuItem();
+        return KeyEventResult.handled;
+    }
   }
 
   @override
   Widget build(BuildContext context) {
     final mediaPadding = MediaQuery.of(context).padding;
 
-    return Stack(
-      children: [
-        Positioned.fill(
-          child: Padding(
-            padding: EdgeInsets.fromLTRB(
-              14,
-              0,
-              14,
-              14 + mediaPadding.bottom,
-            ),
-            child: MediaQuery.removePadding(
-              context: context,
-              removeTop: true,
-              child: widget.content,
+    return Focus(
+      focusNode: _inputFocusNode,
+      autofocus: true,
+      canRequestFocus: true,
+      onKeyEvent: _handleInputKeyEvent,
+      child: Stack(
+        children: [
+          Positioned.fill(
+            child: Padding(
+              padding: EdgeInsets.fromLTRB(
+                14,
+                0,
+                14,
+                14 + mediaPadding.bottom,
+              ),
+              child: MediaQuery.removePadding(
+                context: context,
+                removeTop: true,
+                child: widget.content,
+              ),
             ),
           ),
-        ),
-        if (_isTabPanelVisible)
-          Positioned.fill(
-            child: GestureDetector(
-              behavior: HitTestBehavior.translucent,
-              onTap: _closeTabPanel,
-              child: ClipRect(
-                child: BackdropFilter(
-                  filter: ImageFilter.blur(sigmaX: 25, sigmaY: 25),
-                  child: ColoredBox(
-                    color: widget.isDarkMode
-                        ? Colors.black.withValues(alpha: 0.16)
-                        : Colors.white.withValues(alpha: 0.08),
+          if (_isTabPanelVisible)
+            Positioned.fill(
+              child: GestureDetector(
+                behavior: HitTestBehavior.translucent,
+                onTap: _closeTabPanel,
+                child: ClipRect(
+                  child: BackdropFilter(
+                    filter: ImageFilter.blur(sigmaX: 25, sigmaY: 25),
+                    child: ColoredBox(
+                      color: widget.isDarkMode
+                          ? Colors.black.withValues(alpha: 0.16)
+                          : Colors.white.withValues(alpha: 0.08),
+                    ),
                   ),
                 ),
               ),
             ),
-          ),
-        AnimatedPositioned(
-          duration: const Duration(milliseconds: 240),
-          curve: Curves.easeOutCubic,
-          left: _isTabPanelVisible ? 0 : -kNipaplayLargeScreenTabPanelWidth,
-          top: 0,
-          bottom: 0,
-          child: IgnorePointer(
-            ignoring: !_isTabPanelVisible,
-            child: NipaplayLargeScreenTabPanel(
-              currentIndex: widget.currentIndex,
-              isDarkMode: widget.isDarkMode,
-              tabPage: widget.tabPage,
-              tabController: widget.tabController,
-              onTabActivated: _closeTabPanel,
-              onToggleLargeScreen: widget.onToggleLargeScreen,
-              onToggleThemeFromOrigin: widget.onToggleThemeFromOrigin,
-              onOpenSettings: widget.onOpenSettings,
+          AnimatedPositioned(
+            duration: const Duration(milliseconds: 240),
+            curve: Curves.easeOutCubic,
+            left: _isTabPanelVisible ? 0 : -kNipaplayLargeScreenTabPanelWidth,
+            top: 0,
+            bottom: 0,
+            child: IgnorePointer(
+              ignoring: !_isTabPanelVisible,
+              child: NipaplayLargeScreenTabPanel(
+                currentIndex: widget.currentIndex,
+                isDarkMode: widget.isDarkMode,
+                tabPage: widget.tabPage,
+                tabController: widget.tabController,
+                focusedIndex: _focusedMenuIndex,
+                commandNotifier: _tabPanelCommand,
+                onFocusedIndexChanged: (index) {
+                  if (_focusedMenuIndex == index) {
+                    return;
+                  }
+                  setState(() {
+                    _focusedMenuIndex = index;
+                  });
+                },
+                onTabActivated: _closeTabPanel,
+                onToggleLargeScreen: widget.onToggleLargeScreen,
+                onToggleThemeFromOrigin: widget.onToggleThemeFromOrigin,
+                onOpenSettings: widget.onOpenSettings,
+              ),
             ),
           ),
-        ),
-        Positioned(
-          left: 0,
-          right: 0,
-          top: 0,
-          child: NipaplayLargeScreenTopStatusOverlay(
-            isDarkMode: widget.isDarkMode,
+          Positioned(
+            left: 0,
+            right: 0,
+            top: 0,
+            child: NipaplayLargeScreenTopStatusOverlay(
+              isDarkMode: widget.isDarkMode,
+            ),
           ),
-        ),
-        Positioned(
-          left: 0,
-          right: 0,
-          bottom: 0,
-          child: NipaplayLargeScreenBottomHintOverlay(
-            isDarkMode: widget.isDarkMode,
-            onToggleMenu: _toggleTabPanel,
+          Positioned(
+            left: 0,
+            right: 0,
+            bottom: 0,
+            child: NipaplayLargeScreenBottomHintOverlay(
+              isDarkMode: widget.isDarkMode,
+              onToggleMenu: _toggleTabPanel,
+            ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 }

--- a/lib/themes/nipaplay/widgets/large_screen_scaffold_layout.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_scaffold_layout.dart
@@ -182,7 +182,7 @@ class _NipaplayLargeScreenScaffoldLayoutState
             child: Padding(
               padding: EdgeInsets.fromLTRB(
                 14,
-                0,
+                kNipaplayLargeScreenBottomHintHeight,
                 14,
                 14 + mediaPadding.bottom,
               ),

--- a/lib/themes/nipaplay/widgets/large_screen_scaffold_layout.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_scaffold_layout.dart
@@ -3,7 +3,7 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/large_screen_bottom_hint_overlay.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/large_screen_tab_panel.dart';
-import 'package:nipaplay/utils/globals.dart' as globals;
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_top_status_overlay.dart';
 
 class NipaplayLargeScreenScaffoldLayout extends StatefulWidget {
   const NipaplayLargeScreenScaffoldLayout({
@@ -54,7 +54,6 @@ class _NipaplayLargeScreenScaffoldLayoutState
   @override
   Widget build(BuildContext context) {
     final mediaPadding = MediaQuery.of(context).padding;
-    final double topInset = globals.isDesktop ? 50 : mediaPadding.top + 14;
 
     return Stack(
       children: [
@@ -62,11 +61,15 @@ class _NipaplayLargeScreenScaffoldLayoutState
           child: Padding(
             padding: EdgeInsets.fromLTRB(
               14,
-              topInset,
+              0,
               14,
               14 + mediaPadding.bottom,
             ),
-            child: widget.content,
+            child: MediaQuery.removePadding(
+              context: context,
+              removeTop: true,
+              child: widget.content,
+            ),
           ),
         ),
         if (_isTabPanelVisible)
@@ -104,6 +107,14 @@ class _NipaplayLargeScreenScaffoldLayoutState
               onToggleThemeFromOrigin: widget.onToggleThemeFromOrigin,
               onOpenSettings: widget.onOpenSettings,
             ),
+          ),
+        ),
+        Positioned(
+          left: 0,
+          right: 0,
+          top: 0,
+          child: NipaplayLargeScreenTopStatusOverlay(
+            isDarkMode: widget.isDarkMode,
           ),
         ),
         Positioned(

--- a/lib/themes/nipaplay/widgets/large_screen_scaffold_layout.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_scaffold_layout.dart
@@ -140,13 +140,42 @@ class _NipaplayLargeScreenScaffoldLayoutState
     _tabPanelCommand.value = NipaplayLargeScreenTabPanelCommand.activateFocused;
   }
 
+  void _jumpContentScrollBoundary(TraversalDirection direction) {
+    if (direction != TraversalDirection.up &&
+        direction != TraversalDirection.down) {
+      return;
+    }
+    final focusContext = FocusManager.instance.primaryFocus?.context;
+    final scrollController =
+        PrimaryScrollController.maybeOf(focusContext ?? context);
+    if (scrollController == null || !scrollController.hasClients) {
+      return;
+    }
+    final target = direction == TraversalDirection.up
+        ? scrollController.position.minScrollExtent
+        : scrollController.position.maxScrollExtent;
+    scrollController.jumpTo(target);
+  }
+
   bool _moveContentFocus(TraversalDirection direction) {
     final focusScope = FocusScope.of(context);
     final focusedChild = focusScope.focusedChild;
     if (focusedChild == null || focusedChild == _inputFocusNode) {
-      return focusScope.nextFocus();
+      final moved = focusScope.nextFocus();
+      if (!moved &&
+          (direction == TraversalDirection.up ||
+              direction == TraversalDirection.down)) {
+        _jumpContentScrollBoundary(direction);
+      }
+      return moved;
     }
-    return focusedChild.focusInDirection(direction);
+    final moved = focusedChild.focusInDirection(direction);
+    if (!moved &&
+        (direction == TraversalDirection.up ||
+            direction == TraversalDirection.down)) {
+      _jumpContentScrollBoundary(direction);
+    }
+    return moved;
   }
 
   bool _activateContentFocus() {
@@ -241,7 +270,7 @@ class _NipaplayLargeScreenScaffoldLayoutState
                 14,
                 kNipaplayLargeScreenBottomHintHeight,
                 14,
-                14 + mediaPadding.bottom,
+                kNipaplayLargeScreenBottomHintHeight + mediaPadding.bottom,
               ),
               child: MediaQuery.removePadding(
                 context: context,

--- a/lib/themes/nipaplay/widgets/large_screen_scaffold_layout.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_scaffold_layout.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:nipaplay/pages/tab_labels.dart';
-import 'package:nipaplay/themes/nipaplay/widgets/large_screen_side_panel.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_tab_panel.dart';
 import 'package:nipaplay/utils/globals.dart' as globals;
 
 class NipaplayLargeScreenScaffoldLayout extends StatelessWidget {
@@ -21,43 +20,12 @@ class NipaplayLargeScreenScaffoldLayout extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const Color activeColor = Color(0xFFFF2E55);
-    final Color inactiveColor = isDarkMode ? Colors.white60 : Colors.black54;
     final mediaPadding = MediaQuery.of(context).padding;
     final double topInset = globals.isDesktop ? 50 : mediaPadding.top + 14;
 
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
+    return Stack(
       children: [
-        NipaplayLargeScreenSidePanel(
-          isDarkMode: isDarkMode,
-          child: ListView.builder(
-            padding: EdgeInsets.zero,
-            itemCount: tabPage.length,
-            itemBuilder: (context, index) {
-              final bool isSelected = currentIndex == index;
-              final Color itemColor = isSelected
-                  ? Colors.white
-                  : (isDarkMode ? Colors.white60 : Colors.black54);
-
-              return NipaplayLargeScreenSidePanelItem(
-                isSelected: isSelected,
-                activeColor: activeColor,
-                inactiveColor: inactiveColor,
-                onTap: () {
-                  if (tabController.index != index) {
-                    tabController.animateTo(index);
-                  }
-                },
-                child: _buildSidePanelTabContent(
-                  _stripOuterTabPadding(tabPage[index]),
-                  itemColor: itemColor,
-                ),
-              );
-            },
-          ),
-        ),
-        Expanded(
+        Positioned.fill(
           child: Padding(
             padding: EdgeInsets.fromLTRB(
               14,
@@ -68,43 +36,18 @@ class NipaplayLargeScreenScaffoldLayout extends StatelessWidget {
             child: content,
           ),
         ),
+        Positioned(
+          left: 0,
+          top: 0,
+          bottom: 0,
+          child: NipaplayLargeScreenTabPanel(
+            currentIndex: currentIndex,
+            isDarkMode: isDarkMode,
+            tabPage: tabPage,
+            tabController: tabController,
+          ),
+        ),
       ],
     );
-  }
-
-  Widget _stripOuterTabPadding(Widget tabWidget) {
-    if (tabWidget is Padding && tabWidget.child != null) {
-      return tabWidget.child!;
-    }
-    return tabWidget;
-  }
-
-  Widget _buildSidePanelTabContent(
-    Widget tabWidget, {
-    required Color itemColor,
-  }) {
-    if (tabWidget is HoverZoomTab) {
-      return Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          if (tabWidget.icon != null) ...[
-            IconTheme(
-              data: IconThemeData(color: itemColor),
-              child: tabWidget.icon!,
-            ),
-            const SizedBox(width: 6),
-          ],
-          Text(
-            tabWidget.text,
-            style: TextStyle(
-              color: itemColor,
-              fontSize: tabWidget.fontSize,
-              fontWeight: FontWeight.bold,
-            ),
-          ),
-        ],
-      );
-    }
-    return tabWidget;
   }
 }

--- a/lib/themes/nipaplay/widgets/large_screen_scaffold_layout.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_scaffold_layout.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:nipaplay/pages/tab_labels.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_side_panel.dart';
+import 'package:nipaplay/utils/globals.dart' as globals;
+
+class NipaplayLargeScreenScaffoldLayout extends StatelessWidget {
+  const NipaplayLargeScreenScaffoldLayout({
+    super.key,
+    required this.currentIndex,
+    required this.isDarkMode,
+    required this.tabPage,
+    required this.tabController,
+    required this.content,
+  });
+
+  final int currentIndex;
+  final bool isDarkMode;
+  final List<Widget> tabPage;
+  final TabController tabController;
+  final Widget content;
+
+  @override
+  Widget build(BuildContext context) {
+    const Color activeColor = Color(0xFFFF2E55);
+    final Color inactiveColor = isDarkMode ? Colors.white60 : Colors.black54;
+    final mediaPadding = MediaQuery.of(context).padding;
+    final double topInset = globals.isDesktop ? 50 : mediaPadding.top + 14;
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        NipaplayLargeScreenSidePanel(
+          isDarkMode: isDarkMode,
+          child: ListView.builder(
+            padding: EdgeInsets.zero,
+            itemCount: tabPage.length,
+            itemBuilder: (context, index) {
+              final bool isSelected = currentIndex == index;
+              final Color itemColor = isSelected
+                  ? Colors.white
+                  : (isDarkMode ? Colors.white60 : Colors.black54);
+
+              return NipaplayLargeScreenSidePanelItem(
+                isSelected: isSelected,
+                activeColor: activeColor,
+                inactiveColor: inactiveColor,
+                onTap: () {
+                  if (tabController.index != index) {
+                    tabController.animateTo(index);
+                  }
+                },
+                child: _buildSidePanelTabContent(
+                  _stripOuterTabPadding(tabPage[index]),
+                  itemColor: itemColor,
+                ),
+              );
+            },
+          ),
+        ),
+        Expanded(
+          child: Padding(
+            padding: EdgeInsets.fromLTRB(
+              14,
+              topInset,
+              14,
+              14 + mediaPadding.bottom,
+            ),
+            child: content,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _stripOuterTabPadding(Widget tabWidget) {
+    if (tabWidget is Padding && tabWidget.child != null) {
+      return tabWidget.child!;
+    }
+    return tabWidget;
+  }
+
+  Widget _buildSidePanelTabContent(
+    Widget tabWidget, {
+    required Color itemColor,
+  }) {
+    if (tabWidget is HoverZoomTab) {
+      return Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (tabWidget.icon != null) ...[
+            IconTheme(
+              data: IconThemeData(color: itemColor),
+              child: tabWidget.icon!,
+            ),
+            const SizedBox(width: 6),
+          ],
+          Text(
+            tabWidget.text,
+            style: TextStyle(
+              color: itemColor,
+              fontSize: tabWidget.fontSize,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ],
+      );
+    }
+    return tabWidget;
+  }
+}

--- a/lib/themes/nipaplay/widgets/large_screen_settings_panel.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_settings_panel.dart
@@ -1,0 +1,691 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:nipaplay/l10n/l10n.dart';
+import 'package:nipaplay/providers/app_language_provider.dart';
+import 'package:nipaplay/providers/appearance_settings_provider.dart';
+import 'package:nipaplay/providers/settings_provider.dart';
+import 'package:nipaplay/services/update_service.dart';
+import 'package:nipaplay/themes/nipaplay/pages/settings/settings_entries.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_bottom_hint_overlay.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_side_panel.dart';
+import 'package:nipaplay/utils/network_settings.dart';
+import 'package:nipaplay/utils/theme_notifier.dart';
+import 'package:provider/provider.dart';
+
+const double kNipaplayLargeScreenSettingsPanelWidth = 900;
+const double _kNipaplayLargeScreenSettingsMenuWidth = 230;
+const Color _kNipaplayLargeScreenActiveColor = Color(0xFFFF2E55);
+
+enum NipaplayLargeScreenSettingsPanelCommand {
+  activateFocused,
+  navigateUp,
+  navigateDown,
+  navigateLeft,
+  navigateRight,
+}
+
+class NipaplayLargeScreenSettingsPanel extends StatefulWidget {
+  const NipaplayLargeScreenSettingsPanel({
+    super.key,
+    required this.isDarkMode,
+    this.focusedIndex = 0,
+    this.commandNotifier,
+    this.onFocusedIndexChanged,
+    this.onEntryCountChanged,
+    this.onRequestClose,
+  });
+
+  final bool isDarkMode;
+  final int focusedIndex;
+  final ValueListenable<NipaplayLargeScreenSettingsPanelCommand?>?
+      commandNotifier;
+  final ValueChanged<int>? onFocusedIndexChanged;
+  final ValueChanged<int>? onEntryCountChanged;
+  final VoidCallback? onRequestClose;
+
+  @override
+  State<NipaplayLargeScreenSettingsPanel> createState() =>
+      _NipaplayLargeScreenSettingsPanelState();
+}
+
+class _NipaplayLargeScreenSettingsPanelState
+    extends State<NipaplayLargeScreenSettingsPanel> {
+  late List<NipaplaySettingEntry> _entries;
+  int _selectedIndex = 0;
+  bool _isContentFocused = false;
+  int _contentCursor = 0;
+
+  String _currentServer = NetworkSettings.defaultServer;
+  bool _isServerLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _entries = const <NipaplaySettingEntry>[];
+    _loadNetworkSettings();
+  }
+
+  Future<void> _loadNetworkSettings() async {
+    final server = await NetworkSettings.getDandanplayServer();
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _currentServer = server;
+      _isServerLoading = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    _entries = buildNipaplaySettingEntries(context);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) {
+        return;
+      }
+      widget.onEntryCountChanged?.call(_entries.length);
+    });
+
+    final Color inactiveColor =
+        widget.isDarkMode ? Colors.white70 : Colors.black54;
+    final Color panelBackgroundColor =
+        widget.isDarkMode ? const Color(0xFF1E1E1E) : const Color(0xFFF2F2F2);
+
+    if (_entries.isEmpty) {
+      return ColoredBox(
+        color: panelBackgroundColor,
+        child: const SizedBox.expand(),
+      );
+    }
+
+    if (_selectedIndex < 0 || _selectedIndex >= _entries.length) {
+      _selectedIndex = widget.focusedIndex.clamp(0, _entries.length - 1);
+    }
+
+    final normalizedFocusedIndex =
+        widget.focusedIndex.clamp(0, _entries.length - 1);
+    if (normalizedFocusedIndex != widget.focusedIndex) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        widget.onFocusedIndexChanged?.call(normalizedFocusedIndex);
+      });
+    }
+
+    final contentItems = _buildCurrentContentItems(context);
+    if (_contentCursor >= contentItems.length) {
+      _contentCursor = contentItems.isEmpty ? 0 : contentItems.length - 1;
+    }
+
+    return ColoredBox(
+      color: panelBackgroundColor,
+      child: _NipaplayLargeScreenSettingsPanelCommandHost(
+        commandNotifier: widget.commandNotifier,
+        onNavigateUp: () => _handleNavigateUp(contentItems.length),
+        onNavigateDown: () => _handleNavigateDown(contentItems.length),
+        onNavigateLeft: _handleNavigateLeft,
+        onNavigateRight: _handleNavigateRight,
+        onActivateFocused: () async {
+          if (_isContentFocused) {
+            if (contentItems.isEmpty) {
+              return;
+            }
+            await contentItems[_contentCursor].onActivate();
+            if (!mounted) {
+              return;
+            }
+            setState(() {});
+            return;
+          }
+          _selectIndex(normalizedFocusedIndex);
+        },
+        child: Row(
+          children: [
+            SizedBox(
+              width: _kNipaplayLargeScreenSettingsMenuWidth,
+              child: NipaplayLargeScreenSidePanel(
+                isDarkMode: widget.isDarkMode,
+                width: _kNipaplayLargeScreenSettingsMenuWidth,
+                child: Padding(
+                  padding: const EdgeInsets.only(
+                    top: kNipaplayLargeScreenBottomHintHeight,
+                    bottom: kNipaplayLargeScreenBottomHintHeight,
+                  ),
+                  child: ListView.builder(
+                    padding: EdgeInsets.zero,
+                    itemCount: _entries.length,
+                    itemBuilder: (context, index) {
+                      final entry = _entries[index];
+                      final bool isSelectedByFocus =
+                          !_isContentFocused && index == normalizedFocusedIndex;
+                      final bool isSelectedByPage = index == _selectedIndex;
+                      final bool isActive = isSelectedByFocus || isSelectedByPage;
+                      final Color itemColor =
+                          isActive ? Colors.white : inactiveColor;
+                      return NipaplayLargeScreenSidePanelItem(
+                        isSelected: isActive,
+                        activeColor: _kNipaplayLargeScreenActiveColor,
+                        inactiveColor: inactiveColor,
+                        onTap: () {
+                          _setContentFocused(false);
+                          widget.onFocusedIndexChanged?.call(index);
+                          _selectIndex(index);
+                        },
+                        child: Row(
+                          children: [
+                            Icon(entry.icon, size: 19, color: itemColor),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: Text(
+                                entry.title,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: TextStyle(
+                                  color: itemColor,
+                                  fontSize: 15,
+                                  fontWeight: FontWeight.w700,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              ),
+            ),
+            const VerticalDivider(width: 1, thickness: 1),
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.only(
+                  top: kNipaplayLargeScreenBottomHintHeight,
+                  bottom: kNipaplayLargeScreenBottomHintHeight,
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+                      child: Row(
+                        children: [
+                          Expanded(
+                            child: Text(
+                              _entries[_selectedIndex].pageTitle,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: TextStyle(
+                                fontSize: 20,
+                                fontWeight: FontWeight.w800,
+                                color: widget.isDarkMode
+                                    ? Colors.white
+                                    : Colors.black87,
+                              ),
+                            ),
+                          ),
+                          IconButton(
+                            tooltip: '关闭设置',
+                            onPressed: widget.onRequestClose,
+                            icon: Icon(
+                              Icons.close_rounded,
+                              color: widget.isDarkMode
+                                  ? Colors.white70
+                                  : Colors.black54,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    Divider(
+                      height: 1,
+                      color:
+                          widget.isDarkMode ? Colors.white12 : Colors.black12,
+                    ),
+                    Expanded(
+                      child: contentItems.isEmpty
+                          ? Center(
+                              child: Text(
+                                '该设置项暂未提供大屏幕键盘交互版本',
+                                style: TextStyle(
+                                  color: widget.isDarkMode
+                                      ? Colors.white70
+                                      : Colors.black54,
+                                ),
+                              ),
+                            )
+                          : ListView.builder(
+                              padding: const EdgeInsets.all(16),
+                              itemCount: contentItems.length,
+                              itemBuilder: (context, index) {
+                                return _buildContentItemCard(
+                                  item: contentItems[index],
+                                  isSelected:
+                                      _isContentFocused && index == _contentCursor,
+                                );
+                              },
+                            ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildContentItemCard({
+    required _LargeScreenSettingsContentItem item,
+    required bool isSelected,
+  }) {
+    final Color titleColor = widget.isDarkMode ? Colors.white : Colors.black87;
+    final Color subtitleColor =
+        widget.isDarkMode ? Colors.white70 : Colors.black54;
+
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 120),
+      margin: const EdgeInsets.only(bottom: 10),
+      padding: const EdgeInsets.fromLTRB(14, 12, 14, 12),
+      decoration: BoxDecoration(
+        color: isSelected
+            ? _kNipaplayLargeScreenActiveColor
+            : (widget.isDarkMode
+                ? Colors.white.withValues(alpha: 0.06)
+                : Colors.black.withValues(alpha: 0.04)),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  item.title,
+                  style: TextStyle(
+                    color: isSelected ? Colors.white : titleColor,
+                    fontSize: 15,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                if (item.subtitle != null && item.subtitle!.isNotEmpty) ...[
+                  const SizedBox(height: 4),
+                  Text(
+                    item.subtitle!,
+                    style: TextStyle(
+                      color: isSelected ? Colors.white : subtitleColor,
+                      fontSize: 12,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+          const SizedBox(width: 12),
+          Text(
+            item.valueText,
+            style: TextStyle(
+              color: isSelected ? Colors.white : titleColor,
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _selectIndex(int index) {
+    if (_entries.isEmpty) {
+      return;
+    }
+    final clamped = index.clamp(0, _entries.length - 1);
+    if (_selectedIndex == clamped) {
+      return;
+    }
+    setState(() {
+      _selectedIndex = clamped;
+      _contentCursor = 0;
+    });
+  }
+
+  void _setContentFocused(bool value) {
+    if (_isContentFocused == value) {
+      return;
+    }
+    setState(() {
+      _isContentFocused = value;
+      if (!_isContentFocused) {
+        _contentCursor = 0;
+      }
+    });
+  }
+
+  void _handleNavigateUp(int contentItemCount) {
+    if (_isContentFocused) {
+      if (contentItemCount <= 0) {
+        return;
+      }
+      setState(() {
+        _contentCursor = (_contentCursor - 1) % contentItemCount;
+        if (_contentCursor < 0) {
+          _contentCursor += contentItemCount;
+        }
+      });
+      return;
+    }
+    widget.onFocusedIndexChanged?.call(widget.focusedIndex - 1);
+  }
+
+  void _handleNavigateDown(int contentItemCount) {
+    if (_isContentFocused) {
+      if (contentItemCount <= 0) {
+        return;
+      }
+      setState(() {
+        _contentCursor = (_contentCursor + 1) % contentItemCount;
+      });
+      return;
+    }
+    widget.onFocusedIndexChanged?.call(widget.focusedIndex + 1);
+  }
+
+  void _handleNavigateLeft() {
+    if (_isContentFocused) {
+      _setContentFocused(false);
+    }
+  }
+
+  void _handleNavigateRight() {
+    if (!_isContentFocused) {
+      _setContentFocused(true);
+    }
+  }
+
+  List<_LargeScreenSettingsContentItem> _buildCurrentContentItems(
+      BuildContext context) {
+    final selectedEntryId = _entries[_selectedIndex].id;
+    switch (selectedEntryId) {
+      case NipaplaySettingEntryIds.appearance:
+        return _buildAppearanceContentItems(context);
+      case NipaplaySettingEntryIds.language:
+        return _buildLanguageContentItems(context);
+      case NipaplaySettingEntryIds.general:
+        return _buildGeneralContentItems(context);
+      case NipaplaySettingEntryIds.network:
+        return _buildNetworkContentItems(context);
+      default:
+        return const <_LargeScreenSettingsContentItem>[];
+    }
+  }
+
+  List<_LargeScreenSettingsContentItem> _buildAppearanceContentItems(
+      BuildContext context) {
+    final themeNotifier = context.read<ThemeNotifier>();
+    final appearanceSettings = context.watch<AppearanceSettingsProvider>();
+    final settingsProvider = context.watch<SettingsProvider>();
+
+    final themeText = switch (themeNotifier.themeMode) {
+      ThemeMode.light => '日间模式',
+      ThemeMode.dark => '夜间模式',
+      ThemeMode.system => '跟随系统',
+    };
+
+    return [
+      _LargeScreenSettingsContentItem(
+        title: '主题模式',
+        subtitle: '回车切换: 日间 -> 夜间 -> 跟随系统',
+        valueText: themeText,
+        onActivate: () async {
+          final current = themeNotifier.themeMode;
+          final next = switch (current) {
+            ThemeMode.light => ThemeMode.dark,
+            ThemeMode.dark => ThemeMode.system,
+            ThemeMode.system => ThemeMode.light,
+          };
+          themeNotifier.themeMode = next;
+        },
+      ),
+      _LargeScreenSettingsContentItem(
+        title: '控件毛玻璃效果',
+        subtitle: '回车开关',
+        valueText: appearanceSettings.enableWidgetBlurEffect ? '开启' : '关闭',
+        onActivate: () => appearanceSettings
+            .setEnableWidgetBlurEffect(!appearanceSettings.enableWidgetBlurEffect),
+      ),
+      _LargeScreenSettingsContentItem(
+        title: '番剧卡片显示介绍',
+        subtitle: '回车开关',
+        valueText: appearanceSettings.showAnimeCardSummary ? '开启' : '关闭',
+        onActivate: () => appearanceSettings
+            .setShowAnimeCardSummary(!appearanceSettings.showAnimeCardSummary),
+      ),
+      _LargeScreenSettingsContentItem(
+        title: '界面缩放',
+        subtitle: '回车步进 +0.05，超过最大值回到最小值',
+        valueText: appearanceSettings.uiScale.toStringAsFixed(2),
+        onActivate: () {
+          final current = appearanceSettings.uiScale;
+          const step = AppearanceSettingsProvider.uiScaleStep;
+          const min = AppearanceSettingsProvider.uiScaleMin;
+          const max = AppearanceSettingsProvider.uiScaleMax;
+          var next = current + step;
+          if (next > max + 0.0001) {
+            next = min;
+          }
+          return appearanceSettings.setUiScale(next.clamp(min, max));
+        },
+      ),
+      _LargeScreenSettingsContentItem(
+        title: '全局背景模糊',
+        subtitle: '回车在 0 / 10 之间切换',
+        valueText: settingsProvider.blurPower.toStringAsFixed(0),
+        onActivate: () async {
+          final bool enabled = settingsProvider.isBlurEnabled;
+          await settingsProvider.setBlurPower(enabled ? 0 : 10);
+        },
+      ),
+    ];
+  }
+
+  List<_LargeScreenSettingsContentItem> _buildLanguageContentItems(
+      BuildContext context) {
+    final provider = context.watch<AppLanguageProvider>();
+
+    final modeText = switch (provider.mode) {
+      AppLanguageMode.auto => '自动',
+      AppLanguageMode.simplifiedChinese => '简体中文',
+      AppLanguageMode.traditionalChinese => '繁体中文',
+    };
+
+    return [
+      _LargeScreenSettingsContentItem(
+        title: '应用语言',
+        subtitle: '回车切换: 自动 -> 简体 -> 繁体',
+        valueText: modeText,
+        onActivate: () async {
+          final next = switch (provider.mode) {
+            AppLanguageMode.auto => AppLanguageMode.simplifiedChinese,
+            AppLanguageMode.simplifiedChinese =>
+              AppLanguageMode.traditionalChinese,
+            AppLanguageMode.traditionalChinese => AppLanguageMode.auto,
+          };
+          await context.read<AppLanguageProvider>().setMode(next);
+        },
+      ),
+    ];
+  }
+
+  List<_LargeScreenSettingsContentItem> _buildGeneralContentItems(
+      BuildContext context) {
+    final l10n = context.l10n;
+    final settingsProvider = context.watch<SettingsProvider>();
+
+    return [
+      _LargeScreenSettingsContentItem(
+        title: l10n.aboutAutoCheckUpdates,
+        subtitle: '回车开关',
+        valueText: '动态读取',
+        onActivate: () async {
+          final enabled = await UpdateService.isAutoCheckEnabled();
+          await UpdateService.setAutoCheckEnabled(!enabled);
+          if (!mounted) {
+            return;
+          }
+          setState(() {});
+        },
+      ),
+      _LargeScreenSettingsContentItem(
+        title: '弹幕转简体',
+        subtitle: '回车开关',
+        valueText: settingsProvider.danmakuConvertToSimplified ? '开启' : '关闭',
+        onActivate: () => context.read<SettingsProvider>().setDanmakuConvertToSimplified(
+            !context.read<SettingsProvider>().danmakuConvertToSimplified),
+      ),
+      _LargeScreenSettingsContentItem(
+        title: '自动匹配弹幕(哈希失败)',
+        subtitle: '回车开关',
+        valueText:
+            settingsProvider.autoMatchDanmakuFirstSearchResultOnHashFail
+                ? '开启'
+                : '关闭',
+        onActivate: () => context
+            .read<SettingsProvider>()
+            .setAutoMatchDanmakuFirstSearchResultOnHashFail(
+                !context
+                    .read<SettingsProvider>()
+                    .autoMatchDanmakuFirstSearchResultOnHashFail),
+      ),
+      _LargeScreenSettingsContentItem(
+        title: '播放时自动匹配弹幕',
+        subtitle: '回车开关',
+        valueText: settingsProvider.autoMatchDanmakuOnPlay ? '开启' : '关闭',
+        onActivate: () => context.read<SettingsProvider>().setAutoMatchDanmakuOnPlay(
+            !context.read<SettingsProvider>().autoMatchDanmakuOnPlay),
+      ),
+    ];
+  }
+
+  List<_LargeScreenSettingsContentItem> _buildNetworkContentItems(
+      BuildContext context) {
+    final l10n = context.l10n;
+    final serverText = _isServerLoading
+        ? '加载中'
+        : (_currentServer == NetworkSettings.primaryServer
+            ? l10n.primaryServer
+            : (_currentServer == NetworkSettings.backupServer
+                ? l10n.backupServer
+                : _currentServer));
+
+    return [
+      _LargeScreenSettingsContentItem(
+        title: l10n.dandanplayServer,
+        subtitle: '回车切换主服务器 / 备用服务器',
+        valueText: serverText,
+        onActivate: () async {
+          final next = _currentServer == NetworkSettings.primaryServer
+              ? NetworkSettings.backupServer
+              : NetworkSettings.primaryServer;
+          await NetworkSettings.setDandanplayServer(next);
+          if (!mounted) {
+            return;
+          }
+          setState(() {
+            _currentServer = next;
+          });
+        },
+      ),
+    ];
+  }
+}
+
+class _LargeScreenSettingsContentItem {
+  const _LargeScreenSettingsContentItem({
+    required this.title,
+    required this.valueText,
+    required this.onActivate,
+    this.subtitle,
+  });
+
+  final String title;
+  final String? subtitle;
+  final String valueText;
+  final Future<void> Function() onActivate;
+}
+
+class _NipaplayLargeScreenSettingsPanelCommandHost extends StatefulWidget {
+  const _NipaplayLargeScreenSettingsPanelCommandHost({
+    required this.child,
+    required this.onActivateFocused,
+    required this.onNavigateUp,
+    required this.onNavigateDown,
+    required this.onNavigateLeft,
+    required this.onNavigateRight,
+    this.commandNotifier,
+  });
+
+  final Widget child;
+  final Future<void> Function() onActivateFocused;
+  final VoidCallback onNavigateUp;
+  final VoidCallback onNavigateDown;
+  final VoidCallback onNavigateLeft;
+  final VoidCallback onNavigateRight;
+  final ValueListenable<NipaplayLargeScreenSettingsPanelCommand?>?
+      commandNotifier;
+
+  @override
+  State<_NipaplayLargeScreenSettingsPanelCommandHost> createState() =>
+      _NipaplayLargeScreenSettingsPanelCommandHostState();
+}
+
+class _NipaplayLargeScreenSettingsPanelCommandHostState
+    extends State<_NipaplayLargeScreenSettingsPanelCommandHost> {
+  @override
+  void initState() {
+    super.initState();
+    widget.commandNotifier?.addListener(_handleCommand);
+  }
+
+  @override
+  void didUpdateWidget(
+      covariant _NipaplayLargeScreenSettingsPanelCommandHost oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.commandNotifier == widget.commandNotifier) {
+      return;
+    }
+    oldWidget.commandNotifier?.removeListener(_handleCommand);
+    widget.commandNotifier?.addListener(_handleCommand);
+  }
+
+  @override
+  void dispose() {
+    widget.commandNotifier?.removeListener(_handleCommand);
+    super.dispose();
+  }
+
+  void _handleCommand() {
+    final command = widget.commandNotifier?.value;
+    switch (command) {
+      case NipaplayLargeScreenSettingsPanelCommand.activateFocused:
+        widget.onActivateFocused();
+        break;
+      case NipaplayLargeScreenSettingsPanelCommand.navigateUp:
+        widget.onNavigateUp();
+        break;
+      case NipaplayLargeScreenSettingsPanelCommand.navigateDown:
+        widget.onNavigateDown();
+        break;
+      case NipaplayLargeScreenSettingsPanelCommand.navigateLeft:
+        widget.onNavigateLeft();
+        break;
+      case NipaplayLargeScreenSettingsPanelCommand.navigateRight:
+        widget.onNavigateRight();
+        break;
+      case null:
+        break;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
+  }
+}

--- a/lib/themes/nipaplay/widgets/large_screen_settings_panel.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_settings_panel.dart
@@ -1,16 +1,10 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:nipaplay/l10n/l10n.dart';
-import 'package:nipaplay/providers/app_language_provider.dart';
-import 'package:nipaplay/providers/appearance_settings_provider.dart';
-import 'package:nipaplay/providers/settings_provider.dart';
-import 'package:nipaplay/services/update_service.dart';
+import 'package:flutter/services.dart';
 import 'package:nipaplay/themes/nipaplay/pages/settings/settings_entries.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/large_screen_bottom_hint_overlay.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_editable_slider.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/large_screen_side_panel.dart';
-import 'package:nipaplay/utils/network_settings.dart';
-import 'package:nipaplay/utils/theme_notifier.dart';
-import 'package:provider/provider.dart';
 
 const double kNipaplayLargeScreenSettingsPanelWidth = 900;
 const double _kNipaplayLargeScreenSettingsMenuWidth = 230;
@@ -53,27 +47,53 @@ class _NipaplayLargeScreenSettingsPanelState
   late List<NipaplaySettingEntry> _entries;
   int _selectedIndex = 0;
   bool _isContentFocused = false;
-  int _contentCursor = 0;
-
-  String _currentServer = NetworkSettings.defaultServer;
-  bool _isServerLoading = true;
+  final FocusScopeNode _contentFocusScope = FocusScopeNode(
+    debugLabel: 'nipaplay_large_screen_settings_content',
+  );
+  OnKeyEventCallback? _earlyKeyHandler;
 
   @override
   void initState() {
     super.initState();
     _entries = const <NipaplaySettingEntry>[];
-    _loadNetworkSettings();
+    _earlyKeyHandler = _handleEarlyKeyEvent;
+    FocusManager.instance.addEarlyKeyEventHandler(_earlyKeyHandler!);
   }
 
-  Future<void> _loadNetworkSettings() async {
-    final server = await NetworkSettings.getDandanplayServer();
-    if (!mounted) {
-      return;
+  @override
+  void dispose() {
+    if (_earlyKeyHandler != null) {
+      FocusManager.instance.removeEarlyKeyEventHandler(_earlyKeyHandler!);
+      _earlyKeyHandler = null;
     }
-    setState(() {
-      _currentServer = server;
-      _isServerLoading = false;
-    });
+    _contentFocusScope.dispose();
+    super.dispose();
+  }
+
+  KeyEventResult _handleEarlyKeyEvent(KeyEvent event) {
+    if (!_isContentFocused) {
+      return KeyEventResult.ignored;
+    }
+    if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
+      return KeyEventResult.ignored;
+    }
+    if (!_isFocusInsideContentScope(FocusManager.instance.primaryFocus)) {
+      return KeyEventResult.ignored;
+    }
+    if (NipaplayLargeScreenEditableSlider.isAnyEditing) {
+      return KeyEventResult.ignored;
+    }
+
+    final key = event.logicalKey;
+    if (key == LogicalKeyboardKey.arrowUp) {
+      _moveContentVerticalFocus(reverse: true);
+      return KeyEventResult.handled;
+    }
+    if (key == LogicalKeyboardKey.arrowDown) {
+      _moveContentVerticalFocus(reverse: false);
+      return KeyEventResult.handled;
+    }
+    return KeyEventResult.ignored;
   }
 
   @override
@@ -110,29 +130,17 @@ class _NipaplayLargeScreenSettingsPanelState
       });
     }
 
-    final contentItems = _buildCurrentContentItems(context);
-    if (_contentCursor >= contentItems.length) {
-      _contentCursor = contentItems.isEmpty ? 0 : contentItems.length - 1;
-    }
-
     return ColoredBox(
       color: panelBackgroundColor,
       child: _NipaplayLargeScreenSettingsPanelCommandHost(
         commandNotifier: widget.commandNotifier,
-        onNavigateUp: () => _handleNavigateUp(contentItems.length),
-        onNavigateDown: () => _handleNavigateDown(contentItems.length),
+        onNavigateUp: _handleNavigateUp,
+        onNavigateDown: _handleNavigateDown,
         onNavigateLeft: _handleNavigateLeft,
         onNavigateRight: _handleNavigateRight,
         onActivateFocused: () async {
           if (_isContentFocused) {
-            if (contentItems.isEmpty) {
-              return;
-            }
-            await contentItems[_contentCursor].onActivate();
-            if (!mounted) {
-              return;
-            }
-            setState(() {});
+            _activateContentFocus();
             return;
           }
           _selectIndex(normalizedFocusedIndex);
@@ -157,7 +165,8 @@ class _NipaplayLargeScreenSettingsPanelState
                       final bool isSelectedByFocus =
                           !_isContentFocused && index == normalizedFocusedIndex;
                       final bool isSelectedByPage = index == _selectedIndex;
-                      final bool isActive = isSelectedByFocus || isSelectedByPage;
+                      final bool isActive =
+                          isSelectedByFocus || isSelectedByPage;
                       final Color itemColor =
                           isActive ? Colors.white : inactiveColor;
                       return NipaplayLargeScreenSidePanelItem(
@@ -240,28 +249,13 @@ class _NipaplayLargeScreenSettingsPanelState
                           widget.isDarkMode ? Colors.white12 : Colors.black12,
                     ),
                     Expanded(
-                      child: contentItems.isEmpty
-                          ? Center(
-                              child: Text(
-                                '该设置项暂未提供大屏幕键盘交互版本',
-                                style: TextStyle(
-                                  color: widget.isDarkMode
-                                      ? Colors.white70
-                                      : Colors.black54,
-                                ),
-                              ),
-                            )
-                          : ListView.builder(
-                              padding: const EdgeInsets.all(16),
-                              itemCount: contentItems.length,
-                              itemBuilder: (context, index) {
-                                return _buildContentItemCard(
-                                  item: contentItems[index],
-                                  isSelected:
-                                      _isContentFocused && index == _contentCursor,
-                                );
-                              },
-                            ),
+                      child: FocusScope(
+                        node: _contentFocusScope,
+                        child: KeyedSubtree(
+                          key: ValueKey<String>(_entries[_selectedIndex].id),
+                          child: _entries[_selectedIndex].page,
+                        ),
+                      ),
                     ),
                   ],
                 ),
@@ -269,66 +263,6 @@ class _NipaplayLargeScreenSettingsPanelState
             ),
           ],
         ),
-      ),
-    );
-  }
-
-  Widget _buildContentItemCard({
-    required _LargeScreenSettingsContentItem item,
-    required bool isSelected,
-  }) {
-    final Color titleColor = widget.isDarkMode ? Colors.white : Colors.black87;
-    final Color subtitleColor =
-        widget.isDarkMode ? Colors.white70 : Colors.black54;
-
-    return AnimatedContainer(
-      duration: const Duration(milliseconds: 120),
-      margin: const EdgeInsets.only(bottom: 10),
-      padding: const EdgeInsets.fromLTRB(14, 12, 14, 12),
-      decoration: BoxDecoration(
-        color: isSelected
-            ? _kNipaplayLargeScreenActiveColor
-            : (widget.isDarkMode
-                ? Colors.white.withValues(alpha: 0.06)
-                : Colors.black.withValues(alpha: 0.04)),
-      ),
-      child: Row(
-        children: [
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  item.title,
-                  style: TextStyle(
-                    color: isSelected ? Colors.white : titleColor,
-                    fontSize: 15,
-                    fontWeight: FontWeight.w700,
-                  ),
-                ),
-                if (item.subtitle != null && item.subtitle!.isNotEmpty) ...[
-                  const SizedBox(height: 4),
-                  Text(
-                    item.subtitle!,
-                    style: TextStyle(
-                      color: isSelected ? Colors.white : subtitleColor,
-                      fontSize: 12,
-                    ),
-                  ),
-                ],
-              ],
-            ),
-          ),
-          const SizedBox(width: 12),
-          Text(
-            item.valueText,
-            style: TextStyle(
-              color: isSelected ? Colors.white : titleColor,
-              fontSize: 14,
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-        ],
       ),
     );
   }
@@ -343,7 +277,6 @@ class _NipaplayLargeScreenSettingsPanelState
     }
     setState(() {
       _selectedIndex = clamped;
-      _contentCursor = 0;
     });
   }
 
@@ -353,43 +286,40 @@ class _NipaplayLargeScreenSettingsPanelState
     }
     setState(() {
       _isContentFocused = value;
-      if (!_isContentFocused) {
-        _contentCursor = 0;
-      }
     });
+
+    if (value) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) {
+          return;
+        }
+        _ensureContentFocus();
+      });
+    }
   }
 
-  void _handleNavigateUp(int contentItemCount) {
+  void _handleNavigateUp() {
     if (_isContentFocused) {
-      if (contentItemCount <= 0) {
-        return;
-      }
-      setState(() {
-        _contentCursor = (_contentCursor - 1) % contentItemCount;
-        if (_contentCursor < 0) {
-          _contentCursor += contentItemCount;
-        }
-      });
+      _moveContentVerticalFocus(reverse: true);
       return;
     }
     widget.onFocusedIndexChanged?.call(widget.focusedIndex - 1);
   }
 
-  void _handleNavigateDown(int contentItemCount) {
+  void _handleNavigateDown() {
     if (_isContentFocused) {
-      if (contentItemCount <= 0) {
-        return;
-      }
-      setState(() {
-        _contentCursor = (_contentCursor + 1) % contentItemCount;
-      });
+      _moveContentVerticalFocus(reverse: false);
       return;
     }
     widget.onFocusedIndexChanged?.call(widget.focusedIndex + 1);
   }
 
   void _handleNavigateLeft() {
-    if (_isContentFocused) {
+    if (!_isContentFocused) {
+      return;
+    }
+    final moved = _moveContentFocus(TraversalDirection.left);
+    if (!moved) {
       _setContentFocused(false);
     }
   }
@@ -397,218 +327,131 @@ class _NipaplayLargeScreenSettingsPanelState
   void _handleNavigateRight() {
     if (!_isContentFocused) {
       _setContentFocused(true);
+      return;
     }
+    _moveContentFocus(TraversalDirection.right);
   }
 
-  List<_LargeScreenSettingsContentItem> _buildCurrentContentItems(
-      BuildContext context) {
-    final selectedEntryId = _entries[_selectedIndex].id;
-    switch (selectedEntryId) {
-      case NipaplaySettingEntryIds.appearance:
-        return _buildAppearanceContentItems(context);
-      case NipaplaySettingEntryIds.language:
-        return _buildLanguageContentItems(context);
-      case NipaplaySettingEntryIds.general:
-        return _buildGeneralContentItems(context);
-      case NipaplaySettingEntryIds.network:
-        return _buildNetworkContentItems(context);
-      default:
-        return const <_LargeScreenSettingsContentItem>[];
+  bool _moveContentFocus(TraversalDirection direction) {
+    final previousPrimaryFocus = FocusManager.instance.primaryFocus;
+    if (!_isFocusInsideContentScope(previousPrimaryFocus)) {
+      _ensureContentFocus();
     }
+    final fallbackFocus =
+        _contentFocusScope.focusedChild ?? FocusManager.instance.primaryFocus;
+
+    final focusedChild = _contentFocusScope.focusedChild;
+    if (focusedChild == null) {
+      final moved = _contentFocusScope.focusInDirection(direction);
+      if (!_isFocusInsideContentScope(FocusManager.instance.primaryFocus)) {
+        _restoreContentFocus(fallbackFocus);
+        return false;
+      }
+      if (!moved &&
+          (direction == TraversalDirection.up ||
+              direction == TraversalDirection.down)) {
+        _jumpContentScrollBoundary(direction);
+      }
+      return moved;
+    }
+
+    final moved = focusedChild.focusInDirection(direction);
+    if (!_isFocusInsideContentScope(FocusManager.instance.primaryFocus)) {
+      _restoreContentFocus(fallbackFocus);
+      return false;
+    }
+    if (!moved &&
+        (direction == TraversalDirection.up ||
+            direction == TraversalDirection.down)) {
+      _jumpContentScrollBoundary(direction);
+    }
+    return moved;
   }
 
-  List<_LargeScreenSettingsContentItem> _buildAppearanceContentItems(
-      BuildContext context) {
-    final themeNotifier = context.read<ThemeNotifier>();
-    final appearanceSettings = context.watch<AppearanceSettingsProvider>();
-    final settingsProvider = context.watch<SettingsProvider>();
+  bool _moveContentVerticalFocus({required bool reverse}) {
+    final previousPrimaryFocus = FocusManager.instance.primaryFocus;
+    if (!_isFocusInsideContentScope(previousPrimaryFocus)) {
+      _ensureContentFocus();
+    }
+    final fallbackFocus =
+        _contentFocusScope.focusedChild ?? FocusManager.instance.primaryFocus;
 
-    final themeText = switch (themeNotifier.themeMode) {
-      ThemeMode.light => '日间模式',
-      ThemeMode.dark => '夜间模式',
-      ThemeMode.system => '跟随系统',
-    };
+    final moved = reverse
+        ? _contentFocusScope.previousFocus()
+        : _contentFocusScope.nextFocus();
 
-    return [
-      _LargeScreenSettingsContentItem(
-        title: '主题模式',
-        subtitle: '回车切换: 日间 -> 夜间 -> 跟随系统',
-        valueText: themeText,
-        onActivate: () async {
-          final current = themeNotifier.themeMode;
-          final next = switch (current) {
-            ThemeMode.light => ThemeMode.dark,
-            ThemeMode.dark => ThemeMode.system,
-            ThemeMode.system => ThemeMode.light,
-          };
-          themeNotifier.themeMode = next;
-        },
-      ),
-      _LargeScreenSettingsContentItem(
-        title: '控件毛玻璃效果',
-        subtitle: '回车开关',
-        valueText: appearanceSettings.enableWidgetBlurEffect ? '开启' : '关闭',
-        onActivate: () => appearanceSettings
-            .setEnableWidgetBlurEffect(!appearanceSettings.enableWidgetBlurEffect),
-      ),
-      _LargeScreenSettingsContentItem(
-        title: '番剧卡片显示介绍',
-        subtitle: '回车开关',
-        valueText: appearanceSettings.showAnimeCardSummary ? '开启' : '关闭',
-        onActivate: () => appearanceSettings
-            .setShowAnimeCardSummary(!appearanceSettings.showAnimeCardSummary),
-      ),
-      _LargeScreenSettingsContentItem(
-        title: '界面缩放',
-        subtitle: '回车步进 +0.05，超过最大值回到最小值',
-        valueText: appearanceSettings.uiScale.toStringAsFixed(2),
-        onActivate: () {
-          final current = appearanceSettings.uiScale;
-          const step = AppearanceSettingsProvider.uiScaleStep;
-          const min = AppearanceSettingsProvider.uiScaleMin;
-          const max = AppearanceSettingsProvider.uiScaleMax;
-          var next = current + step;
-          if (next > max + 0.0001) {
-            next = min;
-          }
-          return appearanceSettings.setUiScale(next.clamp(min, max));
-        },
-      ),
-      _LargeScreenSettingsContentItem(
-        title: '全局背景模糊',
-        subtitle: '回车在 0 / 10 之间切换',
-        valueText: settingsProvider.blurPower.toStringAsFixed(0),
-        onActivate: () async {
-          final bool enabled = settingsProvider.isBlurEnabled;
-          await settingsProvider.setBlurPower(enabled ? 0 : 10);
-        },
-      ),
-    ];
+    if (!_isFocusInsideContentScope(FocusManager.instance.primaryFocus)) {
+      _restoreContentFocus(fallbackFocus);
+      return false;
+    }
+
+    if (!moved) {
+      _jumpContentScrollBoundary(
+        reverse ? TraversalDirection.up : TraversalDirection.down,
+      );
+    }
+    return moved;
   }
 
-  List<_LargeScreenSettingsContentItem> _buildLanguageContentItems(
-      BuildContext context) {
-    final provider = context.watch<AppLanguageProvider>();
-
-    final modeText = switch (provider.mode) {
-      AppLanguageMode.auto => '自动',
-      AppLanguageMode.simplifiedChinese => '简体中文',
-      AppLanguageMode.traditionalChinese => '繁体中文',
-    };
-
-    return [
-      _LargeScreenSettingsContentItem(
-        title: '应用语言',
-        subtitle: '回车切换: 自动 -> 简体 -> 繁体',
-        valueText: modeText,
-        onActivate: () async {
-          final next = switch (provider.mode) {
-            AppLanguageMode.auto => AppLanguageMode.simplifiedChinese,
-            AppLanguageMode.simplifiedChinese =>
-              AppLanguageMode.traditionalChinese,
-            AppLanguageMode.traditionalChinese => AppLanguageMode.auto,
-          };
-          await context.read<AppLanguageProvider>().setMode(next);
-        },
-      ),
-    ];
+  bool _isFocusInsideContentScope(FocusNode? node) {
+    if (node == null) {
+      return false;
+    }
+    if (identical(node, _contentFocusScope)) {
+      return true;
+    }
+    return node.ancestors
+        .any((ancestor) => identical(ancestor, _contentFocusScope));
   }
 
-  List<_LargeScreenSettingsContentItem> _buildGeneralContentItems(
-      BuildContext context) {
-    final l10n = context.l10n;
-    final settingsProvider = context.watch<SettingsProvider>();
-
-    return [
-      _LargeScreenSettingsContentItem(
-        title: l10n.aboutAutoCheckUpdates,
-        subtitle: '回车开关',
-        valueText: '动态读取',
-        onActivate: () async {
-          final enabled = await UpdateService.isAutoCheckEnabled();
-          await UpdateService.setAutoCheckEnabled(!enabled);
-          if (!mounted) {
-            return;
-          }
-          setState(() {});
-        },
-      ),
-      _LargeScreenSettingsContentItem(
-        title: '弹幕转简体',
-        subtitle: '回车开关',
-        valueText: settingsProvider.danmakuConvertToSimplified ? '开启' : '关闭',
-        onActivate: () => context.read<SettingsProvider>().setDanmakuConvertToSimplified(
-            !context.read<SettingsProvider>().danmakuConvertToSimplified),
-      ),
-      _LargeScreenSettingsContentItem(
-        title: '自动匹配弹幕(哈希失败)',
-        subtitle: '回车开关',
-        valueText:
-            settingsProvider.autoMatchDanmakuFirstSearchResultOnHashFail
-                ? '开启'
-                : '关闭',
-        onActivate: () => context
-            .read<SettingsProvider>()
-            .setAutoMatchDanmakuFirstSearchResultOnHashFail(
-                !context
-                    .read<SettingsProvider>()
-                    .autoMatchDanmakuFirstSearchResultOnHashFail),
-      ),
-      _LargeScreenSettingsContentItem(
-        title: '播放时自动匹配弹幕',
-        subtitle: '回车开关',
-        valueText: settingsProvider.autoMatchDanmakuOnPlay ? '开启' : '关闭',
-        onActivate: () => context.read<SettingsProvider>().setAutoMatchDanmakuOnPlay(
-            !context.read<SettingsProvider>().autoMatchDanmakuOnPlay),
-      ),
-    ];
+  void _restoreContentFocus(FocusNode? fallbackFocus) {
+    if (fallbackFocus != null &&
+        _isFocusInsideContentScope(fallbackFocus) &&
+        fallbackFocus.canRequestFocus &&
+        fallbackFocus.context != null) {
+      fallbackFocus.requestFocus();
+      return;
+    }
+    _ensureContentFocus();
   }
 
-  List<_LargeScreenSettingsContentItem> _buildNetworkContentItems(
-      BuildContext context) {
-    final l10n = context.l10n;
-    final serverText = _isServerLoading
-        ? '加载中'
-        : (_currentServer == NetworkSettings.primaryServer
-            ? l10n.primaryServer
-            : (_currentServer == NetworkSettings.backupServer
-                ? l10n.backupServer
-                : _currentServer));
-
-    return [
-      _LargeScreenSettingsContentItem(
-        title: l10n.dandanplayServer,
-        subtitle: '回车切换主服务器 / 备用服务器',
-        valueText: serverText,
-        onActivate: () async {
-          final next = _currentServer == NetworkSettings.primaryServer
-              ? NetworkSettings.backupServer
-              : NetworkSettings.primaryServer;
-          await NetworkSettings.setDandanplayServer(next);
-          if (!mounted) {
-            return;
-          }
-          setState(() {
-            _currentServer = next;
-          });
-        },
-      ),
-    ];
+  void _jumpContentScrollBoundary(TraversalDirection direction) {
+    if (direction != TraversalDirection.up &&
+        direction != TraversalDirection.down) {
+      return;
+    }
+    final focusContext = _contentFocusScope.focusedChild?.context;
+    final scrollController =
+        PrimaryScrollController.maybeOf(focusContext ?? context);
+    if (scrollController == null || !scrollController.hasClients) {
+      return;
+    }
+    final target = direction == TraversalDirection.up
+        ? scrollController.position.minScrollExtent
+        : scrollController.position.maxScrollExtent;
+    scrollController.jumpTo(target);
   }
-}
 
-class _LargeScreenSettingsContentItem {
-  const _LargeScreenSettingsContentItem({
-    required this.title,
-    required this.valueText,
-    required this.onActivate,
-    this.subtitle,
-  });
+  void _ensureContentFocus() {
+    if (_contentFocusScope.focusedChild != null) {
+      return;
+    }
+    _contentFocusScope.requestFocus();
+    _contentFocusScope.nextFocus();
+  }
 
-  final String title;
-  final String? subtitle;
-  final String valueText;
-  final Future<void> Function() onActivate;
+  void _activateContentFocus() {
+    final focused = _contentFocusScope.focusedChild;
+    if (focused == null) {
+      _ensureContentFocus();
+      return;
+    }
+    final nodeContext = focused.context;
+    if (nodeContext == null) {
+      return;
+    }
+    Actions.maybeInvoke<ActivateIntent>(nodeContext, const ActivateIntent());
+  }
 }
 
 class _NipaplayLargeScreenSettingsPanelCommandHost extends StatefulWidget {

--- a/lib/themes/nipaplay/widgets/large_screen_settings_panel.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_settings_panel.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:nipaplay/themes/nipaplay/pages/settings/settings_entries.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/large_screen_bottom_hint_overlay.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/blur_dropdown.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/large_screen_editable_slider.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/large_screen_side_panel.dart';
 
@@ -78,6 +79,9 @@ class _NipaplayLargeScreenSettingsPanelState
       return KeyEventResult.ignored;
     }
     if (!_isFocusInsideContentScope(FocusManager.instance.primaryFocus)) {
+      return KeyEventResult.ignored;
+    }
+    if (BlurDropdown.isAnyExpanded) {
       return KeyEventResult.ignored;
     }
     if (NipaplayLargeScreenEditableSlider.isAnyEditing) {

--- a/lib/themes/nipaplay/widgets/large_screen_side_panel.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_side_panel.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+
+class NipaplayLargeScreenSidePanel extends StatelessWidget {
+  const NipaplayLargeScreenSidePanel({
+    super.key,
+    required this.isDarkMode,
+    required this.child,
+    this.width = 220,
+  });
+
+  final bool isDarkMode;
+  final Widget child;
+  final double width;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: width,
+      decoration: BoxDecoration(
+        border: Border(
+          right: BorderSide(
+            color: isDarkMode ? Colors.white12 : Colors.black12,
+            width: 1,
+          ),
+        ),
+      ),
+      child: child,
+    );
+  }
+}
+
+class NipaplayLargeScreenSidePanelItem extends StatefulWidget {
+  const NipaplayLargeScreenSidePanelItem({
+    super.key,
+    required this.isSelected,
+    required this.activeColor,
+    required this.inactiveColor,
+    required this.onTap,
+    required this.child,
+  });
+
+  final bool isSelected;
+  final Color activeColor;
+  final Color inactiveColor;
+  final VoidCallback onTap;
+  final Widget child;
+
+  @override
+  State<NipaplayLargeScreenSidePanelItem> createState() =>
+      _NipaplayLargeScreenSidePanelItemState();
+}
+
+class _NipaplayLargeScreenSidePanelItemState
+    extends State<NipaplayLargeScreenSidePanelItem> {
+  bool _isHovered = false;
+  bool _isPressed = false;
+
+  void _setHovered(bool value) {
+    if (_isHovered == value) return;
+    setState(() {
+      _isHovered = value;
+    });
+  }
+
+  void _setPressed(bool value) {
+    if (_isPressed == value) return;
+    setState(() {
+      _isPressed = value;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bool isInteractiveActive = _isHovered || _isPressed;
+    final bool isActive = widget.isSelected || isInteractiveActive;
+    final Color itemColor = isActive ? Colors.white : widget.inactiveColor;
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.zero,
+        splashFactory: NoSplash.splashFactory,
+        overlayColor: WidgetStateProperty.all(Colors.transparent),
+        splashColor: Colors.transparent,
+        highlightColor: Colors.transparent,
+        onTap: widget.onTap,
+        onHover: _setHovered,
+        onHighlightChanged: _setPressed,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 180),
+          curve: Curves.easeOutCubic,
+          width: double.infinity,
+          padding: const EdgeInsets.symmetric(
+            horizontal: 12,
+            vertical: 10,
+          ),
+          decoration: BoxDecoration(
+            color: isActive ? widget.activeColor : Colors.transparent,
+            border: Border(
+              left: BorderSide(
+                color: isActive ? widget.activeColor : Colors.transparent,
+                width: 3,
+              ),
+            ),
+          ),
+          child: DefaultTextStyle.merge(
+            style: TextStyle(color: itemColor),
+            child: IconTheme.merge(
+              data: IconThemeData(color: itemColor),
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: widget.child,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/themes/nipaplay/widgets/large_screen_tab_panel.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_tab_panel.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 import 'package:nipaplay/l10n/l10n.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/large_screen_bottom_hint_overlay.dart';
 import 'package:nipaplay/pages/tab_labels.dart';
@@ -8,6 +9,10 @@ import 'package:provider/provider.dart';
 
 const double kNipaplayLargeScreenTabPanelWidth = 220;
 
+enum NipaplayLargeScreenTabPanelCommand {
+  activateFocused,
+}
+
 class NipaplayLargeScreenTabPanel extends StatelessWidget {
   const NipaplayLargeScreenTabPanel({
     super.key,
@@ -15,6 +20,9 @@ class NipaplayLargeScreenTabPanel extends StatelessWidget {
     required this.isDarkMode,
     required this.tabPage,
     required this.tabController,
+    this.focusedIndex = 0,
+    this.commandNotifier,
+    this.onFocusedIndexChanged,
     this.onTabActivated,
     this.onToggleLargeScreen,
     this.onToggleThemeFromOrigin,
@@ -25,92 +33,42 @@ class NipaplayLargeScreenTabPanel extends StatelessWidget {
   final bool isDarkMode;
   final List<Widget> tabPage;
   final TabController tabController;
+  final int focusedIndex;
+  final ValueListenable<NipaplayLargeScreenTabPanelCommand?>? commandNotifier;
+  final ValueChanged<int>? onFocusedIndexChanged;
   final VoidCallback? onTabActivated;
   final VoidCallback? onToggleLargeScreen;
   final Future<void> Function(Offset globalOrigin)? onToggleThemeFromOrigin;
   final VoidCallback? onOpenSettings;
 
-  @override
-  Widget build(BuildContext context) {
-    const Color activeColor = Color(0xFFFF2E55);
-    final Color inactiveColor = isDarkMode ? Colors.white60 : Colors.black54;
-    // Keep the side tab panel aligned with page base background color.
-    final Color panelBackgroundColor =
-        isDarkMode ? const Color(0xFF1E1E1E) : const Color(0xFFF2F2F2);
-
-    return ColoredBox(
-      color: panelBackgroundColor,
-      child: NipaplayLargeScreenSidePanel(
-        isDarkMode: isDarkMode,
-        width: kNipaplayLargeScreenTabPanelWidth,
-        child: Padding(
-          padding: const EdgeInsets.only(
-            top: kNipaplayLargeScreenBottomHintHeight,
-            bottom: kNipaplayLargeScreenBottomHintHeight,
+  List<_NipaplayLargeScreenMenuEntry> _buildTabEntries(BuildContext context) {
+    final entries = <_NipaplayLargeScreenMenuEntry>[];
+    for (int index = 0; index < tabPage.length; index++) {
+      entries.add(
+        _NipaplayLargeScreenMenuEntry(
+          buildChild: (itemColor) => _buildSidePanelTabContent(
+            _stripOuterTabPadding(tabPage[index]),
+            itemColor: itemColor,
           ),
-          child: Column(
-            children: [
-              Expanded(
-                child: ListView.builder(
-                  padding: EdgeInsets.zero,
-                  itemCount: tabPage.length,
-                  itemBuilder: (context, index) {
-                    final bool isSelected = currentIndex == index;
-                    final Color itemColor = isSelected
-                        ? Colors.white
-                        : (isDarkMode ? Colors.white60 : Colors.black54);
-
-                    return NipaplayLargeScreenSidePanelItem(
-                      isSelected: isSelected,
-                      activeColor: activeColor,
-                      inactiveColor: inactiveColor,
-                      onTap: () {
-                        if (tabController.index != index) {
-                          tabController.animateTo(index);
-                        }
-                        onTabActivated?.call();
-                      },
-                      child: _buildSidePanelTabContent(
-                        _stripOuterTabPadding(tabPage[index]),
-                        itemColor: itemColor,
-                      ),
-                    );
-                  },
-                ),
-              ),
-              if (onToggleLargeScreen != null ||
-                  onToggleThemeFromOrigin != null ||
-                  onOpenSettings != null)
-                _buildActionItems(
-                  context,
-                  activeColor: activeColor,
-                  inactiveColor: inactiveColor,
-                ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildActionItems(
-    BuildContext context, {
-    required Color activeColor,
-    required Color inactiveColor,
-  }) {
-    final actions = <Widget>[];
-
-    if (onToggleLargeScreen != null) {
-      actions.add(
-        NipaplayLargeScreenSidePanelItem(
-          isSelected: false,
-          activeColor: activeColor,
-          inactiveColor: inactiveColor,
           onTap: () {
-            onToggleLargeScreen!.call();
+            if (tabController.index != index) {
+              tabController.animateTo(index);
+            }
             onTabActivated?.call();
           },
-          child: const Row(
+        ),
+      );
+    }
+    return entries;
+  }
+
+  List<_NipaplayLargeScreenMenuEntry> _buildActionEntries(
+      BuildContext context) {
+    final entries = <_NipaplayLargeScreenMenuEntry>[];
+    if (onToggleLargeScreen != null) {
+      entries.add(
+        _NipaplayLargeScreenMenuEntry(
+          buildChild: (_) => const Row(
             children: [
               Icon(Icons.view_day_rounded, size: 20),
               SizedBox(width: 8),
@@ -127,6 +85,10 @@ class NipaplayLargeScreenTabPanel extends StatelessWidget {
               ),
             ],
           ),
+          onTap: () {
+            onToggleLargeScreen!.call();
+            onTabActivated?.call();
+          },
         ),
       );
     }
@@ -135,22 +97,11 @@ class NipaplayLargeScreenTabPanel extends StatelessWidget {
       final String themeActionLabel = isDarkMode
           ? context.l10n.toggleToLightMode
           : context.l10n.toggleToDarkMode;
-      final IconData themeActionIcon = isDarkMode
-          ? Icons.nightlight_rounded
-          : Icons.light_mode_rounded;
-      actions.add(
-        NipaplayLargeScreenSidePanelItem(
-          isSelected: false,
-          activeColor: activeColor,
-          inactiveColor: inactiveColor,
-          onTap: () {
-            _toggleTheme(
-              context,
-              onToggleFromOrigin: onToggleThemeFromOrigin,
-            );
-            onTabActivated?.call();
-          },
-          child: Row(
+      final IconData themeActionIcon =
+          isDarkMode ? Icons.nightlight_rounded : Icons.light_mode_rounded;
+      entries.add(
+        _NipaplayLargeScreenMenuEntry(
+          buildChild: (_) => Row(
             children: [
               Icon(themeActionIcon, size: 20),
               const SizedBox(width: 8),
@@ -167,21 +118,21 @@ class NipaplayLargeScreenTabPanel extends StatelessWidget {
               ),
             ],
           ),
+          onTap: () {
+            _toggleTheme(
+              context,
+              onToggleFromOrigin: onToggleThemeFromOrigin,
+            );
+            onTabActivated?.call();
+          },
         ),
       );
     }
 
     if (onOpenSettings != null) {
-      actions.add(
-        NipaplayLargeScreenSidePanelItem(
-          isSelected: false,
-          activeColor: activeColor,
-          inactiveColor: inactiveColor,
-          onTap: () {
-            onOpenSettings!.call();
-            onTabActivated?.call();
-          },
-          child: Row(
+      entries.add(
+        _NipaplayLargeScreenMenuEntry(
+          buildChild: (_) => Row(
             children: [
               const Icon(Icons.settings_rounded, size: 20),
               const SizedBox(width: 8),
@@ -198,11 +149,112 @@ class NipaplayLargeScreenTabPanel extends StatelessWidget {
               ),
             ],
           ),
+          onTap: () {
+            onOpenSettings!.call();
+            onTabActivated?.call();
+          },
         ),
       );
     }
+    return entries;
+  }
 
-    return Column(mainAxisSize: MainAxisSize.min, children: actions);
+  @override
+  Widget build(BuildContext context) {
+    const Color activeColor = Color(0xFFFF2E55);
+    final Color inactiveColor = isDarkMode ? Colors.white60 : Colors.black54;
+    // Keep the side tab panel aligned with page base background color.
+    final Color panelBackgroundColor =
+        isDarkMode ? const Color(0xFF1E1E1E) : const Color(0xFFF2F2F2);
+    final tabEntries = _buildTabEntries(context);
+    final actionEntries = _buildActionEntries(context);
+    final entries = <_NipaplayLargeScreenMenuEntry>[
+      ...tabEntries,
+      ...actionEntries,
+    ];
+    final normalizedFocusedIndex =
+        entries.isEmpty ? 0 : focusedIndex.clamp(0, entries.length - 1);
+
+    if (normalizedFocusedIndex != focusedIndex) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        onFocusedIndexChanged?.call(normalizedFocusedIndex);
+      });
+    }
+
+    return ColoredBox(
+      color: panelBackgroundColor,
+      child: NipaplayLargeScreenSidePanel(
+        isDarkMode: isDarkMode,
+        width: kNipaplayLargeScreenTabPanelWidth,
+        child: Padding(
+          padding: const EdgeInsets.only(
+            top: kNipaplayLargeScreenBottomHintHeight,
+            bottom: kNipaplayLargeScreenBottomHintHeight,
+          ),
+          child: _NipaplayLargeScreenTabPanelCommandHost(
+            commandNotifier: commandNotifier,
+            onActivateFocused: () {
+              if (entries.isEmpty) {
+                return;
+              }
+              entries[normalizedFocusedIndex].onTap();
+            },
+            child: Column(
+              children: [
+                Expanded(
+                  child: ListView.builder(
+                    padding: EdgeInsets.zero,
+                    itemCount: tabEntries.length,
+                    itemBuilder: (context, index) {
+                      final bool isSelectedByTab = currentIndex == index;
+                      final bool isSelectedByFocus =
+                          index == normalizedFocusedIndex;
+                      final bool isActive =
+                          isSelectedByTab || isSelectedByFocus;
+                      final Color itemColor =
+                          isActive ? Colors.white : inactiveColor;
+
+                      return NipaplayLargeScreenSidePanelItem(
+                        isSelected: isActive,
+                        activeColor: activeColor,
+                        inactiveColor: inactiveColor,
+                        onTap: () {
+                          onFocusedIndexChanged?.call(index);
+                          tabEntries[index].onTap();
+                        },
+                        child: tabEntries[index].buildChild(itemColor),
+                      );
+                    },
+                  ),
+                ),
+                if (actionEntries.isNotEmpty)
+                  Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children:
+                        List.generate(actionEntries.length, (actionIndex) {
+                      final int entryIndex = tabEntries.length + actionIndex;
+                      final bool isFocused =
+                          entryIndex == normalizedFocusedIndex;
+                      final Color itemColor =
+                          isFocused ? Colors.white : inactiveColor;
+                      return NipaplayLargeScreenSidePanelItem(
+                        isSelected: isFocused,
+                        activeColor: activeColor,
+                        inactiveColor: inactiveColor,
+                        onTap: () {
+                          onFocusedIndexChanged?.call(entryIndex);
+                          actionEntries[actionIndex].onTap();
+                        },
+                        child: actionEntries[actionIndex].buildChild(itemColor),
+                      );
+                    }),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
   }
 
   Widget _stripOuterTabPadding(Widget tabWidget) {
@@ -242,6 +294,73 @@ class NipaplayLargeScreenTabPanel extends StatelessWidget {
   }
 }
 
+class _NipaplayLargeScreenMenuEntry {
+  const _NipaplayLargeScreenMenuEntry({
+    required this.buildChild,
+    required this.onTap,
+  });
+
+  final Widget Function(Color itemColor) buildChild;
+  final VoidCallback onTap;
+}
+
+class _NipaplayLargeScreenTabPanelCommandHost extends StatefulWidget {
+  const _NipaplayLargeScreenTabPanelCommandHost({
+    required this.child,
+    required this.onActivateFocused,
+    this.commandNotifier,
+  });
+
+  final Widget child;
+  final VoidCallback onActivateFocused;
+  final ValueListenable<NipaplayLargeScreenTabPanelCommand?>? commandNotifier;
+
+  @override
+  State<_NipaplayLargeScreenTabPanelCommandHost> createState() =>
+      _NipaplayLargeScreenTabPanelCommandHostState();
+}
+
+class _NipaplayLargeScreenTabPanelCommandHostState
+    extends State<_NipaplayLargeScreenTabPanelCommandHost> {
+  @override
+  void initState() {
+    super.initState();
+    widget.commandNotifier?.addListener(_handleCommand);
+  }
+
+  @override
+  void didUpdateWidget(
+      covariant _NipaplayLargeScreenTabPanelCommandHost oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.commandNotifier == widget.commandNotifier) {
+      return;
+    }
+    oldWidget.commandNotifier?.removeListener(_handleCommand);
+    widget.commandNotifier?.addListener(_handleCommand);
+  }
+
+  @override
+  void dispose() {
+    widget.commandNotifier?.removeListener(_handleCommand);
+    super.dispose();
+  }
+
+  void _handleCommand() {
+    final command = widget.commandNotifier?.value;
+    if (command == null) {
+      return;
+    }
+    if (command == NipaplayLargeScreenTabPanelCommand.activateFocused) {
+      widget.onActivateFocused();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
+  }
+}
+
 void _toggleTheme(
   BuildContext context, {
   Future<void> Function(Offset globalOrigin)? onToggleFromOrigin,
@@ -249,7 +368,8 @@ void _toggleTheme(
   if (onToggleFromOrigin != null) {
     final renderObject = context.findRenderObject();
     if (renderObject is RenderBox && renderObject.hasSize) {
-      final origin = renderObject.localToGlobal(renderObject.size.center(Offset.zero));
+      final origin =
+          renderObject.localToGlobal(renderObject.size.center(Offset.zero));
       onToggleFromOrigin(origin);
       return;
     }

--- a/lib/themes/nipaplay/widgets/large_screen_tab_panel.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_tab_panel.dart
@@ -1,6 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:nipaplay/l10n/l10n.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_bottom_hint_overlay.dart';
 import 'package:nipaplay/pages/tab_labels.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/large_screen_side_panel.dart';
+import 'package:nipaplay/utils/theme_notifier.dart';
+import 'package:provider/provider.dart';
+
+const double kNipaplayLargeScreenTabPanelWidth = 220;
 
 class NipaplayLargeScreenTabPanel extends StatelessWidget {
   const NipaplayLargeScreenTabPanel({
@@ -9,12 +15,20 @@ class NipaplayLargeScreenTabPanel extends StatelessWidget {
     required this.isDarkMode,
     required this.tabPage,
     required this.tabController,
+    this.onTabActivated,
+    this.onToggleLargeScreen,
+    this.onToggleThemeFromOrigin,
+    this.onOpenSettings,
   });
 
   final int currentIndex;
   final bool isDarkMode;
   final List<Widget> tabPage;
   final TabController tabController;
+  final VoidCallback? onTabActivated;
+  final VoidCallback? onToggleLargeScreen;
+  final Future<void> Function(Offset globalOrigin)? onToggleThemeFromOrigin;
+  final VoidCallback? onOpenSettings;
 
   @override
   Widget build(BuildContext context) {
@@ -28,33 +42,166 @@ class NipaplayLargeScreenTabPanel extends StatelessWidget {
       color: panelBackgroundColor,
       child: NipaplayLargeScreenSidePanel(
         isDarkMode: isDarkMode,
-        child: ListView.builder(
-          padding: EdgeInsets.zero,
-          itemCount: tabPage.length,
-          itemBuilder: (context, index) {
-            final bool isSelected = currentIndex == index;
-            final Color itemColor = isSelected
-                ? Colors.white
-                : (isDarkMode ? Colors.white60 : Colors.black54);
+        width: kNipaplayLargeScreenTabPanelWidth,
+        child: Padding(
+          padding: const EdgeInsets.only(
+            bottom: kNipaplayLargeScreenBottomHintHeight,
+          ),
+          child: Column(
+            children: [
+              Expanded(
+                child: ListView.builder(
+                  padding: EdgeInsets.zero,
+                  itemCount: tabPage.length,
+                  itemBuilder: (context, index) {
+                    final bool isSelected = currentIndex == index;
+                    final Color itemColor = isSelected
+                        ? Colors.white
+                        : (isDarkMode ? Colors.white60 : Colors.black54);
 
-            return NipaplayLargeScreenSidePanelItem(
-              isSelected: isSelected,
-              activeColor: activeColor,
-              inactiveColor: inactiveColor,
-              onTap: () {
-                if (tabController.index != index) {
-                  tabController.animateTo(index);
-                }
-              },
-              child: _buildSidePanelTabContent(
-                _stripOuterTabPadding(tabPage[index]),
-                itemColor: itemColor,
+                    return NipaplayLargeScreenSidePanelItem(
+                      isSelected: isSelected,
+                      activeColor: activeColor,
+                      inactiveColor: inactiveColor,
+                      onTap: () {
+                        if (tabController.index != index) {
+                          tabController.animateTo(index);
+                        }
+                        onTabActivated?.call();
+                      },
+                      child: _buildSidePanelTabContent(
+                        _stripOuterTabPadding(tabPage[index]),
+                        itemColor: itemColor,
+                      ),
+                    );
+                  },
+                ),
               ),
-            );
-          },
+              if (onToggleLargeScreen != null ||
+                  onToggleThemeFromOrigin != null ||
+                  onOpenSettings != null)
+                _buildActionItems(
+                  context,
+                  activeColor: activeColor,
+                  inactiveColor: inactiveColor,
+                ),
+            ],
+          ),
         ),
       ),
     );
+  }
+
+  Widget _buildActionItems(
+    BuildContext context, {
+    required Color activeColor,
+    required Color inactiveColor,
+  }) {
+    final actions = <Widget>[];
+
+    if (onToggleLargeScreen != null) {
+      actions.add(
+        NipaplayLargeScreenSidePanelItem(
+          isSelected: false,
+          activeColor: activeColor,
+          inactiveColor: inactiveColor,
+          onTap: () {
+            onToggleLargeScreen!.call();
+            onTabActivated?.call();
+          },
+          child: const Row(
+            children: [
+              Icon(Icons.view_day_rounded, size: 20),
+              SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  '退出大屏幕模式',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    if (onToggleThemeFromOrigin != null) {
+      final String themeActionLabel = isDarkMode
+          ? context.l10n.toggleToLightMode
+          : context.l10n.toggleToDarkMode;
+      final IconData themeActionIcon = isDarkMode
+          ? Icons.nightlight_rounded
+          : Icons.light_mode_rounded;
+      actions.add(
+        NipaplayLargeScreenSidePanelItem(
+          isSelected: false,
+          activeColor: activeColor,
+          inactiveColor: inactiveColor,
+          onTap: () {
+            _toggleTheme(
+              context,
+              onToggleFromOrigin: onToggleThemeFromOrigin,
+            );
+            onTabActivated?.call();
+          },
+          child: Row(
+            children: [
+              Icon(themeActionIcon, size: 20),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  themeActionLabel,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    if (onOpenSettings != null) {
+      actions.add(
+        NipaplayLargeScreenSidePanelItem(
+          isSelected: false,
+          activeColor: activeColor,
+          inactiveColor: inactiveColor,
+          onTap: () {
+            onOpenSettings!.call();
+            onTabActivated?.call();
+          },
+          child: Row(
+            children: [
+              const Icon(Icons.settings_rounded, size: 20),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  context.l10n.settingsLabel,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    return Column(mainAxisSize: MainAxisSize.min, children: actions);
   }
 
   Widget _stripOuterTabPadding(Widget tabWidget) {
@@ -92,4 +239,22 @@ class NipaplayLargeScreenTabPanel extends StatelessWidget {
     }
     return tabWidget;
   }
+}
+
+void _toggleTheme(
+  BuildContext context, {
+  Future<void> Function(Offset globalOrigin)? onToggleFromOrigin,
+}) {
+  if (onToggleFromOrigin != null) {
+    final renderObject = context.findRenderObject();
+    if (renderObject is RenderBox && renderObject.hasSize) {
+      final origin = renderObject.localToGlobal(renderObject.size.center(Offset.zero));
+      onToggleFromOrigin(origin);
+      return;
+    }
+  }
+
+  final isDarkMode = Theme.of(context).brightness == Brightness.dark;
+  context.read<ThemeNotifier>().themeMode =
+      isDarkMode ? ThemeMode.light : ThemeMode.dark;
 }

--- a/lib/themes/nipaplay/widgets/large_screen_tab_panel.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_tab_panel.dart
@@ -45,6 +45,7 @@ class NipaplayLargeScreenTabPanel extends StatelessWidget {
         width: kNipaplayLargeScreenTabPanelWidth,
         child: Padding(
           padding: const EdgeInsets.only(
+            top: kNipaplayLargeScreenBottomHintHeight,
             bottom: kNipaplayLargeScreenBottomHintHeight,
           ),
           child: Column(

--- a/lib/themes/nipaplay/widgets/large_screen_tab_panel.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_tab_panel.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:nipaplay/pages/tab_labels.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_side_panel.dart';
+
+class NipaplayLargeScreenTabPanel extends StatelessWidget {
+  const NipaplayLargeScreenTabPanel({
+    super.key,
+    required this.currentIndex,
+    required this.isDarkMode,
+    required this.tabPage,
+    required this.tabController,
+  });
+
+  final int currentIndex;
+  final bool isDarkMode;
+  final List<Widget> tabPage;
+  final TabController tabController;
+
+  @override
+  Widget build(BuildContext context) {
+    const Color activeColor = Color(0xFFFF2E55);
+    final Color inactiveColor = isDarkMode ? Colors.white60 : Colors.black54;
+    // Keep the side tab panel aligned with page base background color.
+    final Color panelBackgroundColor =
+        isDarkMode ? const Color(0xFF1E1E1E) : const Color(0xFFF2F2F2);
+
+    return ColoredBox(
+      color: panelBackgroundColor,
+      child: NipaplayLargeScreenSidePanel(
+        isDarkMode: isDarkMode,
+        child: ListView.builder(
+          padding: EdgeInsets.zero,
+          itemCount: tabPage.length,
+          itemBuilder: (context, index) {
+            final bool isSelected = currentIndex == index;
+            final Color itemColor = isSelected
+                ? Colors.white
+                : (isDarkMode ? Colors.white60 : Colors.black54);
+
+            return NipaplayLargeScreenSidePanelItem(
+              isSelected: isSelected,
+              activeColor: activeColor,
+              inactiveColor: inactiveColor,
+              onTap: () {
+                if (tabController.index != index) {
+                  tabController.animateTo(index);
+                }
+              },
+              child: _buildSidePanelTabContent(
+                _stripOuterTabPadding(tabPage[index]),
+                itemColor: itemColor,
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget _stripOuterTabPadding(Widget tabWidget) {
+    if (tabWidget is Padding && tabWidget.child != null) {
+      return tabWidget.child!;
+    }
+    return tabWidget;
+  }
+
+  Widget _buildSidePanelTabContent(
+    Widget tabWidget, {
+    required Color itemColor,
+  }) {
+    if (tabWidget is HoverZoomTab) {
+      return Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (tabWidget.icon != null) ...[
+            IconTheme(
+              data: IconThemeData(color: itemColor),
+              child: tabWidget.icon!,
+            ),
+            const SizedBox(width: 6),
+          ],
+          Text(
+            tabWidget.text,
+            style: TextStyle(
+              color: itemColor,
+              fontSize: tabWidget.fontSize,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ],
+      );
+    }
+    return tabWidget;
+  }
+}

--- a/lib/themes/nipaplay/widgets/large_screen_top_status_overlay.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_top_status_overlay.dart
@@ -1,0 +1,214 @@
+import 'dart:async';
+import 'dart:ui';
+
+import 'package:battery_plus/battery_plus.dart';
+import 'package:flutter/cupertino.dart' show CupertinoIcons;
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:nipaplay/services/dandanplay_service.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_bottom_hint_overlay.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_network_status.dart';
+
+class NipaplayLargeScreenTopStatusOverlay extends StatefulWidget {
+  const NipaplayLargeScreenTopStatusOverlay({super.key, required this.isDarkMode});
+
+  final bool isDarkMode;
+
+  @override
+  State<NipaplayLargeScreenTopStatusOverlay> createState() =>
+      _NipaplayLargeScreenTopStatusOverlayState();
+}
+
+class _NipaplayLargeScreenTopStatusOverlayState
+    extends State<NipaplayLargeScreenTopStatusOverlay> {
+  final Battery _battery = Battery();
+  Timer? _timer;
+  StreamSubscription<BatteryState>? _batteryStateSubscription;
+
+  DateTime _now = DateTime.now();
+  int? _batteryLevel;
+  BatteryState? _batteryState;
+  LargeScreenNetworkKind _networkKind = LargeScreenNetworkKind.unavailable;
+  bool _batteryAvailable = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _refreshAll();
+    _timer = Timer.periodic(const Duration(seconds: 30), (_) {
+      if (!mounted) return;
+      _refreshAll();
+    });
+    _listenBatteryState();
+  }
+
+  void _listenBatteryState() {
+    if (kIsWeb) {
+      _batteryAvailable = false;
+      return;
+    }
+    try {
+      _batteryStateSubscription =
+          _battery.onBatteryStateChanged.listen((BatteryState state) {
+        if (!mounted) return;
+        setState(() {
+          _batteryState = state;
+        });
+      });
+    } catch (_) {
+      _batteryAvailable = false;
+    }
+  }
+
+  Future<void> _refreshAll() async {
+    _now = DateTime.now();
+    await Future.wait<void>([
+      _refreshBattery(),
+      _refreshNetworkKind(),
+    ]);
+    if (!mounted) return;
+    setState(() {});
+  }
+
+  Future<void> _refreshBattery() async {
+    if (!_batteryAvailable || kIsWeb) {
+      return;
+    }
+    try {
+      final level = await _battery.batteryLevel;
+      final state = await _battery.batteryState;
+      _batteryLevel = level.clamp(0, 100);
+      _batteryState = state;
+    } catch (_) {
+      _batteryAvailable = false;
+      _batteryLevel = null;
+      _batteryState = null;
+    }
+  }
+
+  Future<void> _refreshNetworkKind() async {
+    _networkKind = await detectLargeScreenNetworkKind();
+  }
+
+  String _formatClock(DateTime time) {
+    final h = time.hour.toString().padLeft(2, '0');
+    final m = time.minute.toString().padLeft(2, '0');
+    return '$h:$m';
+  }
+
+  String _dandanAvatarUrl() {
+    final username = DandanplayService.userName ?? '';
+    if (username.endsWith('@qq.com')) {
+      final qqNumber = username.split('@').first;
+      if (qqNumber.isNotEmpty) {
+        return 'http://q.qlogo.cn/headimg_dl?dst_uin=$qqNumber&spec=640';
+      }
+    }
+    return '';
+  }
+
+  IconData _resolveBatteryIcon() {
+    final level = _batteryLevel;
+    if (_batteryState == BatteryState.charging ||
+        _batteryState == BatteryState.connectedNotCharging) {
+      return CupertinoIcons.battery_charging;
+    }
+    if (level == null || _batteryState == BatteryState.unknown) {
+      return CupertinoIcons.battery_25;
+    }
+    if (level <= 20) return CupertinoIcons.battery_0;
+    if (level <= 60) return CupertinoIcons.battery_25;
+    return CupertinoIcons.battery_100;
+  }
+
+  Widget _buildAvatar(Color textColor) {
+    final avatarUrl = _dandanAvatarUrl();
+    if (!DandanplayService.isLoggedIn) {
+      return Icon(Icons.account_circle_rounded, size: 20, color: textColor);
+    }
+    if (avatarUrl.isEmpty) {
+      return Icon(Icons.account_circle_rounded, size: 20, color: textColor);
+    }
+    return ClipOval(
+      child: Image.network(
+        avatarUrl,
+        width: 20,
+        height: 20,
+        fit: BoxFit.cover,
+        errorBuilder: (_, __, ___) => Icon(
+          Icons.account_circle_rounded,
+          size: 20,
+          color: textColor,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildNetworkIcon(Color textColor) {
+    switch (_networkKind) {
+      case LargeScreenNetworkKind.wifi:
+        return Icon(Icons.wifi_rounded, size: 18, color: textColor);
+      case LargeScreenNetworkKind.cellular:
+        return Icon(Icons.network_cell_rounded, size: 18, color: textColor);
+      case LargeScreenNetworkKind.unavailable:
+        return const SizedBox.shrink();
+    }
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    _batteryStateSubscription?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final textColor = widget.isDarkMode ? Colors.white : Colors.black87;
+    final backgroundTint = widget.isDarkMode
+        ? Colors.black.withValues(alpha: 0.18)
+        : Colors.white.withValues(alpha: 0.14);
+    final clockText = _formatClock(_now);
+
+    return SizedBox(
+      height: kNipaplayLargeScreenBottomHintHeight,
+      child: ClipRect(
+        child: BackdropFilter(
+          filter: ImageFilter.blur(sigmaX: 25, sigmaY: 25),
+          child: ColoredBox(
+            color: backgroundTint,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12),
+              child: Align(
+                alignment: Alignment.centerRight,
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    if (_networkKind != LargeScreenNetworkKind.unavailable) ...[
+                      _buildNetworkIcon(textColor),
+                      const SizedBox(width: 10),
+                    ],
+                    if (_batteryLevel != null) ...[
+                      Icon(_resolveBatteryIcon(), size: 18, color: textColor),
+                      const SizedBox(width: 10),
+                    ],
+                    Text(
+                      clockText,
+                      style: TextStyle(
+                        color: textColor,
+                        fontSize: 14,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                    const SizedBox(width: 10),
+                    _buildAvatar(textColor),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/themes/nipaplay/widgets/large_screen_window_page.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_window_page.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+
+class NipaplayLargeScreenWindowPageRoute<T> extends PageRoute<T> {
+  NipaplayLargeScreenWindowPageRoute({
+    required this.builder,
+    this.enableAnimation = true,
+    this.dismissible = true,
+    super.settings,
+  });
+
+  final WidgetBuilder builder;
+  final bool enableAnimation;
+  final bool dismissible;
+
+  @override
+  bool get opaque => false;
+
+  @override
+  Color? get barrierColor => Colors.transparent;
+
+  @override
+  String? get barrierLabel => 'Close';
+
+  @override
+  bool get barrierDismissible => dismissible;
+
+  @override
+  bool get maintainState => true;
+
+  @override
+  Duration get transitionDuration => const Duration(milliseconds: 250);
+
+  @override
+  Widget buildPage(
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+  ) {
+    return builder(context);
+  }
+
+  @override
+  Widget buildTransitions(
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  ) {
+    if (!enableAnimation) {
+      return FadeTransition(
+        opacity: Tween<double>(begin: 0.0, end: 1.0).animate(
+          CurvedAnimation(parent: animation, curve: Curves.easeOut),
+        ),
+        child: child,
+      );
+    }
+
+    final curvedAnimation = CurvedAnimation(
+      parent: animation,
+      curve: Curves.easeOutBack,
+    );
+    return ScaleTransition(
+      scale: Tween<double>(begin: 0.8, end: 1.0).animate(curvedAnimation),
+      child: FadeTransition(
+        opacity: animation,
+        child: child,
+      ),
+    );
+  }
+}

--- a/lib/themes/nipaplay/widgets/nipaplay_window.dart
+++ b/lib/themes/nipaplay/widgets/nipaplay_window.dart
@@ -4,6 +4,8 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:nipaplay/providers/appearance_settings_provider.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/cached_network_image_widget.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_mode_scope.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_window_page.dart';
 import 'package:nipaplay/utils/globals.dart' as globals;
 import 'package:provider/provider.dart';
 
@@ -411,6 +413,18 @@ class NipaplayWindow {
     bool barrierDismissible = true,
     Color barrierColor = Colors.transparent,
   }) {
+    final bool useLargeScreenSubPage =
+        NipaplayLargeScreenModeScope.isActiveOf(context);
+    if (useLargeScreenSubPage) {
+      return Navigator.of(context).push<T>(
+        NipaplayLargeScreenWindowPageRoute<T>(
+          builder: (_) => child,
+          enableAnimation: enableAnimation,
+          dismissible: barrierDismissible,
+        ),
+      );
+    }
+
     return showGeneralDialog<T>(
       context: context,
       barrierDismissible: barrierDismissible,

--- a/lib/themes/nipaplay/widgets/settings_item.dart
+++ b/lib/themes/nipaplay/widgets/settings_item.dart
@@ -328,6 +328,10 @@ class SettingsItem extends StatelessWidget {
     switch (type) {
       case SettingsItemType.dropdown:
         final bool alignDropdownToTop = _hasDropdownDescriptions();
+        final List<DropdownMenuItemData> items =
+            dropdownItems ?? const <DropdownMenuItemData>[];
+        final bool canCycleSelection =
+            enabled && items.isNotEmpty && onDropdownChanged != null;
         return ListTile(
           titleAlignment:
               alignDropdownToTop ? ListTileTitleAlignment.top : null,
@@ -356,6 +360,15 @@ class SettingsItem extends StatelessWidget {
                     onItemSelected: onDropdownChanged!,
                   ),
                 )
+              : null,
+          onTap: canCycleSelection
+              ? () async {
+                  final currentIndex = items.indexWhere((item) => item.isSelected);
+                  final nextIndex = currentIndex < 0
+                      ? 0
+                      : ((currentIndex + 1) % items.length);
+                  await onDropdownChanged!(items[nextIndex].value);
+                }
               : null,
           enabled: enabled,
         );
@@ -433,6 +446,15 @@ class SettingsItem extends StatelessWidget {
           enabled: enabled,
         );
       case SettingsItemType.slider:
+        final double min = sliderMin ?? 0;
+        final double max = sliderMax ?? 1;
+        final double current = sliderValue ?? min;
+        final int? divisions = sliderDivisions;
+        final double step = (divisions != null && divisions > 0)
+            ? ((max - min) / divisions)
+            : ((max - min) / 20);
+        final bool canAdjustByEnter =
+            enabled && onSliderChanged != null && max > min && step > 0;
         return Column(
           children: [
             ListTile(
@@ -471,6 +493,15 @@ class SettingsItem extends StatelessWidget {
                   fontWeight: FontWeight.bold,
                 ),
               ),
+              onTap: canAdjustByEnter
+                  ? () {
+                      double next = current + step;
+                      if (next > max) {
+                        next = min;
+                      }
+                      onSliderChanged!(next.clamp(min, max));
+                    }
+                  : null,
             ),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
@@ -483,9 +514,9 @@ class SettingsItem extends StatelessWidget {
                   }),
                 ),
                 child: fluent.Slider(
-                  value: sliderValue ?? 0,
-                  min: sliderMin ?? 0,
-                  max: sliderMax ?? 1,
+                  value: current,
+                  min: min,
+                  max: max,
                   divisions: sliderDivisions,
                   onChanged: enabled ? onSliderChanged : null,
                   label: sliderLabelFormatter?.call(sliderValue ?? 0),

--- a/lib/themes/nipaplay/widgets/settings_item.dart
+++ b/lib/themes/nipaplay/widgets/settings_item.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:kmbal_ionicons/kmbal_ionicons.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_dropdown.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/fluent_settings_switch.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_editable_slider.dart';
 
 const Color _fluentAccentColor = Color(0xFFFF2E55);
 
@@ -513,7 +514,7 @@ class SettingsItem extends StatelessWidget {
                     'default': _fluentAccentColor,
                   }),
                 ),
-                child: fluent.Slider(
+                child: NipaplayLargeScreenEditableSlider(
                   value: current,
                   min: min,
                   max: max,

--- a/lib/themes/nipaplay/widgets/settings_item.dart
+++ b/lib/themes/nipaplay/widgets/settings_item.dart
@@ -329,10 +329,6 @@ class SettingsItem extends StatelessWidget {
     switch (type) {
       case SettingsItemType.dropdown:
         final bool alignDropdownToTop = _hasDropdownDescriptions();
-        final List<DropdownMenuItemData> items =
-            dropdownItems ?? const <DropdownMenuItemData>[];
-        final bool canCycleSelection =
-            enabled && items.isNotEmpty && onDropdownChanged != null;
         return ListTile(
           titleAlignment:
               alignDropdownToTop ? ListTileTitleAlignment.top : null,
@@ -362,15 +358,7 @@ class SettingsItem extends StatelessWidget {
                   ),
                 )
               : null,
-          onTap: canCycleSelection
-              ? () async {
-                  final currentIndex = items.indexWhere((item) => item.isSelected);
-                  final nextIndex = currentIndex < 0
-                      ? 0
-                      : ((currentIndex + 1) % items.length);
-                  await onDropdownChanged!(items[nextIndex].value);
-                }
-              : null,
+          onTap: null,
           enabled: enabled,
         );
       case SettingsItemType.toggle:

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -20,7 +20,6 @@ list(APPEND FLUTTER_PLUGIN_LIST
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
-  jni
   nipaplay_smb2
 )
 

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -23,7 +23,6 @@ list(APPEND FLUTTER_PLUGIN_LIST
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
-  jni
   nipaplay_smb2
 )
 


### PR DESCRIPTION
## 变更内容
- 在 nipaplay 主题设置中新增 `实验室` 板块
- 新增首个实验开关：`大屏幕模式`
- 仅当该开关开启时，nipaplay 主题右上角显示大屏幕模式按钮
- 在 cupertino 主题设置中同步加入 `实验室` 入口与页面
- 两个主题共用同一实验室设置项（持久化）

## 影响范围
- 设置页面结构（nipaplay / cupertino）
- 主页面右上角动作区大屏按钮显示逻辑
- 大屏模式入口可用性控制

## 验证
- 已对本次改动文件做 `flutter analyze` 定向检查（无新增 error）
