### PR TITLE
fix: 修复 PR448 引入的退出并发与 WebDAV Tab 映射回归

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1114,6 +1114,7 @@ class MainPageState extends State<MainPage>
     debugPrint('[MainPageState] targetTabIndex: $index');
 
     if (index != null) {
+      final normalizedIndex = _normalizeTabIndex(index);
       debugPrint('[MainPageState] 准备调用_manageHotkeys()...');
       _manageHotkeys();
       debugPrint('[MainPageState] _manageHotkeys()调用完成');
@@ -1121,17 +1122,17 @@ class MainPageState extends State<MainPage>
       if (globalTabController != null) {
         debugPrint(
             '[MainPageState] globalTabController可用，当前索引: ${globalTabController!.index}');
-        if (globalTabController!.index != index) {
+        if (globalTabController!.index != normalizedIndex) {
           try {
-            debugPrint('[MainPageState] 尝试切换到标签: $index');
+            debugPrint('[MainPageState] 尝试切换到标签: $normalizedIndex');
             // 强制启用页面滑动动画
-            globalTabController!.animateTo(index);
-            debugPrint('[MainPageState] 已切换到标签: $index');
+            globalTabController!.animateTo(normalizedIndex);
+            debugPrint('[MainPageState] 已切换到标签: $normalizedIndex');
           } catch (e) {
             debugPrint('[MainPageState] 切换标签失败: $e');
           }
         } else {
-          debugPrint('[MainPageState] 已经是目标标签: $index，无需切换');
+          debugPrint('[MainPageState] 已经是目标标签: $normalizedIndex，无需切换');
         }
       } else {
         debugPrint('[MainPageState] globalTabController为空，无法切换标签');
@@ -1213,9 +1214,17 @@ class MainPageState extends State<MainPage>
   void _onWebDAVSettingsChanged() {
     final showWebDAVTab = _webdavQuickAccessProvider?.showWebDAVTab ?? false;
     if (showWebDAVTab != _showWebDAVTab) {
+      final previousShowWebDAVTab = _showWebDAVTab;
+      final currentIndex = globalTabController?.index;
       _showWebDAVTab = showWebDAVTab;
       _rebuildPages();
-      _rebuildTabController();
+      _rebuildTabController(
+        targetIndex: _remapIndexForWebDAVToggle(
+          currentIndex: currentIndex,
+          oldShowWebDAVTab: previousShowWebDAVTab,
+          newShowWebDAVTab: showWebDAVTab,
+        ),
+      );
     }
   }
 
@@ -1227,28 +1236,13 @@ class MainPageState extends State<MainPage>
   }
 
   int _getInitialTabIndex() {
-    final defaultTab = _webdavQuickAccessProvider?.effectiveDefaultHomeTab ?? WebDAVQuickAccessProvider.tabHome;
-
-    switch (defaultTab) {
-      case WebDAVQuickAccessProvider.tabHome:
-        return 0;
-      case WebDAVQuickAccessProvider.tabVideo:
-        return 1;
-      case WebDAVQuickAccessProvider.tabWebDAV:
-        return _showWebDAVTab ? 2 : 0;
-      case WebDAVQuickAccessProvider.tabMediaLibrary:
-        return _showWebDAVTab ? 3 : 2;
-      case WebDAVQuickAccessProvider.tabAccount:
-        return _showWebDAVTab ? 4 : 3;
-      case WebDAVQuickAccessProvider.tabSettings:
-        return _showWebDAVTab ? 3 : 2;
-      default:
-        return 0;
-    }
+    final defaultTab = _webdavQuickAccessProvider?.effectiveDefaultHomeTab ??
+        WebDAVQuickAccessProvider.tabHome;
+    return _tabIndexForName(defaultTab);
   }
 
-  void _rebuildTabController() {
-    final currentIndex = globalTabController?.index ?? 0;
+  void _rebuildTabController({int? targetIndex}) {
+    final currentIndex = targetIndex ?? globalTabController?.index ?? 0;
     globalTabController?.removeListener(_onTabChange);
     globalTabController?.dispose();
 
@@ -1261,6 +1255,65 @@ class MainPageState extends State<MainPage>
     globalTabController?.addListener(_onTabChange);
 
     setState(() {});
+  }
+
+  int _tabIndexForName(String tabName) {
+    final hasWebDAVTab = _showWebDAVTab;
+    switch (tabName) {
+      case WebDAVQuickAccessProvider.tabHome:
+        return 0;
+      case WebDAVQuickAccessProvider.tabVideo:
+        return 1;
+      case WebDAVQuickAccessProvider.tabWebDAV:
+        return hasWebDAVTab ? 2 : 0;
+      case WebDAVQuickAccessProvider.tabMediaLibrary:
+        return hasWebDAVTab ? 3 : 2;
+      case WebDAVQuickAccessProvider.tabAccount:
+        return hasWebDAVTab ? 4 : 3;
+      default:
+        return 0;
+    }
+  }
+
+  int _normalizeTabIndex(int requestedIndex) {
+    if (requestedIndex == 2 && _showWebDAVTab) {
+      return 3;
+    }
+    final maxIndex = _pages.length - 1;
+    return requestedIndex.clamp(0, maxIndex).toInt();
+  }
+
+  int _remapIndexForWebDAVToggle({
+    required int? currentIndex,
+    required bool oldShowWebDAVTab,
+    required bool newShowWebDAVTab,
+  }) {
+    if (currentIndex == null) {
+      return _getInitialTabIndex();
+    }
+    if (oldShowWebDAVTab == newShowWebDAVTab) {
+      return currentIndex;
+    }
+
+    if (oldShowWebDAVTab && !newShowWebDAVTab) {
+      if (currentIndex == 2) {
+        // WebDAV Tab 被隐藏，回落到首页
+        return 0;
+      }
+      if (currentIndex >= 3) {
+        return currentIndex - 1;
+      }
+      return currentIndex;
+    }
+
+    if (!oldShowWebDAVTab && newShowWebDAVTab) {
+      if (currentIndex >= 2) {
+        return currentIndex + 1;
+      }
+      return currentIndex;
+    }
+
+    return currentIndex;
   }
 
   Future<void> _initializeController() async {
@@ -1391,6 +1444,7 @@ class MainPageState extends State<MainPage>
   void dispose() {
     _tabChangeNotifier
         ?.removeListener(_onTabChangeRequested); // Temporarily remove
+    _webdavQuickAccessProvider?.removeListener(_onWebDAVSettingsChanged);
     globalTabController?.removeListener(_onTabChange);
     _videoPlayerState?.removeListener(_manageHotkeys);
     globalTabController?.dispose();
@@ -1797,24 +1851,28 @@ Future<void> _showGlobalUploadDialog(BuildContext context) async {
 
 // 导航到特定页面逻辑
 void _navigateToPage(BuildContext context, int pageIndex) {
-  print('[Dart] 准备导航到页面索引: $pageIndex');
+  MainPageState? mainPageState = MainPageState.of(context);
+  final resolvedPageIndex = _resolveRequestedPageIndex(
+    requestedIndex: pageIndex,
+    tabLength: mainPageState?.globalTabController?.length,
+  );
+  print('[Dart] 准备导航到页面索引: $resolvedPageIndex');
 
   // 尝试获取MainPageState
-  MainPageState? mainPageState = MainPageState.of(context);
   if (mainPageState != null && mainPageState.globalTabController != null) {
-    if (mainPageState.globalTabController!.index != pageIndex) {
+    if (mainPageState.globalTabController!.index != resolvedPageIndex) {
       final enablePageAnimation =
           context.read<AppearanceSettingsProvider>().enablePageAnimation;
       if (enablePageAnimation) {
-        mainPageState.globalTabController!.animateTo(pageIndex);
+        mainPageState.globalTabController!.animateTo(resolvedPageIndex);
       } else {
-        mainPageState.globalTabController!.index = pageIndex;
+        mainPageState.globalTabController!.index = resolvedPageIndex;
       }
       debugPrint(
-          '[Dart - _navigateToPage] 直接切换到标签页$pageIndex (动画: $enablePageAnimation)');
+          '[Dart - _navigateToPage] 直接切换到标签页$resolvedPageIndex (动画: $enablePageAnimation)');
     } else {
       debugPrint(
-          '[Dart - _navigateToPage] globalTabController已经在索引$pageIndex，无需切换');
+          '[Dart - _navigateToPage] globalTabController已经在索引$resolvedPageIndex，无需切换');
     }
   } else {
     debugPrint(
@@ -1824,6 +1882,20 @@ void _navigateToPage(BuildContext context, int pageIndex) {
     debugPrint(
         '[Dart - _navigateToPage] 备选方案: 使用TabChangeNotifier请求切换到标签页$pageIndex');
   }
+}
+
+int _resolveRequestedPageIndex({
+  required int requestedIndex,
+  required int? tabLength,
+}) {
+  if (requestedIndex != 2) {
+    return requestedIndex;
+  }
+  // Material 首页：开启 WebDAV 后媒体库索引从 2 右移到 3。
+  if (tabLength == 5) {
+    return 3;
+  }
+  return 2;
 }
 
 Brightness _resolveEffectiveBrightness(

--- a/lib/providers/webdav_quick_access_provider.dart
+++ b/lib/providers/webdav_quick_access_provider.dart
@@ -51,6 +51,7 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
   static const String _keyAutoEnterSeasonFolder = 'webdav_auto_enter_season_folder';
   static const String _keySeasonFolderPattern = 'webdav_season_folder_pattern';
   static const String _keyShowPathBreadcrumb = 'webdav_show_path_breadcrumb';
+  static const String _legacyDefaultPageIndexKey = 'default_page_index';
 
   // Tab 名称常量
   static const String tabHome = 'home';
@@ -59,6 +60,14 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
   static const String tabAccount = 'account';
   static const String tabSettings = 'settings';
   static const String tabWebDAV = 'webdav';
+  static const List<String> _allSupportedTabs = [
+    tabHome,
+    tabVideo,
+    tabMediaLibrary,
+    tabAccount,
+    tabSettings,
+    tabWebDAV,
+  ];
 
   // 状态
   bool _showWebDAVTab = false;
@@ -85,17 +94,35 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
   /// 获取有效的默认 Tab（处理 WebDAV 关闭时的回落）
   String get effectiveDefaultHomeTab {
     if (_defaultHomeTab == tabWebDAV && !_showWebDAVTab) {
-      return tabHome; // WebDAV 关闭时回落到首页
+      return tabHome;
     }
+
+    if (_isMaterialOnlyTab(_defaultHomeTab)) {
+      return tabHome;
+    }
+
     return _defaultHomeTab;
+  }
+
+  /// Material 主题可用的默认主页选项
+  List<String> get materialAvailableTabs {
+    if (_showWebDAVTab) {
+      return [tabHome, tabVideo, tabWebDAV, tabMediaLibrary, tabAccount];
+    }
+    return [tabHome, tabVideo, tabMediaLibrary, tabAccount];
+  }
+
+  /// Cupertino 主题可用的默认主页选项
+  List<String> get cupertinoAvailableTabs {
+    if (_showWebDAVTab) {
+      return [tabHome, tabWebDAV, tabMediaLibrary, tabAccount, tabSettings];
+    }
+    return [tabHome, tabMediaLibrary, tabAccount, tabSettings];
   }
 
   /// 获取所有可用的 Tab 选项（根据 WebDAV 是否开启）
   List<String> get availableTabs {
-    if (_showWebDAVTab) {
-      return [tabHome, tabVideo, tabWebDAV, tabMediaLibrary, tabAccount, tabSettings];
-    }
-    return [tabHome, tabVideo, tabMediaLibrary, tabAccount, tabSettings];
+    return materialAvailableTabs;
   }
 
   /// 获取 Tab 的显示名称
@@ -138,7 +165,12 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
       _showWebDAVTab = prefs.getBool(_keyShowWebDAVTab) ?? false;
       _defaultServerName = prefs.getString(_keyDefaultServerName) ?? '';
       _defaultDirectory = prefs.getString(_keyDefaultDirectory) ?? '/';
-      _defaultHomeTab = prefs.getString(_keyDefaultHomeTab) ?? tabHome;
+      final storedDefaultHomeTab = prefs.getString(_keyDefaultHomeTab);
+      if (storedDefaultHomeTab != null && storedDefaultHomeTab.isNotEmpty) {
+        _defaultHomeTab = storedDefaultHomeTab;
+      } else {
+        _defaultHomeTab = _migrateLegacyDefaultPageIndex(prefs);
+      }
       _sortPreset = WebDAVSortPreset.fromValue(prefs.getString(_keySortPreset));
       _autoEnterSeasonFolder = prefs.getBool(_keyAutoEnterSeasonFolder) ?? false;
       _seasonFolderPattern = prefs.getString(_keySeasonFolderPattern) ?? 'Season*';
@@ -168,6 +200,9 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
 
   /// 设置默认主页 Tab
   Future<void> setDefaultHomeTab(String tabName) async {
+    if (!_allSupportedTabs.contains(tabName)) {
+      return;
+    }
     if (_defaultHomeTab == tabName) return;
 
     _defaultHomeTab = tabName;
@@ -179,6 +214,25 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
     } catch (e) {
       debugPrint('保存默认主页 Tab 设置失败: $e');
     }
+  }
+
+  String _migrateLegacyDefaultPageIndex(SharedPreferences prefs) {
+    final legacyIndex = prefs.getInt(_legacyDefaultPageIndexKey);
+    switch (legacyIndex) {
+      case 1:
+        return tabVideo;
+      case 2:
+        return tabMediaLibrary;
+      case 3:
+        return tabAccount;
+      case 0:
+      default:
+        return tabHome;
+    }
+  }
+
+  bool _isMaterialOnlyTab(String tabName) {
+    return tabName == tabSettings;
   }
 
   /// 设置排序预设

--- a/lib/themes/cupertino/pages/settings/pages/webdav_quick_settings_page.dart
+++ b/lib/themes/cupertino/pages/settings/pages/webdav_quick_settings_page.dart
@@ -170,7 +170,7 @@ class _CupertinoWebDAVQuickSettingsPageState
             ],
           ),
         ),
-        ...provider.availableTabs.map((tabName) {
+        ...provider.cupertinoAvailableTabs.map((tabName) {
           final isSelected = tabName == provider.defaultHomeTab;
           return CupertinoSettingsTile(
             leading: Icon(

--- a/lib/themes/nipaplay/pages/settings/webdav_quick_settings_page.dart
+++ b/lib/themes/nipaplay/pages/settings/webdav_quick_settings_page.dart
@@ -92,7 +92,7 @@ class _WebDAVQuickSettingsPageState extends State<WebDAVQuickSettingsPage> {
                         ),
                       ),
                     ),
-                    ...provider.availableTabs.map((tabName) {
+                    ...provider.materialAvailableTabs.map((tabName) {
                       final isSelected = tabName == provider.defaultHomeTab;
                       return RadioListTile<String>(
                         title: Text(

--- a/lib/themes/nipaplay/widgets/dashboard_home_page_actions.dart
+++ b/lib/themes/nipaplay/widgets/dashboard_home_page_actions.dart
@@ -462,29 +462,35 @@ extension DashboardHomePageActions on _DashboardHomePageState {
   // 导航到媒体库-库管理页面
   void _navigateToMediaLibraryManagement() {
     debugPrint('[DashboardHomePage] 准备导航到媒体库-库管理页面');
+    MainPageState? mainPageState = MainPageState.of(context);
+    const mediaLibraryIndexWithoutWebDAV = 2;
+    const mediaLibraryIndexWithWebDAV = 3;
+    final mediaLibraryIndex = mainPageState?.globalTabController?.length == 5
+        ? mediaLibraryIndexWithWebDAV
+        : mediaLibraryIndexWithoutWebDAV;
     
     // 先发送子标签切换请求，避免Widget销毁后无法访问
     try {
       final tabChangeNotifier = Provider.of<TabChangeNotifier>(context, listen: false);
-      tabChangeNotifier.changeToMediaLibrarySubTab(1); // 直接切换到库管理标签
+      tabChangeNotifier.changeToMediaLibrarySubTab(1, mainTabIndex: mediaLibraryIndex);
       debugPrint('[DashboardHomePage] 已发送子标签切换请求');
     } catch (e) {
       debugPrint('[DashboardHomePage] 发送子标签切换请求失败: $e');
     }
     
     // 然后切换到媒体库页面
-    MainPageState? mainPageState = MainPageState.of(context);
     if (mainPageState != null && mainPageState.globalTabController != null) {
-      // 切换到媒体库页面（索引2）
-      if (mainPageState.globalTabController!.index != 2) {
-        mainPageState.globalTabController!.animateTo(2);
-        debugPrint('[DashboardHomePage] 直接调用了globalTabController.animateTo(2)');
+      if (mainPageState.globalTabController!.index != mediaLibraryIndex) {
+        mainPageState.globalTabController!.animateTo(mediaLibraryIndex);
+        debugPrint(
+            '[DashboardHomePage] 直接调用了globalTabController.animateTo($mediaLibraryIndex)');
       } else {
         debugPrint('[DashboardHomePage] globalTabController已经在媒体库页面');
         // 如果已经在媒体库页面，立即触发子标签切换
         try {
           final tabChangeNotifier = Provider.of<TabChangeNotifier>(context, listen: false);
-          tabChangeNotifier.changeToMediaLibrarySubTab(1);
+          tabChangeNotifier.changeToMediaLibrarySubTab(1,
+              mainTabIndex: mediaLibraryIndex);
           debugPrint('[DashboardHomePage] 已在媒体库页面，立即触发子标签切换');
         } catch (e) {
           debugPrint('[DashboardHomePage] 立即触发子标签切换失败: $e');
@@ -495,7 +501,8 @@ extension DashboardHomePageActions on _DashboardHomePageState {
       // 如果直接访问失败，使用TabChangeNotifier作为备选方案
       try {
         final tabChangeNotifier = Provider.of<TabChangeNotifier>(context, listen: false);
-        tabChangeNotifier.changeToMediaLibrarySubTab(1); // 直接切换到媒体库-库管理标签
+        tabChangeNotifier.changeToMediaLibrarySubTab(1,
+            mainTabIndex: mediaLibraryIndex);
         debugPrint('[DashboardHomePage] 备选方案: 使用TabChangeNotifier请求切换到媒体库-库管理标签');
       } catch (e) {
         debugPrint('[DashboardHomePage] TabChangeNotifier也失败: $e');

--- a/lib/utils/tab_change_notifier.dart
+++ b/lib/utils/tab_change_notifier.dart
@@ -20,9 +20,13 @@ class TabChangeNotifier extends ChangeNotifier {
     debugPrint('[TabChangeNotifier] 已通知所有监听器');
   }
 
-  void changeToMediaLibrarySubTab(int subTabIndex) {
-    debugPrint('[TabChangeNotifier] changeToMediaLibrarySubTab called with subTabIndex: $subTabIndex');
-    _targetTabIndex = 2; // 媒体库页面索引
+  void changeToMediaLibrarySubTab(
+    int subTabIndex, {
+    int mainTabIndex = 2,
+  }) {
+    debugPrint(
+        '[TabChangeNotifier] changeToMediaLibrarySubTab called with subTabIndex: $subTabIndex, mainTabIndex: $mainTabIndex');
+    _targetTabIndex = mainTabIndex;
     _targetMediaLibrarySubTabIndex = subTabIndex;
     debugPrint('[TabChangeNotifier] 正在通知监听器切换到媒体库页面子标签: $subTabIndex');
     notifyListeners();
@@ -45,4 +49,4 @@ class TabChangeNotifier extends ChangeNotifier {
     _targetTabIndex = null;
     _targetMediaLibrarySubTabIndex = null;
   }
-} 
+}

--- a/lib/utils/video_player_state/video_player_state_streaming.dart
+++ b/lib/utils/video_player_state/video_player_state_streaming.dart
@@ -61,15 +61,19 @@ extension VideoPlayerStateStreaming on VideoPlayerState {
       _logMacOSHdrExitTrace(
         'handleBackButton start path=$_currentVideoPath status=$_status hasVideo=$hasVideo playerState=${player.state}',
       );
-      // Fire-and-forget：截图和云同步改为后台执行，不阻塞退出
-      unawaited(_captureConditionalScreenshot("返回按钮时").catchError((e) {
+      // 保持顺序执行，避免与 resetPlayer 并发导致状态被提前清空。
+      try {
+        await _captureConditionalScreenshot("返回按钮时");
+      } catch (e) {
         debugPrint('退出截图失败: $e');
-      }));
+      }
 
       if (_currentVideoPath != null) {
-        unawaited(AutoSyncService.instance.syncOnPlaybackEnd().catchError((e) {
+        try {
+          await AutoSyncService.instance.syncOnPlaybackEnd();
+        } catch (e) {
           debugPrint('退出云同步失败: $e');
-        }));
+        }
       }
 
       _logMacOSHdrExitTrace(


### PR DESCRIPTION
## 背景
PR448 合入后出现回归，主要集中在播放器退出流程并发与 WebDAV Tab 开关后的索引映射。

## 修复内容
- 恢复 handleBackButton 中截图与云同步为顺序执行，避免与 resetPlayer 并发导致状态提前被清空。
- 修复 Material 首页 Tab 映射，移除不存在的 settings 目标映射。
- 修复 WebDAV Tab 开关时索引重建，避免切换后落到错误页面。
- 在 dispose 中移除 WebDAVQuickAccessProvider listener，避免 disposed state 回调。
- 增加 default_page_index 到 default_home_tab 的兼容迁移，保留老用户默认页设置。
- 区分 Material / Cupertino 的默认主页可选项，避免跨主题不可达选项。
- 修复媒体库管理跳转在 WebDAV 开启后的主 Tab 索引错误，改为动态索引。

## 验证
- flutter analyze（受影响文件）已执行，未出现新增 error。