### PR TITLE
fix: resolve #408 #379 #369 #359

### DIFF
--- a/lib/services/dandanplay_service_io.dart
+++ b/lib/services/dandanplay_service_io.dart
@@ -141,9 +141,14 @@ class DandanplayService {
     return;
   }
 
-  /// 获取当前弹弹play API 基础 URL（包含用户自定义设置）
+  /// 获取弹幕相关 API 基础 URL（包含用户自定义设置）
   static Future<String> getApiBaseUrl() async {
     return await NetworkSettings.getDandanplayServer();
+  }
+
+  /// 获取账号相关 API 基础 URL（固定官方服务器）
+  static Future<String> getAccountApiBaseUrl() async {
+    return NetworkSettings.primaryServer;
   }
 
   // 预加载最近更新的动画数据
@@ -249,7 +254,7 @@ class DandanplayService {
         final timestamp = (DateTime.now().toUtc().millisecondsSinceEpoch / 1000)
             .round();
 
-        final apiBaseUrl = await getApiBaseUrl();
+        final apiBaseUrl = await getAccountApiBaseUrl();
         final requestUri = Uri.parse('$apiBaseUrl$apiPath');
         final headers = _buildLoginRenewHeaders(
           timestamp: timestamp,
@@ -489,7 +494,7 @@ class DandanplayService {
       final hash = md5.convert(utf8.encode(hashString)).toString();
 
       final response = await http.post(
-        Uri.parse('${await getApiBaseUrl()}/api/v2/login'),
+        Uri.parse('${await getAccountApiBaseUrl()}/api/v2/login'),
         headers: {
           'Content-Type': 'application/json',
           'Accept': 'application/json',
@@ -564,7 +569,7 @@ class DandanplayService {
       final timestamp = (DateTime.now().toUtc().millisecondsSinceEpoch / 1000)
           .round();
       const apiPath = '/api/v2/oauthprovider/bangumi/login';
-      final baseUrl = await getApiBaseUrl();
+      final baseUrl = await getAccountApiBaseUrl();
       final normalizedRedirect = redirectUrl?.trim();
       final query = <String, String>{};
       if (normalizedRedirect != null && normalizedRedirect.isNotEmpty) {
@@ -626,7 +631,7 @@ class DandanplayService {
     }
 
     try {
-      final apiBaseUrl = await getApiBaseUrl();
+      final apiBaseUrl = await getAccountApiBaseUrl();
       const apiPath = '/api/v2/login/renew';
       final appSecret = await getAppSecret();
       final timestamp = (DateTime.now().toUtc().millisecondsSinceEpoch / 1000)
@@ -804,7 +809,7 @@ class DandanplayService {
         appSecret,
       );
       final response = await http.post(
-        Uri.parse('${await getApiBaseUrl()}/api/v2/register'),
+        Uri.parse('${await getAccountApiBaseUrl()}/api/v2/register'),
         headers: {
           'Content-Type': 'application/json',
           'Accept': 'application/json',
@@ -869,7 +874,7 @@ class DandanplayService {
       const apiPath = '/api/v2/playhistory';
 
       final response = await http.post(
-        Uri.parse('${await getApiBaseUrl()}$apiPath'),
+        Uri.parse('${await getAccountApiBaseUrl()}$apiPath'),
         headers: {
           'Content-Type': 'application/json',
           'Accept': 'application/json',
@@ -1662,7 +1667,7 @@ class DandanplayService {
         queryParams['toDate'] = toDate.toUtc().toIso8601String();
       }
 
-      final baseUrl = await getApiBaseUrl();
+      final baseUrl = await getAccountApiBaseUrl();
       final uri = Uri.parse(
         '$baseUrl$apiPath${queryParams.isNotEmpty ? '?' + Uri(queryParameters: queryParams).query : ''}',
       );
@@ -1743,7 +1748,7 @@ class DandanplayService {
       debugPrint('[弹弹play服务] 提交播放历史: $episodeIdList');
 
       final response = await http.post(
-        Uri.parse('${await getApiBaseUrl()}$apiPath'),
+        Uri.parse('${await getAccountApiBaseUrl()}$apiPath'),
         headers: {
           'Content-Type': 'application/json',
           'Accept': 'application/json',
@@ -1903,7 +1908,7 @@ class DandanplayService {
         queryParams['onlyOnAir'] = 'true';
       }
 
-      final baseUrl = await getApiBaseUrl();
+      final baseUrl = await getAccountApiBaseUrl();
       final uri = Uri.parse(
         '$baseUrl$apiPath${queryParams.isNotEmpty ? '?' + Uri(queryParameters: queryParams).query : ''}',
       );
@@ -1978,7 +1983,7 @@ class DandanplayService {
       debugPrint('[弹弹play服务] 添加收藏: animeId=$animeId, status=$favoriteStatus');
 
       final response = await http.post(
-        Uri.parse('${await getApiBaseUrl()}$apiPath'),
+        Uri.parse('${await getAccountApiBaseUrl()}$apiPath'),
         headers: {
           'Content-Type': 'application/json',
           'Accept': 'application/json',
@@ -2031,7 +2036,7 @@ class DandanplayService {
       debugPrint('[弹弹play服务] 取消收藏: animeId=$animeId');
 
       final response = await http.delete(
-        Uri.parse('${await getApiBaseUrl()}$apiPath'),
+        Uri.parse('${await getAccountApiBaseUrl()}$apiPath'),
         headers: {
           'Accept': 'application/json',
           'User-Agent': userAgent,
@@ -2245,7 +2250,7 @@ class DandanplayService {
       final apiPath = '/api/v2/oauth/webToken';
 
       final response = await http.get(
-        Uri.parse('${await getApiBaseUrl()}$apiPath?business=$business'),
+        Uri.parse('${await getAccountApiBaseUrl()}$apiPath?business=$business'),
         headers: {
           'Accept': 'application/json',
           'User-Agent': userAgent,
@@ -2366,7 +2371,7 @@ class DandanplayService {
 
       // 2. 构建注销页面URL
       final deleteAccountUrl =
-          '${await getApiBaseUrl()}/api/v2/oauth/deleteAccount?webToken=$webToken';
+          '${await getAccountApiBaseUrl()}/api/v2/oauth/deleteAccount?webToken=$webToken';
 
       debugPrint('[弹弹play服务] 账号注销URL: $deleteAccountUrl');
 
@@ -2397,7 +2402,7 @@ class DandanplayService {
       }
 
       final manageUri = Uri.parse(
-              '${await getApiBaseUrl()}/api/v2/oauthprovider/bangumi/manage')
+              '${await getAccountApiBaseUrl()}/api/v2/oauthprovider/bangumi/manage')
           .replace(queryParameters: {'webToken': webToken});
       final manageUrl = manageUri.toString();
       debugPrint('[弹弹play服务] Bangumi管理页URL: $manageUrl');

--- a/lib/services/media_server_service_base.dart
+++ b/lib/services/media_server_service_base.dart
@@ -329,6 +329,10 @@ abstract class MediaServerServiceBase {
         } else {
           print('$serviceNameService: 地址已存在，使用现有配置');
         }
+
+        if (profile != null && profile.username != username) {
+          profile = profile.copyWith(username: username);
+        }
       } else if (identifyResult.isConflict) {
         print('$serviceNameService: 检测到冲突，抛出异常: ${identifyResult.error}');
         logService.addLog(
@@ -365,6 +369,7 @@ abstract class MediaServerServiceBase {
       final connectionResult = await _multiAddressService.tryConnect(
         profile: profile,
         testConnection: (url) => testConnection(url, username, password),
+        preferredUrl: normalizedUrl,
       );
 
       if (connectionResult.success && connectionResult.profile != null) {

--- a/lib/services/multi_address_server_service.dart
+++ b/lib/services/multi_address_server_service.dart
@@ -280,10 +280,25 @@ class MultiAddressServerService {
   Future<ConnectionResult> tryConnect({
     required ServerProfile profile,
     required Future<bool> Function(String url) testConnection,
+    String? preferredUrl,
   }) async {
     final addresses = profile.enabledAddresses;
+    final normalizedPreferredUrl = preferredUrl == null
+        ? null
+        : _normalizeUrl(preferredUrl);
+
+    final orderedAddresses = normalizedPreferredUrl == null
+        ? addresses
+        : [
+            ...addresses.where(
+              (address) => address.normalizedUrl == normalizedPreferredUrl,
+            ),
+            ...addresses.where(
+              (address) => address.normalizedUrl != normalizedPreferredUrl,
+            ),
+          ];
     
-    if (addresses.isEmpty) {
+    if (orderedAddresses.isEmpty) {
       return ConnectionResult(
         success: false,
         error: '没有可用的服务器地址',
@@ -294,7 +309,7 @@ class MultiAddressServerService {
     ServerProfile updatedProfile = profile;
     
     // 按优先级尝试每个地址
-    for (final address in addresses) {
+    for (final address in orderedAddresses) {
       if (!address.shouldRetry()) {
         DebugLogService().addLog(
           'MultiAddressServer: 跳过地址 ${address.name} (${address.url}) - 失败次数过多'

--- a/lib/utils/danmaku_dialog_manager.dart
+++ b/lib/utils/danmaku_dialog_manager.dart
@@ -119,6 +119,13 @@ class DanmakuDialogManager {
   // 注册发送弹幕快捷键处理
   bool handleSendDanmakuHotkey() {
     debugPrint('[DanmakuDialogManager] 处理发送弹幕快捷键，当前对话框状态: ${_isShowingDialog ? "显示中" : "未显示"}');
+
+    final focusedContext = FocusManager.instance.primaryFocus?.context;
+    final isEditingText = focusedContext?.widget is EditableText;
+    if (_isShowingDialog && isEditingText) {
+      debugPrint('[DanmakuDialogManager] 检测到输入焦点，忽略关闭弹幕对话框快捷键');
+      return true;
+    }
     
     if (_isShowingDialog) {
       // 如果已经在显示弹幕对话框，则关闭它

--- a/lib/utils/hotkey_service.dart
+++ b/lib/utils/hotkey_service.dart
@@ -228,6 +228,9 @@ class HotkeyService extends ChangeNotifier {
       await hotKeyManager.register(
         hotKey,
         keyDownHandler: (HotKey hotKey) {
+          if (_shouldBlockHotkeyInTextInput()) {
+            return;
+          }
           ////debugPrint('[HotkeyService] 热键触发: $description ($keyString)');
           handler();
         },
@@ -238,6 +241,43 @@ class HotkeyService extends ChangeNotifier {
     } catch (e) {
       ////debugPrint('[HotkeyService] 注册热键失败 $description ($keyString): $e');
     }
+  }
+
+  bool _isEditableTextFocused() {
+    final focusedContext = FocusManager.instance.primaryFocus?.context;
+    if (focusedContext == null) {
+      return false;
+    }
+    return focusedContext.widget is EditableText;
+  }
+
+  bool _shouldBlockHotkeyInTextInput() {
+    if (_isEditableTextFocused()) {
+      return true;
+    }
+    return false;
+  }
+
+  bool _isShiftPressed() {
+    final pressed = HardwareKeyboard.instance.logicalKeysPressed;
+    return pressed.contains(LogicalKeyboardKey.shiftLeft) ||
+        pressed.contains(LogicalKeyboardKey.shiftRight) ||
+        pressed.contains(LogicalKeyboardKey.shift);
+  }
+
+  bool _isShiftShortcutConfigured(String action, PhysicalKeyboardKey arrowKey) {
+    final shortcut = _shortcuts[action];
+    if (shortcut == null || !shortcut.contains('Shift+')) {
+      return false;
+    }
+    final info = _parseKeyString(shortcut);
+    if (info == null) {
+      return false;
+    }
+    if (!info.modifiers.contains(HotKeyModifier.shift)) {
+      return false;
+    }
+    return info.keyCode == arrowKey;
   }
 
   // 特别处理ESC键
@@ -598,6 +638,14 @@ class HotkeyService extends ChangeNotifier {
   }
 
   void _handleRewind() {
+    if (_isShiftPressed() &&
+        _isShiftShortcutConfigured(
+          'previous_episode',
+          PhysicalKeyboardKey.arrowLeft,
+        )) {
+      _handlePreviousEpisode();
+      return;
+    }
     final videoState = _getVideoPlayerState();
     if (videoState != null) {
       videoState.seekBackwardByStep();
@@ -605,6 +653,14 @@ class HotkeyService extends ChangeNotifier {
   }
 
   void _handleForward() {
+    if (_isShiftPressed() &&
+        _isShiftShortcutConfigured(
+          'next_episode',
+          PhysicalKeyboardKey.arrowRight,
+        )) {
+      _handleNextEpisode();
+      return;
+    }
     final videoState = _getVideoPlayerState();
     if (videoState != null) {
       videoState.seekForwardByStep();
@@ -705,6 +761,9 @@ class HotkeyService extends ChangeNotifier {
   }
 
   void _handleForwardKeyDown() {
+    if (_shouldBlockHotkeyInTextInput()) {
+      return;
+    }
     _isForwardKeyPressed = true;
 
     // 取消之前的计时器
@@ -719,6 +778,9 @@ class HotkeyService extends ChangeNotifier {
   }
 
   void _handleForwardKeyUp() {
+    if (_shouldBlockHotkeyInTextInput()) {
+      return;
+    }
     _isForwardKeyPressed = false;
 
     // 取消长按计时器
@@ -752,6 +814,9 @@ class HotkeyService extends ChangeNotifier {
   }
 
   void _handleEscape() {
+    if (_shouldBlockHotkeyInTextInput()) {
+      return;
+    }
     final videoState = _getVideoPlayerState();
     if (videoState != null && videoState.isFullscreen) {
       videoState.toggleFullscreen();

--- a/lib/utils/hotkey_service.dart
+++ b/lib/utils/hotkey_service.dart
@@ -274,7 +274,9 @@ class HotkeyService extends ChangeNotifier {
     if (info == null) {
       return false;
     }
-    if (!info.modifiers.contains(HotKeyModifier.shift)) {
+    final modifierSet = info.modifiers.toSet();
+    if (modifierSet.length != 1 ||
+        !modifierSet.contains(HotKeyModifier.shift)) {
       return false;
     }
     return info.keyCode == arrowKey;


### PR DESCRIPTION
## Summary

Fixes 4 issues in one patch set:

- #359 自定义弹幕源后个人中心功能不可用
- #369 发送弹幕窗口输入时仍触发播放器快捷键
- #379 右 Shift + 方向键无法触发上一集/下一集
- #408 Jellyfin 同服多地址场景命中旧缓存地址导致连接错误

## Changes

### #359
- `DandanplayService` split API base URL responsibilities in `lib/services/dandanplay_service_io.dart`:
  - `getApiBaseUrl()` keeps using user-configured danmaku source.
  - `getAccountApiBaseUrl()` always points to official `NetworkSettings.primaryServer`.
- Switched account-related endpoints (login/renew/register/playhistory/favorite/oauth manage/delete account, etc.) to official account base URL.
- Danmaku/match/search endpoints remain on customizable danmaku server.

### #369
- Added text-input focus guard in `lib/utils/hotkey_service.dart` for all in-app registered hotkey callbacks.
- Added the same guard for forward long-press and ESC handling.
- Updated `lib/utils/danmaku_dialog_manager.dart`: when danmaku dialog is open and an `EditableText` is focused, pressing send-danmaku hotkey no longer closes the dialog.

### #379
- Added Shift-state fallback in `lib/utils/hotkey_service.dart`:
  - When rewind/forward hotkey fires while Shift is pressed, it routes to previous/next episode if corresponding shortcut is still configured as `Shift+←` / `Shift+→`.
- This covers right-shift behavior in the in-app hotkey path while avoiding interference with custom non-arrow shortcut setups.

### #408
- Added preferred URL support in `lib/services/multi_address_server_service.dart::tryConnect(...)`.
- In `lib/services/media_server_service_base.dart::connect(...)`, pass the currently entered URL as `preferredUrl`, so current attempt prioritizes the user input address before cached historical addresses.
- Kept existing multi-address fallback behavior after preferred address attempt.

## Validation

- `flutter analyze --no-pub lib/services/dandanplay_service_io.dart lib/services/media_server_service_base.dart lib/services/multi_address_server_service.dart lib/utils/hotkey_service.dart lib/utils/danmaku_dialog_manager.dart`
  - No new errors introduced by this patch.
  - Existing warnings/infos remain in touched files (pre-existing lint baseline).

