### PR TITLE
feat: WebDAV 快捷 Tab + 播放器手势优化

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -82,6 +82,8 @@ import 'package:nipaplay/models/watch_history_database.dart';
 import 'package:nipaplay/services/http_client_initializer.dart';
 import 'package:nipaplay/services/smb_proxy_service.dart';
 import 'package:nipaplay/providers/bottom_bar_provider.dart';
+import 'package:nipaplay/providers/webdav_quick_access_provider.dart';
+import 'pages/webdav_browser_page.dart';
 import 'package:nipaplay/models/anime_detail_display_mode.dart';
 import 'package:nipaplay/models/background_image_render_mode.dart';
 import 'package:nipaplay/pages/desktop_pip_window_app.dart';
@@ -652,6 +654,7 @@ void main(List<String> args) async {
       MultiProvider(
         providers: [
           ChangeNotifierProvider(create: (_) => BottomBarProvider()),
+          ChangeNotifierProvider(create: (_) => WebDAVQuickAccessProvider()),
           ChangeNotifierProvider(create: (_) => AppLanguageProvider()),
           ChangeNotifierProvider(create: (_) => SettingsProvider()),
           ChangeNotifierProvider(create: (_) => VideoPlayerState()),
@@ -1067,22 +1070,7 @@ class _NipaPlayAppState extends State<NipaPlayApp> with WidgetsBindingObserver {
 class MainPage extends StatefulWidget {
   final String? launchFilePath;
 
-  // 根据平台动态创建pages列表
-  static List<Widget> createPages() {
-    List<Widget> pages = [
-      const DashboardHomePage(),
-      const PlayVideoPage(),
-      const AnimePage(),
-      const AccountPage(),
-    ];
-    return pages;
-  }
-
-  late final List<Widget> pages;
-
-  MainPage({super.key, this.launchFilePath}) {
-    pages = createPages();
-  }
+  MainPage({super.key, this.launchFilePath});
 
   @override
   // ignore: library_private_types_in_public_api
@@ -1096,6 +1084,17 @@ class MainPageState extends State<MainPage>
   bool _showSplash = true;
   bool _isThemeRevealRunning = false;
   bool _useLargeScreenLayout = false;
+
+  // 动态页面列表
+  static const List<Widget> _basePages = [
+    DashboardHomePage(),
+    PlayVideoPage(),
+    AnimePage(),
+    AccountPage(),
+  ];
+  List<Widget> _pages = [];
+  bool _showWebDAVTab = false;
+  WebDAVQuickAccessProvider? _webdavQuickAccessProvider;
 
   // 用于热键管理
   bool _hotkeysAreRegistered = false;
@@ -1185,8 +1184,6 @@ class MainPageState extends State<MainPage>
     _manageHotkeys();
   }
 
-  int _defaultPageIndex = 0;
-
   @override
   void initState() {
     super.initState();
@@ -1194,26 +1191,88 @@ class MainPageState extends State<MainPage>
   }
 
   Future<void> _initialize() async {
+    // 加载 WebDAV 快捷设置
+    try {
+      _webdavQuickAccessProvider =
+          Provider.of<WebDAVQuickAccessProvider>(context, listen: false);
+      await _webdavQuickAccessProvider!.loadSettings();
+      _showWebDAVTab = _webdavQuickAccessProvider!.showWebDAVTab;
+      _webdavQuickAccessProvider!.addListener(_onWebDAVSettingsChanged);
+    } catch (e) {
+      debugPrint('加载 WebDAV 快捷设置失败: $e');
+    }
+
+    // 构建初始页面列表
+    _rebuildPages();
+
     await _initializeController();
     _initializeListeners();
     _postFrameCallbacks();
   }
 
-  Future<void> _initializeController() async {
-    final prefs = await SharedPreferences.getInstance();
-    _defaultPageIndex = prefs.getInt('default_page_index') ?? 0;
-    _useLargeScreenLayout = await LargeScreenModePreferences.load();
+  void _onWebDAVSettingsChanged() {
+    final showWebDAVTab = _webdavQuickAccessProvider?.showWebDAVTab ?? false;
+    if (showWebDAVTab != _showWebDAVTab) {
+      _showWebDAVTab = showWebDAVTab;
+      _rebuildPages();
+      _rebuildTabController();
+    }
+  }
 
-    // 强制启用页面滑动动画
-    // ... (注释省略)
+  void _rebuildPages() {
+    _pages = List<Widget>.from(_basePages);
+    if (_showWebDAVTab) {
+      _pages.insert(2, const WebDAVBrowserPage());
+    }
+  }
+
+  int _getInitialTabIndex() {
+    final defaultTab = _webdavQuickAccessProvider?.effectiveDefaultHomeTab ?? WebDAVQuickAccessProvider.tabHome;
+
+    switch (defaultTab) {
+      case WebDAVQuickAccessProvider.tabHome:
+        return 0;
+      case WebDAVQuickAccessProvider.tabVideo:
+        return 1;
+      case WebDAVQuickAccessProvider.tabWebDAV:
+        return _showWebDAVTab ? 2 : 0;
+      case WebDAVQuickAccessProvider.tabMediaLibrary:
+        return _showWebDAVTab ? 3 : 2;
+      case WebDAVQuickAccessProvider.tabAccount:
+        return _showWebDAVTab ? 4 : 3;
+      case WebDAVQuickAccessProvider.tabSettings:
+        return _showWebDAVTab ? 3 : 2;
+      default:
+        return 0;
+    }
+  }
+
+  void _rebuildTabController() {
+    final currentIndex = globalTabController?.index ?? 0;
+    globalTabController?.removeListener(_onTabChange);
+    globalTabController?.dispose();
+
+    final tabLength = _pages.length;
+    globalTabController = TabController(
+      length: tabLength,
+      vsync: this,
+      initialIndex: currentIndex.clamp(0, tabLength - 1),
+    );
+    globalTabController?.addListener(_onTabChange);
+
+    setState(() {});
+  }
+
+  Future<void> _initializeController() async {
+    _useLargeScreenLayout = await LargeScreenModePreferences.load();
+    final initialIndex = _getInitialTabIndex();
 
     if (mounted) {
-      // 主页面Tab数量与页面列表保持一致
-      final tabLength = widget.pages.length;
+      final tabLength = _pages.length;
       globalTabController = TabController(
         length: tabLength,
         vsync: this,
-        initialIndex: _defaultPageIndex.clamp(0, tabLength - 1),
+        initialIndex: initialIndex.clamp(0, tabLength - 1),
       );
     }
   }
@@ -1258,7 +1317,7 @@ class MainPageState extends State<MainPage>
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       if (!mounted) return;
 
-      // 直接使用已加载的 _defaultPageIndex, 不再需要动画切换
+      // 使用 _getInitialTabIndex() 设置的初始 Tab
       // 如果需要启动动画，可以在这里实现
 
       // 延迟一段时间后隐藏启动画面
@@ -1576,8 +1635,8 @@ class MainPageState extends State<MainPage>
             selector: (context, videoState) => videoState.shouldShowAppBar(),
             builder: (context, shouldShowAppBar, child) {
               return CustomScaffold(
-                pages: widget.pages,
-                tabPage: createTabLabels(context),
+                pages: _pages,
+                tabPage: createTabLabels(context, showWebDAVTab: _showWebDAVTab),
                 pageIsHome: true,
                 shouldShowAppBar: shouldShowAppBar,
                 tabController: globalTabController,

--- a/lib/pages/play_video_page.dart
+++ b/lib/pages/play_video_page.dart
@@ -40,6 +40,7 @@ class _PlayVideoPageState extends State<PlayVideoPage> {
   bool _isUiLocked = false;
   bool _showUiLockButton = false;
   Timer? _uiLockButtonTimer;
+  bool _isExiting = false;
 
   bool get _isMacOSHdrVideoOnlyEnabled {
     return !kIsWeb &&
@@ -69,7 +70,14 @@ class _PlayVideoPageState extends State<PlayVideoPage> {
   // 处理系统返回键事件
   Future<bool> _handleWillPop() async {
     final videoState = Provider.of<VideoPlayerState>(context, listen: false);
-    return await videoState.handleBackButton();
+    final shouldExit = await videoState.handleBackButton();
+    if (shouldExit) {
+      setState(() => _isExiting = true);
+      unawaited(videoState.resetPlayer().catchError((e) {
+        debugPrint('退出重置失败: $e');
+      }));
+    }
+    return shouldExit;
   }
 
   void _handleSideSwipeDragStart(DragStartDetails details) {
@@ -374,7 +382,9 @@ class _PlayVideoPageState extends State<PlayVideoPage> {
         return WillPopScope(
           onWillPop: _handleWillPop,
           child: AnimatedContainer(
-            duration: const Duration(milliseconds: 300),
+            duration: _isExiting
+                ? Duration.zero
+                : const Duration(milliseconds: 300),
             curve: Curves.easeInOut,
             color: videoState.hasVideo && !_isMacOSHdrTransparentFlutterEnabled
                 ? Colors.black

--- a/lib/pages/tab_labels.dart
+++ b/lib/pages/tab_labels.dart
@@ -2,7 +2,7 @@
 import 'package:flutter/material.dart';
 import 'package:nipaplay/l10n/l10n.dart';
 
-List<Widget> createTabLabels(BuildContext context) {
+List<Widget> createTabLabels(BuildContext context, {bool showWebDAVTab = false}) {
   List<Widget> tabs = [
     Padding(
       padding: EdgeInsets.symmetric(horizontal: 8.0),
@@ -12,6 +12,19 @@ List<Widget> createTabLabels(BuildContext context) {
       padding: EdgeInsets.symmetric(horizontal: 8.0),
       child: HoverZoomTab(text: context.l10n.tabVideoPlay),
     ),
+  ];
+
+  // 动态插入 WebDAV Tab
+  if (showWebDAVTab) {
+    tabs.add(
+      const Padding(
+        padding: EdgeInsets.symmetric(horizontal: 8.0),
+        child: HoverZoomTab(text: 'WebDAV'),
+      ),
+    );
+  }
+
+  tabs.addAll([
     Padding(
       padding: EdgeInsets.symmetric(horizontal: 8.0),
       child: HoverZoomTab(text: context.l10n.tabMediaLibrary),
@@ -20,7 +33,7 @@ List<Widget> createTabLabels(BuildContext context) {
       padding: EdgeInsets.symmetric(horizontal: 8.0),
       child: HoverZoomTab(text: context.l10n.tabAccount),
     ),
-  ];
+  ]);
 
   return tabs;
 }

--- a/lib/pages/webdav_browser_page.dart
+++ b/lib/pages/webdav_browser_page.dart
@@ -1,0 +1,887 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:nipaplay/services/webdav_service.dart';
+import 'package:nipaplay/providers/webdav_quick_access_provider.dart';
+import 'package:nipaplay/providers/watch_history_provider.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/blur_snackbar.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/webdav_connection_dialog.dart';
+import 'package:nipaplay/models/watch_history_model.dart';
+import 'package:nipaplay/models/playable_item.dart';
+import 'package:nipaplay/services/playback_service.dart';
+import 'package:kmbal_ionicons/kmbal_ionicons.dart';
+
+/// WebDAV 文件浏览器页面
+/// 用于快捷 Tab，提供快速浏览和播放 WebDAV 视频的功能
+class WebDAVBrowserPage extends StatefulWidget {
+  const WebDAVBrowserPage({super.key});
+
+  @override
+  State<WebDAVBrowserPage> createState() => _WebDAVBrowserPageState();
+}
+
+class _WebDAVBrowserPageState extends State<WebDAVBrowserPage> {
+  // 当前选中的服务器连接
+  WebDAVConnection? _currentConnection;
+  // 当前路径
+  String _currentPath = '/';
+  // 路径历史，用于返回
+  final List<String> _pathHistory = [];
+  // 当前目录内容
+  List<WebDAVFile> _currentFiles = [];
+  // 加载状态
+  bool _isLoading = false;
+  // 是否正在初始化
+  bool _isInitializing = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _initializePage();
+  }
+
+  Future<void> _initializePage() async {
+    // 初始化 WebDAV 服务
+    await WebDAVService.instance.initialize();
+
+    if (!mounted) return;
+
+    // 加载快捷设置
+    final provider = Provider.of<WebDAVQuickAccessProvider>(context, listen: false);
+    await provider.loadSettings();
+
+    if (!mounted) return;
+
+    // 设置默认服务器
+    if (provider.hasValidDefaultServer) {
+      _currentConnection = provider.defaultConnection;
+      _currentPath = provider.defaultDirectory;
+    } else if (WebDAVService.instance.connections.isNotEmpty) {
+      // 如果没有设置默认服务器，使用第一个可用的连接
+      _currentConnection = WebDAVService.instance.connections.first;
+      _currentPath = '/';
+    }
+
+    setState(() {
+      _isInitializing = false;
+    });
+
+    // 加载目录内容
+    if (_currentConnection != null) {
+      await _loadDirectory();
+    }
+  }
+
+  Future<void> _loadDirectory({bool isRecursive = false}) async {
+    if (_currentConnection == null) return;
+    // 只在非递归调用时检查 _isLoading，避免重入
+    if (!isRecursive && _isLoading) return;
+
+    setState(() {
+      _isLoading = true;
+    });
+
+    try {
+      final files = await WebDAVService.instance.listDirectory(
+        _currentConnection!,
+        _currentPath,
+      );
+
+      // 应用排序预设
+      final provider = Provider.of<WebDAVQuickAccessProvider>(context, listen: false);
+      _sortFiles(files, provider.sortPreset);
+
+      // 检查是否需要自动进入 Season 文件夹
+      if (provider.autoEnterSeasonFolder) {
+        final folderNames = files
+            .where((f) => f.isDirectory)
+            .map((f) => f.name)
+            .toList();
+        final matchFolder = provider.findMatchingSeasonFolder(folderNames);
+
+        if (matchFolder != null && mounted) {
+          // 找到匹配的文件夹，自动进入
+          final matchPath = _currentPath.endsWith('/')
+              ? '$_currentPath$matchFolder'
+              : '$_currentPath/$matchFolder';
+          setState(() {
+            _currentPath = matchPath;
+          });
+          // 递归加载（标记为递归调用）
+          await _loadDirectory(isRecursive: true);
+          return;
+        }
+      }
+
+      if (mounted) {
+        setState(() {
+          _currentFiles = files;
+          _isLoading = false;
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+        BlurSnackBar.show(context, '加载目录失败: $e');
+      }
+    }
+  }
+
+  /// 根据排序预设对文件列表排序
+  void _sortFiles(List<WebDAVFile> files, WebDAVSortPreset preset) {
+    switch (preset) {
+      case WebDAVSortPreset.defaultValue:
+        // 默认：文件夹在前，各自按名称 A-Z
+        files.sort((a, b) {
+          if (a.isDirectory && !b.isDirectory) return -1;
+          if (!a.isDirectory && b.isDirectory) return 1;
+          return a.name.toLowerCase().compareTo(b.name.toLowerCase());
+        });
+        break;
+
+      case WebDAVSortPreset.nameAsc:
+        // 名称 A-Z（混合排序）
+        files.sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+        break;
+
+      case WebDAVSortPreset.nameDesc:
+        // 名称 Z-A（混合排序）
+        files.sort((a, b) => b.name.toLowerCase().compareTo(a.name.toLowerCase()));
+        break;
+
+      case WebDAVSortPreset.modifiedDesc:
+        // 最新修改
+        files.sort((a, b) {
+          final aTime = a.lastModified ?? DateTime(1970);
+          final bTime = b.lastModified ?? DateTime(1970);
+          return bTime.compareTo(aTime);
+        });
+        break;
+
+      case WebDAVSortPreset.modifiedAsc:
+        // 最旧修改
+        files.sort((a, b) {
+          final aTime = a.lastModified ?? DateTime(1970);
+          final bTime = b.lastModified ?? DateTime(1970);
+          return aTime.compareTo(bTime);
+        });
+        break;
+
+      case WebDAVSortPreset.sizeDesc:
+        // 最大文件
+        files.sort((a, b) {
+          final aSize = a.size ?? 0;
+          final bSize = b.size ?? 0;
+          return bSize.compareTo(aSize);
+        });
+        break;
+
+      case WebDAVSortPreset.sizeAsc:
+        // 最小文件
+        files.sort((a, b) {
+          final aSize = a.size ?? 0;
+          final bSize = b.size ?? 0;
+          return aSize.compareTo(bSize);
+        });
+        break;
+    }
+  }
+
+  void _navigateToDirectory(String path) {
+    if (_currentPath != '/') {
+      _pathHistory.add(_currentPath);
+    }
+    setState(() {
+      _currentPath = path;
+    });
+    _loadDirectory();
+  }
+
+  void _navigateBack() {
+    if (_pathHistory.isNotEmpty) {
+      setState(() {
+        _currentPath = _pathHistory.removeLast();
+      });
+      _loadDirectory();
+    } else if (_currentPath != '/') {
+      // 返回上一级目录（而不是直接跳到根目录）
+      final segments = _currentPath.split('/').where((s) => s.isNotEmpty).toList();
+      if (segments.isNotEmpty) {
+        segments.removeLast();
+        final parentPath = segments.isEmpty ? '/' : '/' + segments.join('/');
+        setState(() {
+          _currentPath = parentPath;
+        });
+        _loadDirectory();
+      }
+    }
+  }
+
+  /// 是否可以返回上一级
+  bool get _canNavigateBack => _currentPath != '/';
+
+  void _playVideo(WebDAVFile file) {
+    if (_currentConnection == null) return;
+
+    final videoUrl = WebDAVService.instance.getFileUrl(
+      _currentConnection!,
+      file.path,
+    );
+
+    // 创建观看历史项用于播放
+    final historyItem = WatchHistoryItem(
+      animeName: file.name.replaceAll(RegExp(r'\.[^.]+$'), ''),
+      episodeTitle: file.name,
+      filePath: videoUrl,
+      watchProgress: 0,
+      lastPosition: 0,
+      duration: 0,
+      lastWatchTime: DateTime.now(),
+    );
+
+    // 使用 PlaybackService 播放视频
+    final playableItem = PlayableItem(
+      videoPath: videoUrl,
+      title: file.name.replaceAll(RegExp(r'\.[^.]+$'), ''),
+      subtitle: file.name,
+      historyItem: historyItem,
+    );
+
+    PlaybackService().play(playableItem);
+  }
+
+  void _showServerSelector() {
+    final connections = WebDAVService.instance.connections;
+    if (connections.isEmpty) {
+      BlurSnackBar.show(context, '没有配置任何 WebDAV 服务器');
+      return;
+    }
+
+    showModalBottomSheet(
+      context: context,
+      backgroundColor: Colors.transparent,
+      builder: (context) => _ServerSelectorSheet(
+        connections: connections,
+        currentConnection: _currentConnection,
+        onSelected: (connection) {
+          setState(() {
+            _currentConnection = connection;
+            _currentPath = '/';
+            _pathHistory.clear();
+          });
+          _loadDirectory();
+        },
+      ),
+    );
+  }
+
+  /// 显示添加 WebDAV 服务器对话框
+  Future<void> _showAddServerDialog() async {
+    final connectionsBefore = WebDAVService.instance.connections.length;
+
+    final result = await WebDAVConnectionDialog.show(context);
+
+    if (result == true && mounted) {
+      // 添加成功
+      final connectionsAfter = WebDAVService.instance.connections;
+
+      if (connectionsAfter.isNotEmpty) {
+        // 获取新添加的服务器（最后一个）
+        final newConnection = connectionsAfter.last;
+
+        // 如果添加前没有服务器，添加后只有一个服务器，则自动设置为默认服务器
+        if (connectionsBefore == 0 && connectionsAfter.length == 1) {
+          final provider = Provider.of<WebDAVQuickAccessProvider>(context, listen: false);
+          await provider.setDefaultServerName(newConnection.name);
+          BlurSnackBar.show(context, '已将 ${newConnection.name} 设置为默认 WebDAV 服务器');
+        }
+
+        // 自动选择新添加的服务器并加载目录
+        setState(() {
+          _currentConnection = newConnection;
+          _currentPath = '/';
+          _pathHistory.clear();
+        });
+        await _loadDirectory();
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final backgroundColor = isDark ? const Color(0xFF1A1A1A) : const Color(0xFFF5F5F5);
+    final cardColor = isDark ? const Color(0xFF2A2A2A) : Colors.white;
+    final textColor = isDark ? Colors.white : Colors.black87;
+    final secondaryTextColor = isDark ? Colors.white60 : Colors.black54;
+    final accentColor = const Color(0xFFFF2E55);
+
+    if (_isInitializing) {
+      return Scaffold(
+        backgroundColor: backgroundColor,
+        body: const Center(
+          child: CircularProgressIndicator(color: Color(0xFFFF2E55)),
+        ),
+      );
+    }
+
+    // 没有配置任何 WebDAV 服务器
+    if (_currentConnection == null) {
+      return Scaffold(
+        backgroundColor: backgroundColor,
+        body: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(
+                Icons.cloud_off_outlined,
+                size: 64,
+                color: secondaryTextColor,
+              ),
+              const SizedBox(height: 16),
+              Text(
+                '没有配置 WebDAV 服务器',
+                style: TextStyle(
+                  fontSize: 18,
+                  color: textColor,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                '请先在设置中添加 WebDAV 服务器',
+                style: TextStyle(
+                  fontSize: 14,
+                  color: secondaryTextColor,
+                ),
+              ),
+              const SizedBox(height: 24),
+              ElevatedButton.icon(
+                onPressed: () => _showAddServerDialog(),
+                icon: const Icon(Icons.add),
+                label: const Text('添加服务器'),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: accentColor,
+                  foregroundColor: Colors.white,
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    return PopScope(
+      canPop: !_canNavigateBack, // 如果可以返回上一级，则阻止系统返回
+      onPopInvokedWithResult: (didPop, result) {
+        if (!didPop && _canNavigateBack) {
+          _navigateBack();
+        }
+      },
+      child: Scaffold(
+        backgroundColor: backgroundColor,
+        body: Column(
+          children: [
+            // 顶部导航栏
+            _buildNavigationBar(
+              context: context,
+              cardColor: cardColor,
+              textColor: textColor,
+              secondaryTextColor: secondaryTextColor,
+              accentColor: accentColor,
+            ),
+            // 文件列表
+            Expanded(
+              child: _isLoading
+                  ? const Center(
+                      child: CircularProgressIndicator(color: Color(0xFFFF2E55)),
+                    )
+                  : _currentFiles.isEmpty
+                      ? Center(
+                          child: Text(
+                            '当前目录为空',
+                            style: TextStyle(color: secondaryTextColor),
+                          ),
+                        )
+                      : ListView.builder(
+                          padding: const EdgeInsets.all(16),
+                        itemCount: _currentFiles.length,
+                        itemBuilder: (context, index) {
+                          final file = _currentFiles[index];
+                          return _buildFileItem(
+                            file: file,
+                            cardColor: cardColor,
+                            textColor: textColor,
+                            secondaryTextColor: secondaryTextColor,
+                            accentColor: accentColor,
+                          );
+                        },
+                      ),
+          ),
+        ],
+      ),
+      ),
+    );
+  }
+
+  Widget _buildNavigationBar({
+    required BuildContext context,
+    required Color cardColor,
+    required Color textColor,
+    required Color secondaryTextColor,
+    required Color accentColor,
+  }) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(16, 48, 16, 16),
+      decoration: BoxDecoration(
+        color: cardColor,
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.1),
+            blurRadius: 4,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // 服务器选择和返回按钮
+          Row(
+            children: [
+              // 返回按钮
+              if (_currentPath != '/' || _pathHistory.isNotEmpty)
+                IconButton(
+                  icon: const Icon(Icons.arrow_back),
+                  color: textColor,
+                  onPressed: _navigateBack,
+                ),
+              // 服务器选择
+              Expanded(
+                child: InkWell(
+                  onTap: _showServerSelector,
+                  borderRadius: BorderRadius.circular(8),
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 12,
+                      vertical: 10,
+                    ),
+                    decoration: BoxDecoration(
+                      color: cardColor.withOpacity(0.5),
+                      borderRadius: BorderRadius.circular(8),
+                      border: Border.all(
+                        color: secondaryTextColor.withOpacity(0.3),
+                      ),
+                    ),
+                    child: Row(
+                      children: [
+                        Icon(
+                          Icons.cloud_outlined,
+                          size: 20,
+                          color: accentColor,
+                        ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            _currentConnection?.name ?? '选择服务器',
+                            style: TextStyle(
+                              color: textColor,
+                              fontSize: 14,
+                            ),
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                        Icon(
+                          Icons.expand_more,
+                          size: 20,
+                          color: secondaryTextColor,
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+          // 路径面包屑导航（根据设置显示）
+          if (Provider.of<WebDAVQuickAccessProvider>(context).showPathBreadcrumb) ...[
+            const SizedBox(height: 12),
+            _buildPathBreadcrumb(
+              textColor: textColor,
+              secondaryTextColor: secondaryTextColor,
+              accentColor: accentColor,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPathBreadcrumb({
+    required Color textColor,
+    required Color secondaryTextColor,
+    required Color accentColor,
+  }) {
+    // 将路径分割成片段
+    final segments = _currentPath.split('/').where((s) => s.isNotEmpty).toList();
+    final hasSegments = segments.isNotEmpty;
+
+    return SizedBox(
+      height: 32,
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        physics: const BouncingScrollPhysics(),
+        child: Row(
+          children: [
+            // 根目录
+            InkWell(
+              onTap: () => _navigateToPath('/'),
+              borderRadius: BorderRadius.circular(4),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
+                child: Text(
+                  '根目录',
+                  style: TextStyle(
+                    color: !hasSegments ? accentColor : secondaryTextColor,
+                    fontSize: 13,
+                    fontWeight: !hasSegments ? FontWeight.w600 : FontWeight.normal,
+                  ),
+                ),
+              ),
+            ),
+            // 路径片段
+            ...List.generate(segments.length, (index) {
+              final segment = segments[index];
+              final isLast = index == segments.length - 1;
+              final path = '/' + segments.sublist(0, index + 1).join('/');
+
+              return Row(
+                children: [
+                  Icon(
+                    Icons.chevron_right,
+                    size: 16,
+                    color: secondaryTextColor,
+                  ),
+                  InkWell(
+                    onTap: isLast ? null : () => _navigateToPath(path),
+                    borderRadius: BorderRadius.circular(4),
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
+                      child: Text(
+                        segment,
+                        style: TextStyle(
+                          color: isLast ? accentColor : secondaryTextColor,
+                          fontSize: 13,
+                          fontWeight: isLast ? FontWeight.w600 : FontWeight.normal,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              );
+            }),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _navigateToPath(String path) {
+    // 清空历史记录，直接跳转到指定路径
+    setState(() {
+      _pathHistory.clear();
+      _currentPath = path;
+    });
+    _loadDirectory();
+  }
+
+  Widget _buildFileItem({
+    required WebDAVFile file,
+    required Color cardColor,
+    required Color textColor,
+    required Color secondaryTextColor,
+    required Color accentColor,
+  }) {
+    final isDirectory = file.isDirectory;
+
+    // 提取 SxxExx 季集信息
+    String? seasonEpisode;
+    if (!isDirectory) {
+      final match = RegExp(r'[Ss](\d{1,2})[Ee](\d{1,2})').firstMatch(file.name);
+      if (match != null) {
+        seasonEpisode = 'S${match.group(1)}E${match.group(2)}';
+      }
+    }
+
+    // 查找播放历史
+    final videoUrl = _currentConnection != null
+        ? WebDAVService.instance.getFileUrl(_currentConnection!, file.path)
+        : null;
+    final historyProvider = Provider.of<WatchHistoryProvider>(context, listen: false);
+    WatchHistoryItem? historyItem;
+    if (videoUrl != null) {
+      try {
+        historyItem = historyProvider.history.firstWhere(
+          (item) => item.filePath == videoUrl,
+        );
+      } catch (_) {
+        historyItem = null;
+      }
+    }
+    final hasProgress = historyItem != null &&
+        historyItem.duration > 0 &&
+        historyItem.watchProgress > 0.01 &&
+        historyItem.watchProgress < 0.95;
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 8),
+      color: cardColor,
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: BorderSide(
+          color: secondaryTextColor.withOpacity(0.1),
+        ),
+      ),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: isDirectory
+            ? () => _navigateToDirectory(file.path)
+            : () => _playVideo(file),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          child: Row(
+            children: [
+              Icon(
+                isDirectory ? Icons.folder_outlined : Icons.video_file_outlined,
+                color: isDirectory ? Colors.amber : accentColor,
+                size: 28,
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // 文件名 - 最多显示两行
+                    Text(
+                      file.name,
+                      style: TextStyle(
+                        color: textColor,
+                        fontSize: 14,
+                        fontWeight: FontWeight.w500,
+                      ),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 4),
+                    // 文件大小和播放进度
+                    Row(
+                      children: [
+                        if (!isDirectory && file.size != null && file.size! > 0) ...[
+                          Text(
+                            _formatFileSize(file.size!),
+                            style: TextStyle(
+                              color: secondaryTextColor,
+                              fontSize: 12,
+                            ),
+                          ),
+                          if (seasonEpisode != null) ...[
+                            const SizedBox(width: 8),
+                            Container(
+                              padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 1),
+                              decoration: BoxDecoration(
+                                color: Colors.blue.withOpacity(0.15),
+                                borderRadius: BorderRadius.circular(4),
+                                border: Border.all(
+                                  color: Colors.blue.withOpacity(0.3),
+                                  width: 0.5,
+                                ),
+                              ),
+                              child: Text(
+                                seasonEpisode,
+                                style: const TextStyle(
+                                  color: Colors.blue,
+                                  fontSize: 10,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                            ),
+                          ],
+                          if (hasProgress) ...[
+                            const SizedBox(width: 8),
+                            Container(
+                              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                              decoration: BoxDecoration(
+                                color: accentColor.withOpacity(0.1),
+                                borderRadius: BorderRadius.circular(4),
+                              ),
+                              child: Text(
+                                '${(historyItem.watchProgress * 100).toStringAsFixed(0)}%',
+                                style: TextStyle(
+                                  color: accentColor,
+                                  fontSize: 11,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ] else if (!isDirectory && seasonEpisode != null) ...[
+                          Text(
+                            seasonEpisode,
+                            style: const TextStyle(
+                              color: Colors.blue,
+                              fontSize: 10,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ] else if (isDirectory) ...[
+                          Text(
+                            '文件夹',
+                            style: TextStyle(
+                              color: secondaryTextColor,
+                              fontSize: 12,
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                    // 播放进度条
+                    if (hasProgress) ...[
+                      const SizedBox(height: 6),
+                      ClipRRect(
+                        borderRadius: BorderRadius.circular(2),
+                        child: LinearProgressIndicator(
+                          value: historyItem.watchProgress,
+                          backgroundColor: secondaryTextColor.withOpacity(0.2),
+                          valueColor: AlwaysStoppedAnimation<Color>(accentColor),
+                          minHeight: 3,
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+              const SizedBox(width: 8),
+              if (!isDirectory)
+                IconButton(
+                  icon: const Icon(Icons.play_circle_outline),
+                  color: accentColor,
+                  onPressed: () => _playVideo(file),
+                )
+              else
+                Icon(
+                  Icons.chevron_right,
+                  color: secondaryTextColor,
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _formatFileSize(int bytes) {
+    if (bytes < 1024) return '$bytes B';
+    if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
+    if (bytes < 1024 * 1024 * 1024) {
+      return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
+    }
+    return '${(bytes / (1024 * 1024 * 1024)).toStringAsFixed(1)} GB';
+  }
+}
+
+/// 服务器选择底部弹窗
+class _ServerSelectorSheet extends StatelessWidget {
+  final List<WebDAVConnection> connections;
+  final WebDAVConnection? currentConnection;
+  final ValueChanged<WebDAVConnection> onSelected;
+
+  const _ServerSelectorSheet({
+    required this.connections,
+    this.currentConnection,
+    required this.onSelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final backgroundColor = isDark ? const Color(0xFF2A2A2A) : Colors.white;
+    final textColor = isDark ? Colors.white : Colors.black87;
+    final secondaryTextColor = isDark ? Colors.white60 : Colors.black54;
+    final accentColor = const Color(0xFFFF2E55);
+
+    return Container(
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // 拖动指示器
+          Container(
+            margin: const EdgeInsets.only(top: 12),
+            width: 40,
+            height: 4,
+            decoration: BoxDecoration(
+              color: secondaryTextColor.withOpacity(0.3),
+              borderRadius: BorderRadius.circular(2),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Text(
+              '选择 WebDAV 服务器',
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.bold,
+                color: textColor,
+              ),
+            ),
+          ),
+          const Divider(height: 1),
+          ListView.builder(
+            shrinkWrap: true,
+            padding: const EdgeInsets.symmetric(vertical: 8),
+            itemCount: connections.length,
+            itemBuilder: (context, index) {
+              final connection = connections[index];
+              final isSelected = connection.name == currentConnection?.name;
+
+              return ListTile(
+                leading: Icon(
+                  isSelected ? Icons.cloud : Icons.cloud_outlined,
+                  color: isSelected ? accentColor : secondaryTextColor,
+                ),
+                title: Text(
+                  connection.name,
+                  style: TextStyle(
+                    color: textColor,
+                    fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+                  ),
+                ),
+                subtitle: Text(
+                  connection.url,
+                  style: TextStyle(
+                    color: secondaryTextColor,
+                    fontSize: 12,
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                ),
+                trailing: isSelected
+                    ? Icon(Icons.check_circle, color: accentColor)
+                    : null,
+                onTap: () {
+                  Navigator.pop(context);
+                  onSelected(connection);
+                },
+              );
+            },
+          ),
+          // 底部安全区域
+          SizedBox(height: MediaQuery.of(context).padding.bottom + 16),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/providers/webdav_quick_access_provider.dart
+++ b/lib/providers/webdav_quick_access_provider.dart
@@ -1,0 +1,379 @@
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:nipaplay/services/webdav_service.dart';
+
+/// WebDAV 文件排序预设
+enum WebDAVSortPreset {
+  /// 默认：文件夹在前，各自按名称 A-Z
+  defaultValue('default', '默认', '文件夹在前，名称 A-Z'),
+
+  /// 名称 A-Z（混合排序）
+  nameAsc('name_asc', '名称 A-Z', '所有项目按名称升序（例：A文件夹 → B文件 → C文件夹）'),
+
+  /// 名称 Z-A（混合排序）
+  nameDesc('name_desc', '名称 Z-A', '所有项目按名称降序（例：Z文件夹 → Y文件 → X文件夹）'),
+
+  /// 最新修改
+  modifiedDesc('modified_desc', '最新修改', '最近修改的项目在前'),
+
+  /// 最旧修改
+  modifiedAsc('modified_asc', '最旧修改', '最早修改的项目在前'),
+
+  /// 最大文件
+  sizeDesc('size_desc', '最大文件', '文件大小从大到小'),
+
+  /// 最小文件
+  sizeAsc('size_asc', '最小文件', '文件大小从小到大');
+
+  final String value;
+  final String displayName;
+  final String description;
+
+  const WebDAVSortPreset(this.value, this.displayName, this.description);
+
+  static WebDAVSortPreset fromValue(String? value) {
+    return WebDAVSortPreset.values.firstWhere(
+      (e) => e.value == value,
+      orElse: () => WebDAVSortPreset.defaultValue,
+    );
+  }
+}
+
+/// WebDAV 快捷访问设置 Provider
+/// 管理 WebDAV Tab 的显示开关、默认服务器、默认目录等设置
+class WebDAVQuickAccessProvider extends ChangeNotifier {
+  // 存储键名
+  static const String _keyShowWebDAVTab = 'show_webdav_tab';
+  static const String _keyDefaultServerName = 'webdav_default_server_name';
+  static const String _keyDefaultDirectory = 'webdav_default_directory';
+  static const String _keyDefaultHomeTab = 'default_home_tab';
+  static const String _keySortPreset = 'webdav_sort_preset';
+  static const String _keyAutoEnterSeasonFolder = 'webdav_auto_enter_season_folder';
+  static const String _keySeasonFolderPattern = 'webdav_season_folder_pattern';
+  static const String _keyShowPathBreadcrumb = 'webdav_show_path_breadcrumb';
+
+  // Tab 名称常量
+  static const String tabHome = 'home';
+  static const String tabVideo = 'video';
+  static const String tabMediaLibrary = 'media_library';
+  static const String tabAccount = 'account';
+  static const String tabSettings = 'settings';
+  static const String tabWebDAV = 'webdav';
+
+  // 状态
+  bool _showWebDAVTab = false;
+  String _defaultServerName = '';
+  String _defaultDirectory = '/';
+  String _defaultHomeTab = tabHome;
+  WebDAVSortPreset _sortPreset = WebDAVSortPreset.defaultValue;
+  bool _autoEnterSeasonFolder = false;
+  String _seasonFolderPattern = 'Season*';
+  bool _showPathBreadcrumb = true;
+  bool _isLoaded = false;
+
+  // Getters
+  bool get showWebDAVTab => _showWebDAVTab;
+  String get defaultServerName => _defaultServerName;
+  String get defaultDirectory => _defaultDirectory;
+  String get defaultHomeTab => _defaultHomeTab;
+  WebDAVSortPreset get sortPreset => _sortPreset;
+  bool get autoEnterSeasonFolder => _autoEnterSeasonFolder;
+  String get seasonFolderPattern => _seasonFolderPattern;
+  bool get showPathBreadcrumb => _showPathBreadcrumb;
+  bool get isLoaded => _isLoaded;
+
+  /// 获取有效的默认 Tab（处理 WebDAV 关闭时的回落）
+  String get effectiveDefaultHomeTab {
+    if (_defaultHomeTab == tabWebDAV && !_showWebDAVTab) {
+      return tabHome; // WebDAV 关闭时回落到首页
+    }
+    return _defaultHomeTab;
+  }
+
+  /// 获取所有可用的 Tab 选项（根据 WebDAV 是否开启）
+  List<String> get availableTabs {
+    if (_showWebDAVTab) {
+      return [tabHome, tabVideo, tabWebDAV, tabMediaLibrary, tabAccount, tabSettings];
+    }
+    return [tabHome, tabVideo, tabMediaLibrary, tabAccount, tabSettings];
+  }
+
+  /// 获取 Tab 的显示名称
+  static String getTabDisplayName(String tabName) {
+    switch (tabName) {
+      case tabHome:
+        return '首页';
+      case tabVideo:
+        return '视频播放';
+      case tabMediaLibrary:
+        return '媒体库';
+      case tabAccount:
+        return '我的';
+      case tabSettings:
+        return '设置';
+      case tabWebDAV:
+        return 'WebDAV';
+      default:
+        return tabName;
+    }
+  }
+
+  /// 获取默认服务器连接对象
+  WebDAVConnection? get defaultConnection {
+    if (_defaultServerName.isEmpty) return null;
+    return WebDAVService.instance.getConnection(_defaultServerName);
+  }
+
+  /// 获取所有可用的 WebDAV 连接
+  List<WebDAVConnection> get availableConnections =>
+      WebDAVService.instance.connections;
+
+  /// 从 SharedPreferences 加载设置
+  Future<void> loadSettings() async {
+    if (_isLoaded) return;
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+
+      _showWebDAVTab = prefs.getBool(_keyShowWebDAVTab) ?? false;
+      _defaultServerName = prefs.getString(_keyDefaultServerName) ?? '';
+      _defaultDirectory = prefs.getString(_keyDefaultDirectory) ?? '/';
+      _defaultHomeTab = prefs.getString(_keyDefaultHomeTab) ?? tabHome;
+      _sortPreset = WebDAVSortPreset.fromValue(prefs.getString(_keySortPreset));
+      _autoEnterSeasonFolder = prefs.getBool(_keyAutoEnterSeasonFolder) ?? false;
+      _seasonFolderPattern = prefs.getString(_keySeasonFolderPattern) ?? 'Season*';
+      _showPathBreadcrumb = prefs.getBool(_keyShowPathBreadcrumb) ?? true;
+
+      _isLoaded = true;
+      notifyListeners();
+    } catch (e) {
+      debugPrint('加载 WebDAV 快捷设置失败: $e');
+    }
+  }
+
+  /// 设置是否显示 WebDAV Tab
+  Future<void> setShowWebDAVTab(bool value) async {
+    if (_showWebDAVTab == value) return;
+
+    _showWebDAVTab = value;
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool(_keyShowWebDAVTab, value);
+      notifyListeners();
+    } catch (e) {
+      debugPrint('保存 WebDAV Tab 显示设置失败: $e');
+    }
+  }
+
+  /// 设置默认主页 Tab
+  Future<void> setDefaultHomeTab(String tabName) async {
+    if (_defaultHomeTab == tabName) return;
+
+    _defaultHomeTab = tabName;
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_keyDefaultHomeTab, tabName);
+      notifyListeners();
+    } catch (e) {
+      debugPrint('保存默认主页 Tab 设置失败: $e');
+    }
+  }
+
+  /// 设置排序预设
+  Future<void> setSortPreset(WebDAVSortPreset preset) async {
+    if (_sortPreset == preset) return;
+
+    _sortPreset = preset;
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_keySortPreset, preset.value);
+      notifyListeners();
+    } catch (e) {
+      debugPrint('保存排序设置失败: $e');
+    }
+  }
+
+  /// 设置默认服务器名称
+  Future<void> setDefaultServerName(String serverName) async {
+    if (_defaultServerName == serverName) return;
+
+    _defaultServerName = serverName;
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_keyDefaultServerName, serverName);
+      notifyListeners();
+    } catch (e) {
+      debugPrint('保存默认服务器设置失败: $e');
+    }
+  }
+
+  /// 设置默认目录
+  Future<void> setDefaultDirectory(String directory) async {
+    if (_defaultDirectory == directory) return;
+
+    // 确保目录以 / 开头
+    if (!directory.startsWith('/')) {
+      directory = '/$directory';
+    }
+
+    _defaultDirectory = directory;
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_keyDefaultDirectory, directory);
+      notifyListeners();
+    } catch (e) {
+      debugPrint('保存默认目录设置失败: $e');
+    }
+  }
+
+  /// 验证当前设置是否有效（有可用的默认服务器）
+  bool get hasValidDefaultServer {
+    if (_defaultServerName.isEmpty) return false;
+    return defaultConnection != null;
+  }
+
+  /// 设置是否自动进入 Season 文件夹
+  Future<void> setAutoEnterSeasonFolder(bool value) async {
+    if (_autoEnterSeasonFolder == value) return;
+
+    _autoEnterSeasonFolder = value;
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool(_keyAutoEnterSeasonFolder, value);
+      notifyListeners();
+    } catch (e) {
+      debugPrint('保存自动进入 Season 文件夹设置失败: $e');
+    }
+  }
+
+  /// 设置 Season 文件夹匹配模式
+  Future<void> setSeasonFolderPattern(String pattern) async {
+    if (_seasonFolderPattern == pattern) return;
+
+    _seasonFolderPattern = pattern;
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_keySeasonFolderPattern, pattern);
+      notifyListeners();
+    } catch (e) {
+      debugPrint('保存 Season 文件夹匹配模式失败: $e');
+    }
+  }
+
+  /// 设置是否显示路径面包屑导航
+  Future<void> setShowPathBreadcrumb(bool value) async {
+    if (_showPathBreadcrumb == value) return;
+
+    _showPathBreadcrumb = value;
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool(_keyShowPathBreadcrumb, value);
+      notifyListeners();
+    } catch (e) {
+      debugPrint('保存路径面包屑显示设置失败: $e');
+    }
+  }
+
+  /// 检查文件夹名称是否匹配模式（支持通配符 * 和 ?）
+  bool matchesSeasonPattern(String folderName) {
+    if (_seasonFolderPattern.isEmpty) return false;
+
+    // 将通配符模式转换为正则表达式
+    String pattern = _seasonFolderPattern
+        .replaceAll('.', r'\.')
+        .replaceAll('*', '.*')
+        .replaceAll('?', '.');
+    pattern = '^$pattern\$';
+
+    try {
+      return RegExp(pattern, caseSensitive: false).hasMatch(folderName);
+    } catch (e) {
+      debugPrint('匹配模式解析失败: $e');
+      return false;
+    }
+  }
+
+  /// 在文件夹列表中查找匹配的 Season 文件夹
+  String? findMatchingSeasonFolder(List<String> folderNames) {
+    if (!_autoEnterSeasonFolder || _seasonFolderPattern.isEmpty) {
+      return null;
+    }
+
+    final matchingFolders = folderNames
+        .where((name) => matchesSeasonPattern(name))
+        .toList();
+
+    // 如果只有一个匹配项，返回它
+    if (matchingFolders.length == 1) {
+      return matchingFolders.first;
+    }
+
+    // 如果有多个匹配项，按自然排序返回第一个
+    if (matchingFolders.isNotEmpty) {
+      matchingFolders.sort((a, b) => _naturalCompare(a, b));
+      return matchingFolders.first;
+    }
+
+    return null;
+  }
+
+  /// 自然排序比较（处理数字）
+  static int _naturalCompare(String a, String b) {
+    final regex = RegExp(r'(\d+)|(\D+)');
+    final aMatches = regex.allMatches(a).toList();
+    final bMatches = regex.allMatches(b).toList();
+
+    for (int i = 0; i < aMatches.length && i < bMatches.length; i++) {
+      final aPart = aMatches[i].group(0)!;
+      final bPart = bMatches[i].group(0)!;
+
+      final aNum = int.tryParse(aPart);
+      final bNum = int.tryParse(bPart);
+
+      if (aNum != null && bNum != null) {
+        final cmp = aNum.compareTo(bNum);
+        if (cmp != 0) return cmp;
+      } else {
+        final cmp = aPart.compareTo(bPart);
+        if (cmp != 0) return cmp;
+      }
+    }
+
+    return aMatches.length.compareTo(bMatches.length);
+  }
+
+  /// 重置所有设置
+  Future<void> resetSettings() async {
+    _showWebDAVTab = false;
+    _defaultServerName = '';
+    _defaultDirectory = '/';
+    _defaultHomeTab = tabHome;
+    _sortPreset = WebDAVSortPreset.defaultValue;
+    _autoEnterSeasonFolder = false;
+    _seasonFolderPattern = 'Season*';
+    _showPathBreadcrumb = true;
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.remove(_keyShowWebDAVTab);
+      await prefs.remove(_keyDefaultServerName);
+      await prefs.remove(_keyDefaultDirectory);
+      await prefs.remove(_keyDefaultHomeTab);
+      await prefs.remove(_keySortPreset);
+      await prefs.remove(_keyAutoEnterSeasonFolder);
+      await prefs.remove(_keySeasonFolderPattern);
+      await prefs.remove(_keyShowPathBreadcrumb);
+      notifyListeners();
+    } catch (e) {
+      debugPrint('重置 WebDAV 快捷设置失败: $e');
+    }
+  }
+}

--- a/lib/themes/cupertino/pages/cupertino_main_page.dart
+++ b/lib/themes/cupertino/pages/cupertino_main_page.dart
@@ -9,8 +9,10 @@ import 'package:nipaplay/themes/cupertino/pages/cupertino_media_library_page.dar
 import 'package:nipaplay/themes/cupertino/pages/cupertino_play_video_page.dart';
 import 'package:nipaplay/themes/cupertino/pages/cupertino_settings_page.dart';
 import 'package:nipaplay/providers/bottom_bar_provider.dart';
+import 'package:nipaplay/providers/webdav_quick_access_provider.dart';
 import 'package:nipaplay/utils/tab_change_notifier.dart';
 import 'package:nipaplay/themes/cupertino/widgets/cupertino_bounce_wrapper.dart';
+import 'package:nipaplay/pages/webdav_browser_page.dart';
 
 class CupertinoMainPage extends StatefulWidget {
   final String? launchFilePath;
@@ -25,35 +27,201 @@ class _CupertinoMainPageState extends State<CupertinoMainPage> {
   int _selectedIndex = 0;
   TabChangeNotifier? _tabChangeNotifier;
   bool _isVideoPagePresented = false;
+  bool _showWebDAVTab = false;
+  WebDAVQuickAccessProvider? _webdavProvider;
+  String? _lastAppliedDefaultTab;
+  List<GlobalKey<CupertinoBounceWrapperState>> _bounceKeys = [];
 
-  final List<GlobalKey<CupertinoBounceWrapperState>> _bounceKeys = [
-    GlobalKey<CupertinoBounceWrapperState>(),
-    GlobalKey<CupertinoBounceWrapperState>(),
-    GlobalKey<CupertinoBounceWrapperState>(),
-    GlobalKey<CupertinoBounceWrapperState>(),
-  ];
-
-  static const List<Widget> _pages = [
+  static const List<Widget> _basePages = [
     CupertinoHomePage(),
     CupertinoMediaLibraryPage(),
     CupertinoAccountPage(),
     CupertinoSettingsPage(),
   ];
 
+  List<Widget> get _pages {
+    if (_showWebDAVTab) {
+      return [
+        _basePages[0],
+        const WebDAVBrowserPage(),
+        _basePages[1],
+        _basePages[2],
+        _basePages[3],
+      ];
+    }
+    return _basePages;
+  }
+
+  List<BottomNavigationBarItem> _buildNavItems(BuildContext context) {
+    final l10n = context.l10n;
+    if (_showWebDAVTab) {
+      return [
+        BottomNavigationBarItem(
+          icon: const Icon(CupertinoIcons.house),
+          activeIcon: const Icon(CupertinoIcons.house_fill),
+          label: l10n.tabHome,
+        ),
+        const BottomNavigationBarItem(
+          icon: Icon(CupertinoIcons.cloud),
+          activeIcon: Icon(CupertinoIcons.cloud_fill),
+          label: 'WebDAV',
+        ),
+        BottomNavigationBarItem(
+          icon: const Icon(CupertinoIcons.play_rectangle),
+          activeIcon: const Icon(CupertinoIcons.play_rectangle_fill),
+          label: l10n.tabMediaLibrary,
+        ),
+        BottomNavigationBarItem(
+          icon: const Icon(CupertinoIcons.person_crop_circle),
+          activeIcon: const Icon(CupertinoIcons.person_crop_circle_fill),
+          label: l10n.tabAccount,
+        ),
+        BottomNavigationBarItem(
+          icon: const Icon(CupertinoIcons.gear_alt),
+          activeIcon: const Icon(CupertinoIcons.gear_alt_fill),
+          label: l10n.tabSettings,
+        ),
+      ];
+    }
+    return [
+      BottomNavigationBarItem(
+        icon: const Icon(CupertinoIcons.house),
+        activeIcon: const Icon(CupertinoIcons.house_fill),
+        label: l10n.tabHome,
+      ),
+      BottomNavigationBarItem(
+        icon: const Icon(CupertinoIcons.play_rectangle),
+        activeIcon: const Icon(CupertinoIcons.play_rectangle_fill),
+        label: l10n.tabMediaLibrary,
+      ),
+      BottomNavigationBarItem(
+        icon: const Icon(CupertinoIcons.person_crop_circle),
+        activeIcon: const Icon(CupertinoIcons.person_crop_circle_fill),
+        label: l10n.tabAccount,
+      ),
+      BottomNavigationBarItem(
+        icon: const Icon(CupertinoIcons.gear_alt),
+        activeIcon: const Icon(CupertinoIcons.gear_alt_fill),
+        label: l10n.tabSettings,
+      ),
+    ];
+  }
+
+  List<AdaptiveNavigationDestination> _buildAdaptiveNavItems(BuildContext context) {
+    final l10n = context.l10n;
+    if (_showWebDAVTab) {
+      return [
+        AdaptiveNavigationDestination(
+          icon: 'house.fill',
+          label: l10n.tabHome,
+        ),
+        const AdaptiveNavigationDestination(
+          icon: 'cloud.fill',
+          label: 'WebDAV',
+        ),
+        AdaptiveNavigationDestination(
+          icon: 'play.rectangle.fill',
+          label: l10n.tabMediaLibrary,
+        ),
+        AdaptiveNavigationDestination(
+          icon: 'person.crop.circle.fill',
+          label: l10n.tabAccount,
+        ),
+        AdaptiveNavigationDestination(
+          icon: 'gearshape.fill',
+          label: l10n.tabSettings,
+        ),
+      ];
+    }
+    return [
+      AdaptiveNavigationDestination(
+        icon: 'house.fill',
+        label: l10n.tabHome,
+      ),
+      AdaptiveNavigationDestination(
+        icon: 'play.rectangle.fill',
+        label: l10n.tabMediaLibrary,
+      ),
+      AdaptiveNavigationDestination(
+        icon: 'person.crop.circle.fill',
+        label: l10n.tabAccount,
+      ),
+      AdaptiveNavigationDestination(
+        icon: 'gearshape.fill',
+        label: l10n.tabSettings,
+      ),
+    ];
+  }
+
+  void _updateBounceKeys() {
+    final neededKeys = _pages.length;
+    while (_bounceKeys.length < neededKeys) {
+      _bounceKeys.add(GlobalKey<CupertinoBounceWrapperState>());
+    }
+  }
+
+  int _getInitialTabIndex() {
+    final defaultTab = _webdavProvider?.effectiveDefaultHomeTab ?? WebDAVQuickAccessProvider.tabHome;
+
+    switch (defaultTab) {
+      case WebDAVQuickAccessProvider.tabHome:
+        return 0;
+      case WebDAVQuickAccessProvider.tabWebDAV:
+        return _showWebDAVTab ? 1 : 0;
+      case WebDAVQuickAccessProvider.tabMediaLibrary:
+        return _showWebDAVTab ? 2 : 1;
+      case WebDAVQuickAccessProvider.tabAccount:
+        return _showWebDAVTab ? 3 : 2;
+      case WebDAVQuickAccessProvider.tabSettings:
+        return _showWebDAVTab ? 4 : 3;
+      default:
+        return 0;
+    }
+  }
+
+  void _onWebDAVSettingsChanged() {
+    if (!mounted) return;
+    final showWebDAVTab = _webdavProvider?.showWebDAVTab ?? false;
+    final shouldUpdate = showWebDAVTab != _showWebDAVTab ||
+        _webdavProvider?.defaultHomeTab != _lastAppliedDefaultTab;
+
+    if (shouldUpdate) {
+      setState(() {
+        _showWebDAVTab = showWebDAVTab;
+        _lastAppliedDefaultTab = _webdavProvider?.defaultHomeTab;
+        _updateBounceKeys();
+        _selectedIndex = _getInitialTabIndex().clamp(0, _pages.length - 1);
+      });
+    }
+  }
+
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
+    _updateBounceKeys();
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
       if (!mounted) return;
-      CupertinoBounceWrapper.playAnimation(_bounceKeys[_selectedIndex]);
       _tabChangeNotifier = Provider.of<TabChangeNotifier>(context, listen: false);
       _tabChangeNotifier?.addListener(_handleTabChange);
+      _webdavProvider = Provider.of<WebDAVQuickAccessProvider>(context, listen: false);
+      _webdavProvider?.addListener(_onWebDAVSettingsChanged);
+      await _webdavProvider?.loadSettings();
+
+      if (mounted) {
+        setState(() {
+          _showWebDAVTab = _webdavProvider?.showWebDAVTab ?? false;
+          _updateBounceKeys();
+          _selectedIndex = _getInitialTabIndex();
+        });
+        CupertinoBounceWrapper.playAnimation(_bounceKeys[_selectedIndex]);
+      }
     });
   }
 
   @override
   void dispose() {
     _tabChangeNotifier?.removeListener(_handleTabChange);
+    _webdavProvider?.removeListener(_onWebDAVSettingsChanged);
     super.dispose();
   }
 
@@ -96,47 +264,9 @@ class _CupertinoMainPageState extends State<CupertinoMainPage> {
                     activeColor: activeColor,
                     inactiveColor: inactiveColor,
                     height: tabBarHeight,
-                    items: [
-                      BottomNavigationBarItem(
-                        icon: Icon(CupertinoIcons.house),
-                        activeIcon: Icon(CupertinoIcons.house_fill),
-                        label: l10n.tabHome,
-                      ),
-                      BottomNavigationBarItem(
-                        icon: Icon(CupertinoIcons.play_rectangle),
-                        activeIcon: Icon(CupertinoIcons.play_rectangle_fill),
-                        label: l10n.tabMediaLibrary,
-                      ),
-                      BottomNavigationBarItem(
-                        icon: Icon(CupertinoIcons.person_crop_circle),
-                        activeIcon: Icon(CupertinoIcons.person_crop_circle_fill),
-                        label: l10n.tabAccount,
-                      ),
-                      BottomNavigationBarItem(
-                        icon: Icon(CupertinoIcons.gear_alt),
-                        activeIcon: Icon(CupertinoIcons.gear_alt_fill),
-                        label: l10n.tabSettings,
-                      ),
-                    ],
+                    items: _buildNavItems(context),
                   ),
-                  items: [
-                    AdaptiveNavigationDestination(
-                      icon: 'house.fill',
-                      label: l10n.tabHome,
-                    ),
-                    AdaptiveNavigationDestination(
-                      icon: 'play.rectangle.fill',
-                      label: l10n.tabMediaLibrary,
-                    ),
-                    AdaptiveNavigationDestination(
-                      icon: 'person.crop.circle.fill',
-                      label: l10n.tabAccount,
-                    ),
-                    AdaptiveNavigationDestination(
-                      icon: 'gearshape.fill',
-                      label: l10n.tabSettings,
-                    ),
-                  ],
+                  items: _buildAdaptiveNavItems(context),
                   selectedIndex: _selectedIndex,
                   onTap: _selectTab,
                 )

--- a/lib/themes/cupertino/pages/cupertino_play_video_page.dart
+++ b/lib/themes/cupertino/pages/cupertino_play_video_page.dart
@@ -63,6 +63,7 @@ class _CupertinoPlayVideoPageState extends State<CupertinoPlayVideoPage> {
   OverlayEntry? _playbackInfoOverlay;
   OverlayEntry? _settingsOverlay;
   final GlobalKey _settingsButtonKey = GlobalKey();
+  bool _isExiting = false;
 
   bool _isRepeatableShortcut(LogicalKeyboardKey key) {
     return key == LogicalKeyboardKey.arrowLeft ||
@@ -1757,7 +1758,10 @@ class _CupertinoPlayVideoPageState extends State<CupertinoPlayVideoPage> {
   Future<bool> _requestExit(VideoPlayerState videoState) async {
     final shouldPop = await videoState.handleBackButton();
     if (shouldPop) {
-      await videoState.resetPlayer();
+      setState(() => _isExiting = true);
+      unawaited(videoState.resetPlayer().catchError((e) {
+        debugPrint('退出重置失败: $e');
+      }));
     }
     return shouldPop;
   }

--- a/lib/themes/cupertino/pages/settings/pages/cupertino_labs_settings_page.dart
+++ b/lib/themes/cupertino/pages/settings/pages/cupertino_labs_settings_page.dart
@@ -4,6 +4,7 @@ import 'package:nipaplay/providers/labs_settings_provider.dart';
 import 'package:nipaplay/themes/cupertino/widgets/cupertino_settings_group_card.dart';
 import 'package:nipaplay/themes/cupertino/widgets/cupertino_settings_tile.dart';
 import 'package:nipaplay/utils/cupertino_settings_colors.dart';
+import 'package:nipaplay/themes/cupertino/pages/settings/pages/webdav_quick_settings_page.dart';
 import 'package:provider/provider.dart';
 
 class CupertinoLabsSettingsPage extends StatelessWidget {
@@ -56,6 +57,30 @@ class CupertinoLabsSettingsPage extends StatelessWidget {
                         onTap: () {
                           labsSettings.setEnableLargeScreenMode(
                             !labsSettings.enableLargeScreenMode,
+                          );
+                        },
+                        backgroundColor: resolveSettingsTileBackground(context),
+                      ),
+                      CupertinoSettingsTile(
+                        leading: Icon(
+                          CupertinoIcons.cloud,
+                          color: resolveSettingsIconColor(context),
+                        ),
+                        title: const Text('WebDAV 快捷设置'),
+                        subtitle: const Text('配置底部 WebDAV 快捷 Tab，快速访问 WebDAV 服务器'),
+                        trailing: Icon(
+                          CupertinoIcons.chevron_forward,
+                          color: CupertinoDynamicColor.resolve(
+                            CupertinoColors.tertiaryLabel,
+                            context,
+                          ),
+                          size: 18,
+                        ),
+                        onTap: () {
+                          Navigator.of(context).push(
+                            CupertinoPageRoute(
+                              builder: (_) => const CupertinoWebDAVQuickSettingsPage(),
+                            ),
                           );
                         },
                         backgroundColor: resolveSettingsTileBackground(context),

--- a/lib/themes/cupertino/pages/settings/pages/webdav_quick_settings_page.dart
+++ b/lib/themes/cupertino/pages/settings/pages/webdav_quick_settings_page.dart
@@ -1,0 +1,665 @@
+import 'package:nipaplay/themes/cupertino/cupertino_adaptive_platform_ui.dart';
+import 'package:nipaplay/themes/cupertino/cupertino_imports.dart';
+import 'package:nipaplay/l10n/l10n.dart';
+import 'package:provider/provider.dart';
+
+import 'package:nipaplay/providers/webdav_quick_access_provider.dart';
+import 'package:nipaplay/services/webdav_service.dart';
+import 'package:nipaplay/utils/cupertino_settings_colors.dart';
+import 'package:nipaplay/themes/cupertino/widgets/cupertino_settings_group_card.dart';
+import 'package:nipaplay/themes/cupertino/widgets/cupertino_settings_tile.dart';
+
+class CupertinoWebDAVQuickSettingsPage extends StatefulWidget {
+  const CupertinoWebDAVQuickSettingsPage({super.key});
+
+  @override
+  State<CupertinoWebDAVQuickSettingsPage> createState() =>
+      _CupertinoWebDAVQuickSettingsPageState();
+}
+
+class _CupertinoWebDAVQuickSettingsPageState
+    extends State<CupertinoWebDAVQuickSettingsPage> {
+  late final TextEditingController _directoryController;
+
+  @override
+  void initState() {
+    super.initState();
+    _directoryController = TextEditingController();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      Provider.of<WebDAVQuickAccessProvider>(context, listen: false)
+          .loadSettings();
+    });
+  }
+
+  @override
+  void dispose() {
+    _directoryController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final Color backgroundColor = CupertinoDynamicColor.resolve(
+      CupertinoColors.systemGroupedBackground,
+      context,
+    );
+    final double topPadding = MediaQuery.of(context).padding.top + 64;
+
+    return Consumer<WebDAVQuickAccessProvider>(
+      builder: (context, provider, _) {
+        _directoryController.text = provider.defaultDirectory;
+
+        return AdaptiveScaffold(
+          appBar: AdaptiveAppBar(
+            title: 'WebDAV快捷设置',
+            useNativeToolbar: true,
+          ),
+          body: ColoredBox(
+            color: backgroundColor,
+            child: SafeArea(
+              top: false,
+              bottom: false,
+              child: ListView(
+                physics: const BouncingScrollPhysics(
+                  parent: AlwaysScrollableScrollPhysics(),
+                ),
+                padding: EdgeInsets.fromLTRB(16, topPadding, 16, 32),
+                children: [
+                  _buildDescriptionCard(context),
+                  const SizedBox(height: 24),
+                  _buildToggleCard(context, provider),
+                  const SizedBox(height: 24),
+                  _buildDefaultTabCard(context, provider),
+                  if (provider.showWebDAVTab) ...[
+                    const SizedBox(height: 24),
+                    _buildServerSelectorCard(context, provider),
+                    const SizedBox(height: 24),
+                    _buildDirectoryCard(context, provider),
+                  ],
+                  const SizedBox(height: 24),
+                  _buildSortPresetCard(context, provider),
+                  const SizedBox(height: 24),
+                  _buildPathBreadcrumbCard(context, provider),
+                  const SizedBox(height: 24),
+                  _buildAutoEnterSeasonCard(context, provider),
+                  const SizedBox(height: 24),
+                  _buildResetCard(context, provider),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildDescriptionCard(BuildContext context) {
+    final Color sectionColor = resolveSettingsSectionBackground(context);
+    final Color secondaryColor = resolveSettingsSecondaryTextColor(context);
+    final textTheme = CupertinoTheme.of(context).textTheme.textStyle;
+
+    return CupertinoSettingsGroupCard(
+      margin: EdgeInsets.zero,
+      backgroundColor: sectionColor,
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: Text(
+            '配置底部 WebDAV 快捷 Tab，可以快速访问 WebDAV 服务器中的视频文件。',
+            style: textTheme.copyWith(
+              fontSize: 14,
+              color: secondaryColor,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildToggleCard(BuildContext context, WebDAVQuickAccessProvider provider) {
+    final Color tileColor = resolveSettingsTileBackground(context);
+    final Color sectionColor = resolveSettingsSectionBackground(context);
+    final Color iconColor = resolveSettingsIconColor(context);
+
+    return CupertinoSettingsGroupCard(
+      margin: EdgeInsets.zero,
+      backgroundColor: sectionColor,
+      children: [
+        CupertinoSettingsTile(
+          leading: Icon(CupertinoIcons.eye, color: iconColor),
+          title: const Text('显示 WebDAV Tab'),
+          subtitle: const Text('在底部导航栏显示 WebDAV 快捷入口'),
+          backgroundColor: tileColor,
+          trailing: CupertinoSwitch(
+            value: provider.showWebDAVTab,
+            activeColor: CupertinoColors.activeBlue,
+            onChanged: (value) {
+              provider.setShowWebDAVTab(value);
+            },
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildDefaultTabCard(BuildContext context, WebDAVQuickAccessProvider provider) {
+    final Color tileColor = resolveSettingsTileBackground(context);
+    final Color sectionColor = resolveSettingsSectionBackground(context);
+    final Color iconColor = resolveSettingsIconColor(context);
+    final Color secondaryColor = resolveSettingsSecondaryTextColor(context);
+
+    return CupertinoSettingsGroupCard(
+      margin: EdgeInsets.zero,
+      backgroundColor: sectionColor,
+      addDividers: true,
+      dividerIndent: 56,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+          child: Row(
+            children: [
+              Icon(CupertinoIcons.house, size: 16, color: iconColor),
+              const SizedBox(width: 8),
+              Text(
+                '默认主页',
+                style: CupertinoTheme.of(context).textTheme.textStyle.copyWith(
+                      fontSize: 13,
+                      color: secondaryColor,
+                    ),
+              ),
+            ],
+          ),
+        ),
+        ...provider.availableTabs.map((tabName) {
+          final isSelected = tabName == provider.defaultHomeTab;
+          return CupertinoSettingsTile(
+            leading: Icon(
+              _getTabIcon(tabName),
+              color: iconColor,
+            ),
+            title: Text(WebDAVQuickAccessProvider.getTabDisplayName(tabName)),
+            subtitle: Text(
+              tabName == WebDAVQuickAccessProvider.tabWebDAV
+                  ? '打开时直接进入 WebDAV'
+                  : '打开时直接进入此页面',
+              style: TextStyle(fontSize: 11, color: secondaryColor),
+            ),
+            backgroundColor: tileColor,
+            trailing: isSelected
+                ? const Icon(CupertinoIcons.check_mark, color: CupertinoColors.activeBlue)
+                : null,
+            onTap: () {
+              provider.setDefaultHomeTab(tabName);
+            },
+          );
+        }),
+        if (provider.defaultHomeTab == WebDAVQuickAccessProvider.tabWebDAV && !provider.showWebDAVTab)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 12),
+            child: Text(
+              '⚠️ 当前已选择 WebDAV 为默认主页，但 WebDAV Tab 未开启，将自动回落到首页',
+              style: TextStyle(
+                color: CupertinoColors.systemOrange.resolveFrom(context),
+                fontSize: 12,
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+
+  IconData _getTabIcon(String tabName) {
+    switch (tabName) {
+      case WebDAVQuickAccessProvider.tabHome:
+        return CupertinoIcons.house_fill;
+      case WebDAVQuickAccessProvider.tabVideo:
+        return CupertinoIcons.play_rectangle_fill;
+      case WebDAVQuickAccessProvider.tabMediaLibrary:
+        return CupertinoIcons.film_fill;
+      case WebDAVQuickAccessProvider.tabAccount:
+        return CupertinoIcons.person_crop_circle_fill;
+      case WebDAVQuickAccessProvider.tabSettings:
+        return CupertinoIcons.gear_alt_fill;
+      case WebDAVQuickAccessProvider.tabWebDAV:
+        return CupertinoIcons.cloud_fill;
+      default:
+        return CupertinoIcons.circle;
+    }
+  }
+
+  Widget _buildServerSelectorCard(
+      BuildContext context, WebDAVQuickAccessProvider provider) {
+    final Color tileColor = resolveSettingsTileBackground(context);
+    final Color sectionColor = resolveSettingsSectionBackground(context);
+    final Color iconColor = resolveSettingsIconColor(context);
+    final Color secondaryColor = resolveSettingsSecondaryTextColor(context);
+    final connections = WebDAVService.instance.connections;
+
+    if (connections.isEmpty) {
+      return CupertinoSettingsGroupCard(
+        margin: EdgeInsets.zero,
+        backgroundColor: sectionColor,
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(20),
+            child: Column(
+              children: [
+                Icon(
+                  CupertinoIcons.cloud,
+                  size: 48,
+                  color: secondaryColor,
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  '没有配置 WebDAV 服务器',
+                  style: CupertinoTheme.of(context).textTheme.textStyle,
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  '请先在「远程媒体库」设置中添加 WebDAV 服务器',
+                  style: CupertinoTheme.of(context).textTheme.textStyle.copyWith(
+                        fontSize: 13,
+                        color: secondaryColor,
+                      ),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            ),
+          ),
+        ],
+      );
+    }
+
+    return CupertinoSettingsGroupCard(
+      margin: EdgeInsets.zero,
+      backgroundColor: sectionColor,
+      addDividers: true,
+      dividerIndent: 56,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+          child: Row(
+            children: [
+              Icon(CupertinoIcons.device_desktop, size: 16, color: iconColor),
+              const SizedBox(width: 8),
+              Text(
+                '默认服务器',
+                style: CupertinoTheme.of(context).textTheme.textStyle.copyWith(
+                      fontSize: 13,
+                      color: secondaryColor,
+                    ),
+              ),
+            ],
+          ),
+        ),
+        ...connections.map((connection) {
+          final isSelected = connection.name == provider.defaultServerName;
+          return CupertinoSettingsTile(
+            leading: Icon(
+              isSelected ? CupertinoIcons.cloud_fill : CupertinoIcons.cloud,
+              color: iconColor,
+            ),
+            title: Text(connection.name),
+            subtitle: Text(
+              connection.url,
+              style: TextStyle(fontSize: 11, color: secondaryColor),
+            ),
+            backgroundColor: tileColor,
+            trailing: isSelected
+                ? const Icon(CupertinoIcons.check_mark, color: CupertinoColors.activeBlue)
+                : null,
+            onTap: () {
+              provider.setDefaultServerName(connection.name);
+            },
+          );
+        }),
+      ],
+    );
+  }
+
+  Widget _buildDirectoryCard(
+      BuildContext context, WebDAVQuickAccessProvider provider) {
+    final Color sectionColor = resolveSettingsSectionBackground(context);
+    final Color iconColor = resolveSettingsIconColor(context);
+    final Color secondaryColor = resolveSettingsSecondaryTextColor(context);
+    final textTheme = CupertinoTheme.of(context).textTheme.textStyle;
+
+    return CupertinoSettingsGroupCard(
+      margin: EdgeInsets.zero,
+      backgroundColor: sectionColor,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Icon(CupertinoIcons.folder, size: 18, color: iconColor),
+                  const SizedBox(width: 8),
+                  Text(
+                    '默认目录',
+                    style: textTheme.copyWith(
+                      fontSize: 15,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              Text(
+                '点击 WebDAV Tab 时将直接打开此目录',
+                style: textTheme.copyWith(
+                  fontSize: 13,
+                  color: secondaryColor,
+                ),
+              ),
+              const SizedBox(height: 12),
+              CupertinoTextField(
+                controller: _directoryController,
+                placeholder: '例如: /视频/动画',
+                keyboardType: TextInputType.url,
+                autocorrect: false,
+                enableSuggestions: false,
+                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                decoration: BoxDecoration(
+                  color: CupertinoDynamicColor.resolve(
+                    CupertinoColors.tertiarySystemFill,
+                    context,
+                  ),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                suffix: CupertinoButton(
+                  padding: const EdgeInsets.only(right: 4),
+                  onPressed: () {
+                    provider.setDefaultDirectory('/');
+                    _directoryController.text = '/';
+                  },
+                  child: const Icon(CupertinoIcons.refresh, size: 18),
+                ),
+                onSubmitted: (value) {
+                  provider.setDefaultDirectory(value);
+                },
+              ),
+              const SizedBox(height: 12),
+              Align(
+                alignment: Alignment.centerRight,
+                child: SizedBox(
+                  height: 36,
+                  child: CupertinoButton.filled(
+                    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 0),
+                    onPressed: () {
+                      provider.setDefaultDirectory(_directoryController.text);
+                      AdaptiveSnackBar.show(
+                        context,
+                        message: '目录已保存',
+                        type: AdaptiveSnackBarType.success,
+                      );
+                    },
+                    child: const Text('保存'),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSortPresetCard(BuildContext context, WebDAVQuickAccessProvider provider) {
+    final Color tileColor = resolveSettingsTileBackground(context);
+    final Color sectionColor = resolveSettingsSectionBackground(context);
+    final Color iconColor = resolveSettingsIconColor(context);
+    final Color secondaryColor = resolveSettingsSecondaryTextColor(context);
+
+    return CupertinoSettingsGroupCard(
+      margin: EdgeInsets.zero,
+      backgroundColor: sectionColor,
+      addDividers: true,
+      dividerIndent: 56,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+          child: Row(
+            children: [
+              Icon(CupertinoIcons.sort_down, size: 16, color: iconColor),
+              const SizedBox(width: 8),
+              Text(
+                '文件排序',
+                style: CupertinoTheme.of(context).textTheme.textStyle.copyWith(
+                      fontSize: 13,
+                      color: secondaryColor,
+                    ),
+              ),
+            ],
+          ),
+        ),
+        ...WebDAVSortPreset.values.map((preset) {
+          final isSelected = preset == provider.sortPreset;
+          return CupertinoSettingsTile(
+            leading: Icon(
+              _getSortIcon(preset),
+              color: iconColor,
+            ),
+            title: Text(preset.displayName),
+            subtitle: Text(
+              preset.description,
+              style: TextStyle(fontSize: 11, color: secondaryColor),
+            ),
+            backgroundColor: tileColor,
+            trailing: isSelected
+                ? const Icon(CupertinoIcons.check_mark, color: CupertinoColors.activeBlue)
+                : null,
+            onTap: () {
+              provider.setSortPreset(preset);
+            },
+          );
+        }),
+      ],
+    );
+  }
+
+  IconData _getSortIcon(WebDAVSortPreset preset) {
+    switch (preset) {
+      case WebDAVSortPreset.defaultValue:
+        return CupertinoIcons.folder_fill;
+      case WebDAVSortPreset.nameAsc:
+        return CupertinoIcons.sort_up;
+      case WebDAVSortPreset.nameDesc:
+        return CupertinoIcons.sort_down;
+      case WebDAVSortPreset.modifiedDesc:
+        return CupertinoIcons.time;
+      case WebDAVSortPreset.modifiedAsc:
+        return CupertinoIcons.clock;
+      case WebDAVSortPreset.sizeDesc:
+        return CupertinoIcons.arrow_down;
+      case WebDAVSortPreset.sizeAsc:
+        return CupertinoIcons.arrow_up;
+      default:
+        return CupertinoIcons.sort_down;
+    }
+  }
+
+  Widget _buildPathBreadcrumbCard(BuildContext context, WebDAVQuickAccessProvider provider) {
+    final Color tileColor = resolveSettingsTileBackground(context);
+    final Color sectionColor = resolveSettingsSectionBackground(context);
+    final Color iconColor = resolveSettingsIconColor(context);
+
+    return CupertinoSettingsGroupCard(
+      margin: EdgeInsets.zero,
+      backgroundColor: sectionColor,
+      children: [
+        CupertinoSettingsTile(
+          leading: Icon(CupertinoIcons.map_pin, color: iconColor),
+          title: const Text('显示路径导航'),
+          subtitle: const Text('在顶部显示可点击的路径面包屑导航'),
+          backgroundColor: tileColor,
+          trailing: CupertinoSwitch(
+            value: provider.showPathBreadcrumb,
+            activeColor: CupertinoColors.activeBlue,
+            onChanged: (value) {
+              provider.setShowPathBreadcrumb(value);
+            },
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildAutoEnterSeasonCard(BuildContext context, WebDAVQuickAccessProvider provider) {
+    final Color tileColor = resolveSettingsTileBackground(context);
+    final Color sectionColor = resolveSettingsSectionBackground(context);
+    final Color iconColor = resolveSettingsIconColor(context);
+    final Color secondaryColor = resolveSettingsSecondaryTextColor(context);
+    final textTheme = CupertinoTheme.of(context).textTheme.textStyle;
+
+    return CupertinoSettingsGroupCard(
+      margin: EdgeInsets.zero,
+      backgroundColor: sectionColor,
+      children: [
+        CupertinoSettingsTile(
+          leading: Icon(CupertinoIcons.folder_fill, color: iconColor),
+          title: const Text('自动进入 Season 文件夹'),
+          subtitle: const Text('打开文件夹时自动进入匹配的子文件夹'),
+          backgroundColor: tileColor,
+          trailing: CupertinoSwitch(
+            value: provider.autoEnterSeasonFolder,
+            activeColor: CupertinoColors.activeBlue,
+            onChanged: (value) {
+              provider.setAutoEnterSeasonFolder(value);
+            },
+          ),
+        ),
+        if (provider.autoEnterSeasonFolder) ...[
+          Container(
+            color: tileColor,
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '匹配模式',
+                  style: textTheme.copyWith(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  '支持通配符：* 匹配任意字符，? 匹配单个字符',
+                  style: textTheme.copyWith(
+                    fontSize: 12,
+                    color: secondaryColor,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                CupertinoTextField(
+                  controller: TextEditingController(
+                    text: provider.seasonFolderPattern,
+                  ),
+                  placeholder: '例如: Season*、Season ??、S*',
+                  keyboardType: TextInputType.url,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                  decoration: BoxDecoration(
+                    color: CupertinoDynamicColor.resolve(
+                      CupertinoColors.tertiarySystemFill,
+                      context,
+                    ),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  onSubmitted: (value) {
+                    provider.setSeasonFolderPattern(value);
+                  },
+                ),
+                const SizedBox(height: 12),
+                Wrap(
+                  spacing: 8,
+                  children: [
+                    _buildPresetChip(context, 'Season*', provider),
+                    _buildPresetChip(context, 'Season ??', provider),
+                    _buildPresetChip(context, 'S*', provider),
+                    _buildPresetChip(context, 'Disc*', provider),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildPresetChip(
+    BuildContext context,
+    String pattern,
+    WebDAVQuickAccessProvider provider,
+  ) {
+    final isSelected = provider.seasonFolderPattern == pattern;
+    return CupertinoButton(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      minSize: 0,
+      color: isSelected
+          ? CupertinoColors.activeBlue.withOpacity(0.1)
+          : CupertinoDynamicColor.resolve(
+              CupertinoColors.tertiarySystemFill,
+              context,
+            ),
+      borderRadius: BorderRadius.circular(16),
+      onPressed: () {
+        provider.setSeasonFolderPattern(pattern);
+      },
+      child: Text(
+        pattern,
+        style: TextStyle(
+          color: isSelected
+              ? CupertinoColors.activeBlue
+              : CupertinoDynamicColor.resolve(
+                  CupertinoColors.label,
+                  context,
+                ),
+          fontSize: 13,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildResetCard(BuildContext context, WebDAVQuickAccessProvider provider) {
+    final Color sectionColor = resolveSettingsSectionBackground(context);
+    final Color secondaryColor = resolveSettingsSecondaryTextColor(context);
+
+    return CupertinoSettingsGroupCard(
+      margin: EdgeInsets.zero,
+      backgroundColor: sectionColor,
+      children: [
+        Center(
+          child: CupertinoButton(
+            padding: const EdgeInsets.symmetric(vertical: 16),
+            onPressed: () {
+              provider.resetSettings();
+              _directoryController.text = '/';
+              AdaptiveSnackBar.show(
+                context,
+                message: 'WebDAV 快捷设置已重置',
+                type: AdaptiveSnackBarType.success,
+              );
+            },
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(CupertinoIcons.refresh, size: 18, color: secondaryColor),
+                const SizedBox(width: 8),
+                Text(
+                  '重置所有设置',
+                  style: TextStyle(color: secondaryColor),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/themes/cupertino/pages/settings/widgets/webdav_quick_setting_tile.dart
+++ b/lib/themes/cupertino/pages/settings/widgets/webdav_quick_setting_tile.dart
@@ -1,0 +1,58 @@
+import 'package:nipaplay/themes/cupertino/cupertino_imports.dart';
+import 'package:nipaplay/l10n/l10n.dart';
+import 'package:provider/provider.dart';
+
+import 'package:nipaplay/providers/webdav_quick_access_provider.dart';
+import 'package:nipaplay/services/webdav_service.dart';
+import 'package:nipaplay/utils/cupertino_settings_colors.dart';
+import 'package:nipaplay/themes/cupertino/widgets/cupertino_settings_tile.dart';
+
+import '../pages/webdav_quick_settings_page.dart' show CupertinoWebDAVQuickSettingsPage;
+
+class CupertinoWebDAVQuickSettingTile extends StatelessWidget {
+  const CupertinoWebDAVQuickSettingTile({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final Color iconColor = resolveSettingsIconColor(context);
+    final Color backgroundColor = resolveSettingsTileBackground(context);
+
+    return Consumer<WebDAVQuickAccessProvider>(
+      builder: (context, provider, _) {
+        final subtitle = _buildSubtitle(context, provider);
+
+        return CupertinoSettingsTile(
+          leading: Icon(CupertinoIcons.cloud, color: iconColor),
+          title: const Text('WebDAV快捷'),
+          subtitle: Text(subtitle),
+          backgroundColor: backgroundColor,
+          showChevron: true,
+          onTap: () {
+            Navigator.of(context).push(
+              CupertinoPageRoute(
+                builder: (_) => const CupertinoWebDAVQuickSettingsPage(),
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  String _buildSubtitle(BuildContext context, WebDAVQuickAccessProvider provider) {
+    if (!provider.showWebDAVTab) {
+      return '未启用';
+    }
+
+    final connections = WebDAVService.instance.connections;
+    if (connections.isEmpty) {
+      return '无服务器配置';
+    }
+
+    if (provider.defaultServerName != null && provider.defaultServerName!.isNotEmpty) {
+      return provider.defaultServerName!;
+    }
+
+    return '已启用';
+  }
+}

--- a/lib/themes/nipaplay/pages/settings/labs_page.dart
+++ b/lib/themes/nipaplay/pages/settings/labs_page.dart
@@ -3,6 +3,7 @@ import 'package:kmbal_ionicons/kmbal_ionicons.dart';
 import 'package:nipaplay/providers/labs_settings_provider.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/settings_item.dart';
 import 'package:nipaplay/themes/nipaplay/pages/settings/webdav_quick_settings_page.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/nipaplay_window.dart';
 import 'package:provider/provider.dart';
 
 class LabsPage extends StatelessWidget {
@@ -11,47 +12,46 @@ class LabsPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
-    return ListView(
-      children: [
-        Consumer<LabsSettingsProvider>(
-          builder: (context, labsSettings, child) {
-            return Column(
-              children: [
-                SettingsItem.toggle(
-                  title: '大屏幕模式',
-                  subtitle: '开启后，NipaPlay 主题右上角显示大屏幕模式按钮',
-                  icon: Ionicons.tv_outline,
-                  value: labsSettings.enableLargeScreenMode,
-                  onChanged: (bool value) {
-                    labsSettings.setEnableLargeScreenMode(value);
-                  },
-                ),
-                Divider(
-                  color: colorScheme.onSurface.withValues(alpha: 0.12),
-                  height: 1,
-                ),
-              ],
-            );
-          },
-        ),
-        SettingsItem.button(
-          title: 'WebDAV 快捷设置',
-          subtitle: '配置底部 WebDAV 快捷 Tab，快速访问 WebDAV 服务器',
-          icon: Ionicons.cloud_outline,
-          trailingIcon: Ionicons.chevron_forward,
-          onTap: () {
-            Navigator.of(context).push(
-              MaterialPageRoute(
-                builder: (_) => const WebDAVQuickSettingsPage(),
-              ),
-            );
-          },
-        ),
-        Divider(
-          color: colorScheme.onSurface.withValues(alpha: 0.12),
-          height: 1,
-        ),
-      ],
+    return Consumer<LabsSettingsProvider>(
+      builder: (context, labsSettings, child) {
+        return ListView(
+          children: [
+            SettingsItem.toggle(
+              title: '大屏幕模式',
+              subtitle: '开启后，NipaPlay 主题右上角显示大屏幕模式按钮',
+              icon: Ionicons.tv_outline,
+              value: labsSettings.enableLargeScreenMode,
+              onChanged: (bool value) {
+                labsSettings.setEnableLargeScreenMode(value);
+              },
+            ),
+            Divider(
+              color: colorScheme.onSurface.withValues(alpha: 0.12),
+              height: 1,
+            ),
+            SettingsItem.button(
+              title: 'WebDAV 快捷设置',
+              subtitle: '配置底部 WebDAV 快捷 Tab，快速访问 WebDAV 服务器',
+              icon: Ionicons.cloud_outline,
+              trailingIcon: Ionicons.chevron_forward,
+              onTap: () {
+                NipaplayWindow.show(
+                  context: context,
+                  child: const NipaplayWindowScaffold(
+                    maxWidth: 600,
+                    maxHeightFactor: 0.9,
+                    child: WebDAVQuickSettingsPage(),
+                  ),
+                );
+              },
+            ),
+            Divider(
+              color: colorScheme.onSurface.withValues(alpha: 0.12),
+              height: 1,
+            ),
+          ],
+        );
+      },
     );
   }
 }

--- a/lib/themes/nipaplay/pages/settings/labs_page.dart
+++ b/lib/themes/nipaplay/pages/settings/labs_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:kmbal_ionicons/kmbal_ionicons.dart';
 import 'package:nipaplay/providers/labs_settings_provider.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/settings_item.dart';
+import 'package:nipaplay/themes/nipaplay/pages/settings/webdav_quick_settings_page.dart';
 import 'package:provider/provider.dart';
 
 class LabsPage extends StatelessWidget {
@@ -10,26 +11,47 @@ class LabsPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
-    return Consumer<LabsSettingsProvider>(
-      builder: (context, labsSettings, child) {
-        return ListView(
-          children: [
-            SettingsItem.toggle(
-              title: '大屏幕模式',
-              subtitle: '开启后，NipaPlay 主题右上角显示大屏幕模式按钮',
-              icon: Ionicons.tv_outline,
-              value: labsSettings.enableLargeScreenMode,
-              onChanged: (bool value) {
-                labsSettings.setEnableLargeScreenMode(value);
-              },
-            ),
-            Divider(
-              color: colorScheme.onSurface.withValues(alpha: 0.12),
-              height: 1,
-            ),
-          ],
-        );
-      },
+    return ListView(
+      children: [
+        Consumer<LabsSettingsProvider>(
+          builder: (context, labsSettings, child) {
+            return Column(
+              children: [
+                SettingsItem.toggle(
+                  title: '大屏幕模式',
+                  subtitle: '开启后，NipaPlay 主题右上角显示大屏幕模式按钮',
+                  icon: Ionicons.tv_outline,
+                  value: labsSettings.enableLargeScreenMode,
+                  onChanged: (bool value) {
+                    labsSettings.setEnableLargeScreenMode(value);
+                  },
+                ),
+                Divider(
+                  color: colorScheme.onSurface.withValues(alpha: 0.12),
+                  height: 1,
+                ),
+              ],
+            );
+          },
+        ),
+        SettingsItem.button(
+          title: 'WebDAV 快捷设置',
+          subtitle: '配置底部 WebDAV 快捷 Tab，快速访问 WebDAV 服务器',
+          icon: Ionicons.cloud_outline,
+          trailingIcon: Ionicons.chevron_forward,
+          onTap: () {
+            Navigator.of(context).push(
+              MaterialPageRoute(
+                builder: (_) => const WebDAVQuickSettingsPage(),
+              ),
+            );
+          },
+        ),
+        Divider(
+          color: colorScheme.onSurface.withValues(alpha: 0.12),
+          height: 1,
+        ),
+      ],
     );
   }
 }

--- a/lib/themes/nipaplay/pages/settings/webdav_quick_settings_page.dart
+++ b/lib/themes/nipaplay/pages/settings/webdav_quick_settings_page.dart
@@ -1,0 +1,547 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:nipaplay/providers/webdav_quick_access_provider.dart';
+import 'package:nipaplay/services/webdav_service.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/blur_snackbar.dart';
+import 'package:kmbal_ionicons/kmbal_ionicons.dart';
+
+/// WebDAV 快捷访问设置页面
+class WebDAVQuickSettingsPage extends StatefulWidget {
+  const WebDAVQuickSettingsPage({super.key});
+
+  @override
+  State<WebDAVQuickSettingsPage> createState() => _WebDAVQuickSettingsPageState();
+}
+
+class _WebDAVQuickSettingsPageState extends State<WebDAVQuickSettingsPage> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      Provider.of<WebDAVQuickAccessProvider>(context, listen: false).loadSettings();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final textColor = colorScheme.onSurface;
+    final secondaryTextColor = textColor.withOpacity(0.7);
+    final cardColor = isDark ? const Color(0xFF2A2A2A) : const Color(0xFFF5F5F5);
+    const accentColor = Color(0xFFFF2E55);
+
+    return Consumer<WebDAVQuickAccessProvider>(
+      builder: (context, provider, child) {
+        final connections = WebDAVService.instance.connections;
+
+        return SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // 说明文字
+              Text(
+                '配置底部 WebDAV 快捷 Tab，可以快速访问 WebDAV 服务器中的视频文件。',
+                style: TextStyle(
+                  color: secondaryTextColor,
+                  fontSize: 14,
+                ),
+              ),
+              const SizedBox(height: 24),
+
+              // 开关：显示 WebDAV Tab
+              _buildSettingsCard(
+                cardColor: cardColor,
+                child: SwitchListTile(
+                  title: Text(
+                    '显示 WebDAV Tab',
+                    style: TextStyle(color: textColor),
+                  ),
+                  subtitle: Text(
+                    '在底部导航栏显示 WebDAV 快捷入口',
+                    style: TextStyle(
+                      color: secondaryTextColor,
+                      fontSize: 12,
+                    ),
+                  ),
+                  value: provider.showWebDAVTab,
+                  activeColor: accentColor,
+                  onChanged: (value) {
+                    provider.setShowWebDAVTab(value);
+                  },
+                ),
+              ),
+
+              const SizedBox(height: 16),
+
+              // 默认主页 Tab 设置
+              _buildSettingsCard(
+                cardColor: cardColor,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Text(
+                        '默认主页',
+                        style: TextStyle(
+                          color: textColor,
+                          fontSize: 16,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                    ...provider.availableTabs.map((tabName) {
+                      final isSelected = tabName == provider.defaultHomeTab;
+                      return RadioListTile<String>(
+                        title: Text(
+                          WebDAVQuickAccessProvider.getTabDisplayName(tabName),
+                          style: TextStyle(color: textColor),
+                        ),
+                        subtitle: Text(
+                          tabName == WebDAVQuickAccessProvider.tabWebDAV
+                              ? '打开应用时直接进入 WebDAV 文件浏览'
+                              : '打开应用时直接进入此页面',
+                          style: TextStyle(
+                            color: secondaryTextColor,
+                            fontSize: 12,
+                          ),
+                        ),
+                        value: tabName,
+                        groupValue: provider.effectiveDefaultHomeTab,
+                        activeColor: accentColor,
+                        selected: isSelected,
+                        onChanged: (value) {
+                          if (value != null) {
+                            provider.setDefaultHomeTab(value);
+                          }
+                        },
+                      );
+                    }),
+                    if (provider.defaultHomeTab == WebDAVQuickAccessProvider.tabWebDAV && !provider.showWebDAVTab)
+                      Padding(
+                        padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+                        child: Text(
+                          '⚠️ 当前已选择 WebDAV 为默认主页，但 WebDAV Tab 未开启，将自动回落到首页',
+                          style: TextStyle(
+                            color: Colors.orange,
+                            fontSize: 12,
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+
+              const SizedBox(height: 16),
+
+              // 只有在开启 Tab 显示且有服务器连接时才显示以下设置
+              if (provider.showWebDAVTab && connections.isNotEmpty) ...[
+                // 选择默认服务器
+                _buildSettingsCard(
+                  cardColor: cardColor,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.all(16),
+                        child: Text(
+                          '默认服务器',
+                          style: TextStyle(
+                            color: textColor,
+                            fontSize: 16,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ),
+                      ...connections.map((connection) {
+                        final isSelected =
+                            connection.name == provider.defaultServerName;
+                        return RadioListTile<String>(
+                          title: Text(
+                            connection.name,
+                            style: TextStyle(color: textColor),
+                          ),
+                          subtitle: Text(
+                            connection.url,
+                            style: TextStyle(
+                              color: secondaryTextColor,
+                              fontSize: 12,
+                            ),
+                          ),
+                          value: connection.name,
+                          groupValue: provider.defaultServerName,
+                          activeColor: accentColor,
+                          selected: isSelected,
+                          onChanged: (value) {
+                            if (value != null) {
+                              provider.setDefaultServerName(value);
+                            }
+                          },
+                        );
+                      }),
+                    ],
+                  ),
+                ),
+
+                const SizedBox(height: 16),
+
+                // 设置默认目录
+                _buildSettingsCard(
+                  cardColor: cardColor,
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          '默认目录',
+                          style: TextStyle(
+                            color: textColor,
+                            fontSize: 16,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        const SizedBox(height: 12),
+                        TextField(
+                          controller: TextEditingController(
+                            text: provider.defaultDirectory,
+                          ),
+                          style: TextStyle(color: textColor),
+                          decoration: InputDecoration(
+                            hintText: '例如: /视频/动画',
+                            hintStyle: TextStyle(color: secondaryTextColor),
+                            filled: true,
+                            fillColor: cardColor,
+                            border: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(8),
+                              borderSide: BorderSide(
+                                color: secondaryTextColor.withOpacity(0.3),
+                              ),
+                            ),
+                            enabledBorder: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(8),
+                              borderSide: BorderSide(
+                                color: secondaryTextColor.withOpacity(0.3),
+                              ),
+                            ),
+                            focusedBorder: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(8),
+                              borderSide: const BorderSide(color: accentColor),
+                            ),
+                            suffixIcon: IconButton(
+                              icon: const Icon(Icons.refresh),
+                              color: secondaryTextColor,
+                              onPressed: () {
+                                // 重置为根目录
+                                provider.setDefaultDirectory('/');
+                              },
+                            ),
+                          ),
+                          onSubmitted: (value) {
+                            provider.setDefaultDirectory(value);
+                          },
+                        ),
+                        const SizedBox(height: 8),
+                        Text(
+                          '点击 WebDAV Tab 时将直接打开此目录',
+                          style: TextStyle(
+                            color: secondaryTextColor,
+                            fontSize: 12,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+
+                const SizedBox(height: 16),
+
+                // 排序设置
+                _buildSettingsCard(
+                  cardColor: cardColor,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.all(16),
+                        child: Text(
+                          '文件排序',
+                          style: TextStyle(
+                            color: textColor,
+                            fontSize: 16,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ),
+                      ...WebDAVSortPreset.values.map((preset) {
+                        final isSelected = preset == provider.sortPreset;
+                        return RadioListTile<WebDAVSortPreset>(
+                          title: Text(
+                            preset.displayName,
+                            style: TextStyle(color: textColor),
+                          ),
+                          subtitle: Text(
+                            preset.description,
+                            style: TextStyle(
+                              color: secondaryTextColor,
+                              fontSize: 11,
+                            ),
+                          ),
+                          value: preset,
+                          groupValue: provider.sortPreset,
+                          activeColor: accentColor,
+                          selected: isSelected,
+                          onChanged: (value) {
+                            if (value != null) {
+                              provider.setSortPreset(value);
+                            }
+                          },
+                        );
+                      }),
+                    ],
+                  ),
+                ),
+
+                const SizedBox(height: 16),
+
+                // 路径面包屑导航开关
+                _buildSettingsCard(
+                  cardColor: cardColor,
+                  child: SwitchListTile(
+                    title: Text(
+                      '显示路径导航',
+                      style: TextStyle(color: textColor),
+                    ),
+                    subtitle: Text(
+                      '在顶部显示可点击的路径面包屑导航',
+                      style: TextStyle(
+                        color: secondaryTextColor,
+                        fontSize: 12,
+                      ),
+                    ),
+                    value: provider.showPathBreadcrumb,
+                    activeColor: accentColor,
+                    onChanged: (value) {
+                      provider.setShowPathBreadcrumb(value);
+                    },
+                  ),
+                ),
+
+                const SizedBox(height: 16),
+
+                // 自动进入 Season 文件夹设置
+                _buildSettingsCard(
+                  cardColor: cardColor,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      SwitchListTile(
+                        title: Text(
+                          '自动进入 Season 文件夹',
+                          style: TextStyle(color: textColor),
+                        ),
+                        subtitle: Text(
+                          '打开文件夹时自动进入匹配的子文件夹',
+                          style: TextStyle(
+                            color: secondaryTextColor,
+                            fontSize: 12,
+                          ),
+                        ),
+                        value: provider.autoEnterSeasonFolder,
+                        activeColor: accentColor,
+                        onChanged: (value) {
+                          provider.setAutoEnterSeasonFolder(value);
+                        },
+                      ),
+                      if (provider.autoEnterSeasonFolder) ...[
+                        const Divider(height: 1),
+                        Padding(
+                          padding: const EdgeInsets.all(16),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                '匹配模式',
+                                style: TextStyle(
+                                  color: textColor,
+                                  fontSize: 14,
+                                  fontWeight: FontWeight.w500,
+                                ),
+                              ),
+                              const SizedBox(height: 8),
+                              Text(
+                                '支持通配符：* 匹配任意字符，? 匹配单个字符',
+                                style: TextStyle(
+                                  color: secondaryTextColor,
+                                  fontSize: 12,
+                                ),
+                              ),
+                              const SizedBox(height: 12),
+                              TextField(
+                                controller: TextEditingController(
+                                  text: provider.seasonFolderPattern,
+                                ),
+                                style: TextStyle(color: textColor),
+                                decoration: InputDecoration(
+                                  hintText: '例如: Season*、Season ??、S*',
+                                  hintStyle: TextStyle(color: secondaryTextColor),
+                                  filled: true,
+                                  fillColor: cardColor,
+                                  border: OutlineInputBorder(
+                                    borderRadius: BorderRadius.circular(8),
+                                    borderSide: BorderSide(
+                                      color: secondaryTextColor.withOpacity(0.3),
+                                    ),
+                                  ),
+                                  enabledBorder: OutlineInputBorder(
+                                    borderRadius: BorderRadius.circular(8),
+                                    borderSide: BorderSide(
+                                      color: secondaryTextColor.withOpacity(0.3),
+                                    ),
+                                  ),
+                                  focusedBorder: OutlineInputBorder(
+                                    borderRadius: BorderRadius.circular(8),
+                                    borderSide: const BorderSide(color: accentColor),
+                                  ),
+                                ),
+                                onSubmitted: (value) {
+                                  provider.setSeasonFolderPattern(value);
+                                },
+                              ),
+                              const SizedBox(height: 12),
+                              // 预设模式
+                              Wrap(
+                                spacing: 8,
+                                children: [
+                                  _buildPresetChip(
+                                    'Season*',
+                                    provider,
+                                    accentColor,
+                                    secondaryTextColor,
+                                  ),
+                                  _buildPresetChip(
+                                    'Season ??',
+                                    provider,
+                                    accentColor,
+                                    secondaryTextColor,
+                                  ),
+                                  _buildPresetChip(
+                                    'S*',
+                                    provider,
+                                    accentColor,
+                                    secondaryTextColor,
+                                  ),
+                                  _buildPresetChip(
+                                    'Disc*',
+                                    provider,
+                                    accentColor,
+                                    secondaryTextColor,
+                                  ),
+                                ],
+                              ),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              ],
+
+              // 没有服务器连接时的提示
+              if (provider.showWebDAVTab && connections.isEmpty)
+                _buildSettingsCard(
+                  cardColor: cardColor,
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Column(
+                      children: [
+                        Icon(
+                          Ionicons.cloud_offline_outline,
+                          size: 48,
+                          color: secondaryTextColor,
+                        ),
+                        const SizedBox(height: 16),
+                        Text(
+                          '没有配置 WebDAV 服务器',
+                          style: TextStyle(
+                            color: textColor,
+                            fontSize: 16,
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                        Text(
+                          '请先在「远程媒体库」设置中添加 WebDAV 服务器',
+                          style: TextStyle(
+                            color: secondaryTextColor,
+                            fontSize: 14,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+
+              const SizedBox(height: 32),
+
+              // 重置按钮
+              Center(
+                child: TextButton.icon(
+                  icon: const Icon(Icons.refresh),
+                  label: const Text('重置所有设置'),
+                  style: TextButton.styleFrom(
+                    foregroundColor: secondaryTextColor,
+                  ),
+                  onPressed: () {
+                    provider.resetSettings();
+                    BlurSnackBar.show(context, 'WebDAV 快捷设置已重置');
+                  },
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildSettingsCard({
+    required Color cardColor,
+    required Widget child,
+  }) {
+    return Container(
+      decoration: BoxDecoration(
+        color: cardColor,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: child,
+    );
+  }
+
+  Widget _buildPresetChip(
+    String pattern,
+    WebDAVQuickAccessProvider provider,
+    Color accentColor,
+    Color secondaryTextColor,
+  ) {
+    final isSelected = provider.seasonFolderPattern == pattern;
+    return ActionChip(
+      label: Text(
+        pattern,
+        style: TextStyle(
+          color: isSelected ? accentColor : secondaryTextColor,
+          fontSize: 13,
+        ),
+      ),
+      backgroundColor: isSelected ? accentColor.withOpacity(0.1) : null,
+      side: BorderSide(
+        color: isSelected ? accentColor : secondaryTextColor.withOpacity(0.3),
+      ),
+      onPressed: () {
+        provider.setSeasonFolderPattern(pattern);
+      },
+    );
+  }
+}

--- a/lib/themes/nipaplay/widgets/brightness_gesture_area.dart
+++ b/lib/themes/nipaplay/widgets/brightness_gesture_area.dart
@@ -10,34 +10,65 @@ class BrightnessGestureArea extends StatefulWidget {
 }
 
 class _BrightnessGestureAreaState extends State<BrightnessGestureArea> {
+  // 防误触区域高度
+  static const double _topSafeArea = 48.0;
+  static const double _bottomSafeArea = 40.0;
+  // 最小滑动距离阈值
+  static const double _minDragDistance = 10.0;
+
+  double _accumulatedDrag = 0.0;
+  bool _hasStartedAdjustment = false;
+
   void _onVerticalDragStart(BuildContext context, DragStartDetails details) {
-    final videoState = Provider.of<VideoPlayerState>(context, listen: false);
-    videoState.startBrightnessDrag();
+    _accumulatedDrag = 0.0;
+    _hasStartedAdjustment = false;
   }
 
   void _onVerticalDragUpdate(BuildContext context, DragUpdateDetails details) {
-    final videoState = Provider.of<VideoPlayerState>(context, listen: false);
-    videoState.updateBrightnessOnDrag(details.delta.dy, context);
+    _accumulatedDrag += details.delta.dy.abs();
+
+    if (!_hasStartedAdjustment && _accumulatedDrag > _minDragDistance) {
+      _hasStartedAdjustment = true;
+      final videoState = Provider.of<VideoPlayerState>(context, listen: false);
+      videoState.startBrightnessDrag();
+    }
+
+    if (_hasStartedAdjustment) {
+      final videoState = Provider.of<VideoPlayerState>(context, listen: false);
+      videoState.updateBrightnessOnDrag(details.delta.dy, context);
+    }
   }
 
   void _onVerticalDragEnd(BuildContext context, DragEndDetails details) {
-    final videoState = Provider.of<VideoPlayerState>(context, listen: false);
-    videoState.endBrightnessDrag();
+    if (_hasStartedAdjustment) {
+      final videoState = Provider.of<VideoPlayerState>(context, listen: false);
+      videoState.endBrightnessDrag();
+    }
+    _accumulatedDrag = 0.0;
+    _hasStartedAdjustment = false;
   }
 
   void _onVerticalDragCancel(BuildContext context) {
-    final videoState = Provider.of<VideoPlayerState>(context, listen: false);
-    videoState.endBrightnessDrag();
+    if (_hasStartedAdjustment) {
+      final videoState = Provider.of<VideoPlayerState>(context, listen: false);
+      videoState.endBrightnessDrag();
+    }
+    _accumulatedDrag = 0.0;
+    _hasStartedAdjustment = false;
   }
 
   @override
   Widget build(BuildContext context) {
+    final safeTop = MediaQuery.of(context).padding.top;
+    final safeBottom = MediaQuery.of(context).padding.bottom;
+    final effectiveTopSafeArea = safeTop + _topSafeArea;
+    final effectiveBottomSafeArea = safeBottom + _bottomSafeArea;
+
     return Positioned(
       left: 0,
-      top: 0,
-      bottom: 0,
-      width: MediaQuery.of(context).size.width /
-          2.2, // Consistent with original width
+      top: effectiveTopSafeArea,
+      bottom: effectiveBottomSafeArea,
+      width: MediaQuery.of(context).size.width / 2.2,
       child: GestureDetector(
         onVerticalDragStart: (details) =>
             _onVerticalDragStart(context, details),
@@ -46,7 +77,7 @@ class _BrightnessGestureAreaState extends State<BrightnessGestureArea> {
         onVerticalDragEnd: (details) => _onVerticalDragEnd(context, details),
         onVerticalDragCancel: () => _onVerticalDragCancel(context),
         behavior: HitTestBehavior.translucent,
-        child: Container(), // Empty container, purely for gesture detection
+        child: Container(),
       ),
     );
   }

--- a/lib/themes/nipaplay/widgets/video_player_ui.dart
+++ b/lib/themes/nipaplay/widgets/video_player_ui.dart
@@ -65,6 +65,10 @@ class _VideoPlayerUIState extends State<VideoPlayerUI>
   bool _isProcessingTap = false;
   bool _isMouseVisible = true;
   bool _isHorizontalDragging = false;
+  // 防误触：最小水平滑动距离阈值
+  static const double _minHorizontalDragDistance = 20.0;
+  double _accumulatedHorizontalDrag = 0.0;
+  bool _hasStartedSeekDrag = false;
   final OverlayContextMenuController _contextMenuController =
       OverlayContextMenuController();
 
@@ -523,35 +527,45 @@ class _VideoPlayerUIState extends State<VideoPlayerUI>
     if (!globals.isMobilePlatform && !_isTouchLikePointer(details.kind)) {
       return;
     }
-    final videoState = Provider.of<VideoPlayerState>(context, listen: false);
-    if (videoState.hasVideo) {
-      _isHorizontalDragging = true;
-      videoState.startSeekDrag(context);
-      _doubleTapTimer?.cancel();
-      _tapCount = 0;
-    }
+    _accumulatedHorizontalDrag = 0.0;
+    _hasStartedSeekDrag = false;
+    _isHorizontalDragging = true;
+    _doubleTapTimer?.cancel();
+    _tapCount = 0;
   }
 
   void _handleHorizontalDragUpdate(
     BuildContext context,
     DragUpdateDetails details,
   ) {
-    if (_isHorizontalDragging) {
+    if (!_isHorizontalDragging) return;
+
+    if (details.delta.dx.abs() <= details.delta.dy.abs()) return;
+
+    _accumulatedHorizontalDrag += details.delta.dx.abs();
+
+    if (!_hasStartedSeekDrag && _accumulatedHorizontalDrag > _minHorizontalDragDistance) {
+      _hasStartedSeekDrag = true;
       final videoState = Provider.of<VideoPlayerState>(context, listen: false);
-      if (details.primaryDelta != null && details.primaryDelta!.abs() > 0) {
-        if ((details.delta.dx.abs() > details.delta.dy.abs())) {
-          videoState.updateSeekDrag(details.delta.dx, context);
-        }
+      if (videoState.hasVideo) {
+        videoState.startSeekDrag(context);
       }
+    }
+
+    if (_hasStartedSeekDrag) {
+      final videoState = Provider.of<VideoPlayerState>(context, listen: false);
+      videoState.updateSeekDrag(details.delta.dx, context);
     }
   }
 
   void _handleHorizontalDragEnd(BuildContext context, DragEndDetails details) {
-    if (_isHorizontalDragging) {
+    if (_hasStartedSeekDrag) {
       final videoState = Provider.of<VideoPlayerState>(context, listen: false);
       videoState.endSeekDrag();
-      _isHorizontalDragging = false;
     }
+    _isHorizontalDragging = false;
+    _accumulatedHorizontalDrag = 0.0;
+    _hasStartedSeekDrag = false;
   }
 
   @override

--- a/lib/themes/nipaplay/widgets/volume_gesture_area.dart
+++ b/lib/themes/nipaplay/widgets/volume_gesture_area.dart
@@ -10,32 +10,64 @@ class VolumeGestureArea extends StatefulWidget {
 }
 
 class _VolumeGestureAreaState extends State<VolumeGestureArea> {
+  // 防误触区域高度
+  static const double _topSafeArea = 48.0;
+  static const double _bottomSafeArea = 40.0;
+  // 最小滑动距离阈值
+  static const double _minDragDistance = 10.0;
+
+  double _accumulatedDrag = 0.0;
+  bool _hasStartedAdjustment = false;
+
   void _onVerticalDragStart(BuildContext context, DragStartDetails details) {
-    final videoState = Provider.of<VideoPlayerState>(context, listen: false);
-    videoState.startVolumeDrag();
+    _accumulatedDrag = 0.0;
+    _hasStartedAdjustment = false;
   }
 
   void _onVerticalDragUpdate(BuildContext context, DragUpdateDetails details) {
-    final videoState = Provider.of<VideoPlayerState>(context, listen: false);
-    videoState.updateVolumeOnDrag(details.delta.dy, context);
+    _accumulatedDrag += details.delta.dy.abs();
+
+    if (!_hasStartedAdjustment && _accumulatedDrag > _minDragDistance) {
+      _hasStartedAdjustment = true;
+      final videoState = Provider.of<VideoPlayerState>(context, listen: false);
+      videoState.startVolumeDrag();
+    }
+
+    if (_hasStartedAdjustment) {
+      final videoState = Provider.of<VideoPlayerState>(context, listen: false);
+      videoState.updateVolumeOnDrag(details.delta.dy, context);
+    }
   }
 
   void _onVerticalDragEnd(BuildContext context, DragEndDetails details) {
-    final videoState = Provider.of<VideoPlayerState>(context, listen: false);
-    videoState.endVolumeDrag();
+    if (_hasStartedAdjustment) {
+      final videoState = Provider.of<VideoPlayerState>(context, listen: false);
+      videoState.endVolumeDrag();
+    }
+    _accumulatedDrag = 0.0;
+    _hasStartedAdjustment = false;
   }
 
   void _onVerticalDragCancel(BuildContext context) {
-    final videoState = Provider.of<VideoPlayerState>(context, listen: false);
-    videoState.endVolumeDrag();
+    if (_hasStartedAdjustment) {
+      final videoState = Provider.of<VideoPlayerState>(context, listen: false);
+      videoState.endVolumeDrag();
+    }
+    _accumulatedDrag = 0.0;
+    _hasStartedAdjustment = false;
   }
 
   @override
   Widget build(BuildContext context) {
+    final safeTop = MediaQuery.of(context).padding.top;
+    final safeBottom = MediaQuery.of(context).padding.bottom;
+    final effectiveTopSafeArea = safeTop + _topSafeArea;
+    final effectiveBottomSafeArea = safeBottom + _bottomSafeArea;
+
     return Positioned(
       right: 0,
-      top: 0,
-      bottom: 0,
+      top: effectiveTopSafeArea,
+      bottom: effectiveBottomSafeArea,
       width: MediaQuery.of(context).size.width / 2.2,
       child: GestureDetector(
         onVerticalDragStart: (details) =>

--- a/lib/utils/video_player_state/video_player_state_playback_controls.dart
+++ b/lib/utils/video_player_state/video_player_state_playback_controls.dart
@@ -130,21 +130,12 @@ extension VideoPlayerStatePlaybackControls on VideoPlayerState {
         player.state = PlaybackState.stopped;
       }
 
-      // 等待一小段时间确保播放器完全停止
-      await Future.delayed(const Duration(milliseconds: 100));
-      _logMacOSHdrResetTrace(
-        'after stop delay path=$_currentVideoPath status=$_status playerState=${player.state}',
-      );
-
       // 释放纹理，确保资源被正确释放
       if (player.textureId.value != null) {
         // Keep the null check for reading
         _disposeTextureResources();
         // player.textureId.value = null; // COMMENTED OUT
       }
-
-      // 等待一小段时间确保纹理完全释放
-      await Future.delayed(const Duration(milliseconds: 200));
 
       // 重置状态
       await _clearTimelinePreviewFiles();

--- a/lib/utils/video_player_state/video_player_state_streaming.dart
+++ b/lib/utils/video_player_state/video_player_state_streaming.dart
@@ -61,23 +61,21 @@ extension VideoPlayerStateStreaming on VideoPlayerState {
       _logMacOSHdrExitTrace(
         'handleBackButton start path=$_currentVideoPath status=$_status hasVideo=$hasVideo playerState=${player.state}',
       );
-      // 在允许播放器重置前完成截图，避免截图与 native surface 拆除并发。
-      await _captureConditionalScreenshot("返回按钮时");
+      // Fire-and-forget：截图和云同步改为后台执行，不阻塞退出
+      unawaited(_captureConditionalScreenshot("返回按钮时").catchError((e) {
+        debugPrint('退出截图失败: $e');
+      }));
 
-      // 退出视频播放时触发自动云同步
       if (_currentVideoPath != null) {
-        try {
-          await AutoSyncService.instance.syncOnPlaybackEnd();
-          debugPrint('退出视频播放时云同步成功');
-        } catch (e) {
-          debugPrint('退出视频播放时云同步失败: $e');
-        }
+        unawaited(AutoSyncService.instance.syncOnPlaybackEnd().catchError((e) {
+          debugPrint('退出云同步失败: $e');
+        }));
       }
 
       _logMacOSHdrExitTrace(
         'handleBackButton done path=$_currentVideoPath status=$_status hasVideo=$hasVideo playerState=${player.state}',
       );
-      return true; // 允许返回
+      return true; // 立即允许返回
     }
   }
 


### PR DESCRIPTION
## Summary

- 新增 WebDAV 快捷 Tab，支持在底部导航栏一键访问 WebDAV 服务器，浏览文件并播放视频
- WebDAV 设置入口集成到「实验室」板块，不修改现有设置页面结构
- 优化播放器退出动画，消除退出时的卡顿和闪烁（退出延迟 500-2500ms → <100ms）
- 优化播放器手势防误触，避免下拉通知栏或滑动时误触亮度/音量/进度调节

## Related Issue

无

## What Changed

### 1. WebDAV 快捷 Tab 核心 (`f60c9d8`)
- 新增 `WebDAVQuickAccessProvider` — 管理 WebDAV Tab 开关、默认服务器、默认目录、排序预设、默认主页 Tab 等设置
- 新增 `WebDAVBrowserPage` — WebDAV 文件浏览器（7 种排序、观看历史进度、面包屑导航、Season 文件夹自动进入、服务器添加）
- 修改 `main.dart` — 注册 Provider + 动态 Tab 结构（WebDAV 关闭时代码路径与上游完全一致）
- 修改 `tab_labels.dart` — 支持 `showWebDAVTab` 参数（默认 false，向后兼容）
- 修改 `cupertino_main_page.dart` — 移动端动态导航栏支持 WebDAV Tab + 默认主页选择

### 2. WebDAV 设置集成到实验室 (`3f699d5`)
- 新增 `WebDAVQuickSettingsPage`（nipaplay + Cupertino 双主题版本）
- 修改 `labs_page.dart` — 实验室中新增「WebDAV 快捷设置」导航入口
- 修改 `cupertino_labs_settings_page.dart` — 对应 Cupertino 主题入口

### 3. 播放器退出动画优化 (`0b98bd6`)
- 修改 `video_player_state_streaming.dart` — 截图和云同步改为 fire-and-forget（unawaited），不阻塞退出
- 修改 `video_player_state_playback_controls.dart` — 移除 `resetPlayer()` 中两个无效硬等待（100ms + 200ms）
- 修改 `play_video_page.dart` / `cupertino_play_video_page.dart` — 退出时禁用 AnimatedContainer 颜色过渡动画，消除闪烁

### 4. 播放器手势防误触 (`558d7d0`)
- 修改 `brightness_gesture_area.dart` / `volume_gesture_area.dart` — 顶部 48px + 底部 40px 安全区域，最小滑动阈值 10px
- 修改 `video_player_ui.dart` — 水平进度滑动最小阈值 20px，避免上下滑动时误触进度调整

## 影响范围

| 类别 | 影响 |
|------|------|
| WebDAV 专用模块（5 新文件） | 零全局影响，删除后不影响其他功能 |
| WebDAV 宿主修改（5 文件） | WebDAV Tab 关闭时行为与上游完全一致 |
| 播放器优化（7 文件） | 优化类改动，不改变功能行为 |

## Verification

- `flutter analyze` 无新增 error（仅 third_party/ 预存问题）
- 已构建签名 APK 验证功能正常