### PR TITLE
Fix selected open issues

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -144,6 +144,14 @@
                 <data android:scheme="file" android:pathPattern=".*\\.wmv" />
                 <data android:scheme="content" android:pathPattern=".*\\.wmv" />
             </intent-filter>
+
+            <!-- 部分 Android 7/8 文件管理器只提供 content:// 和 video/*，不带可匹配扩展名 -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="content" android:mimeType="video/*" />
+                <data android:scheme="file" android:mimeType="video/*" />
+            </intent-filter>
         </activity>
         <meta-data
             android:name="flutterEmbedding"

--- a/android/app/src/main/kotlin/com/aimessoft/nipaplay/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/aimessoft/nipaplay/MainActivity.kt
@@ -35,6 +35,9 @@ class MainActivity: FlutterActivity() {
     private val FILE_ASSOCIATION_CHANNEL = "file_association_channel"
     private val SYSTEM_SHARE_CHANNEL = "nipaplay/system_share"
     private val DEVICE_PROFILE_CHANNEL = "nipaplay/device_profile"
+    private var fileAssociationChannel: MethodChannel? = null
+    private var pendingOpenFilePath: String? = null
+    private var lastDeliveredOpenUri: String? = null
     
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
@@ -228,22 +231,17 @@ class MainActivity: FlutterActivity() {
         }
 
         // 文件关联通道 - 处理从系统传入的文件
-        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, FILE_ASSOCIATION_CHANNEL).setMethodCallHandler { call, result ->
+        fileAssociationChannel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, FILE_ASSOCIATION_CHANNEL)
+        fileAssociationChannel?.setMethodCallHandler { call, result ->
             when (call.method) {
                 "getOpenFileUri" -> {
-                    val uri = intent?.data
-                    if (uri != null) {
-                        val filePath = getPathFromUri(this@MainActivity, uri)
-                        if (filePath != null) {
-                            Log.d("MainActivity", "File association: $filePath")
-                            result.success(filePath)
-                        } else {
-                            Log.e("MainActivity", "Failed to resolve file path from URI: $uri")
-                            result.error("PATH_RESOLUTION_FAILED", "Failed to resolve file path", null)
-                        }
-                    } else {
-                        result.success(null)
+                    val pending = pendingOpenFilePath
+                    if (pending != null) {
+                        pendingOpenFilePath = null
+                        result.success(pending)
+                        return@setMethodCallHandler
                     }
+                    result.success(resolveOpenFileFromIntent(intent, allowDuplicate = false))
                 }
                 else -> result.notImplemented()
             }
@@ -331,6 +329,7 @@ class MainActivity: FlutterActivity() {
     // 覆盖onCreate以添加额外的配置，解决黑屏问题
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        pendingOpenFilePath = resolveOpenFileFromIntent(intent, allowDuplicate = false)
         
         // 设置窗口属性，确保硬件加速启用
         window.decorView.systemUiVisibility = (View.SYSTEM_UI_FLAG_LAYOUT_STABLE
@@ -342,6 +341,19 @@ class MainActivity: FlutterActivity() {
             WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED,
             WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED
         )
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+
+        val filePath = resolveOpenFileFromIntent(intent, allowDuplicate = true)
+        if (filePath == null) {
+            return
+        }
+
+        pendingOpenFilePath = filePath
+        fileAssociationChannel?.invokeMethod("onOpenFileUri", filePath)
     }
     
     // 文件选择请求码和结果回调
@@ -380,6 +392,23 @@ class MainActivity: FlutterActivity() {
     }
     
     // 从URI获取实际文件路径的辅助方法
+    private fun resolveOpenFileFromIntent(intent: Intent?, allowDuplicate: Boolean): String? {
+        val uri = intent?.data ?: return null
+        if (!allowDuplicate && uri.toString() == lastDeliveredOpenUri) {
+            return null
+        }
+
+        val filePath = getPathFromUri(this@MainActivity, uri)
+        if (filePath != null) {
+            Log.d("MainActivity", "File association: $filePath")
+            lastDeliveredOpenUri = uri.toString()
+            return filePath
+        }
+
+        Log.e("MainActivity", "Failed to resolve file path from URI: $uri")
+        return null
+    }
+
     private fun getPathFromUri(context: Context, uri: Uri): String? {
         // 首先尝试使用DocumentFile
         if (DocumentsContract.isDocumentUri(context, uri)) {
@@ -389,6 +418,7 @@ class MainActivity: FlutterActivity() {
         // 如果是内容URI，尝试从MediaStore查询
         if (ContentResolver.SCHEME_CONTENT == uri.scheme) {
             return getDataColumn(context, uri, null, null)
+                ?: saveContentToCache(context, uri)
         }
         
         // 如果是文件URI，直接返回路径

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1084,6 +1084,7 @@ class MainPageState extends State<MainPage>
   bool _showSplash = true;
   bool _isThemeRevealRunning = false;
   bool _useLargeScreenLayout = false;
+  StreamSubscription<String>? _androidFileAssociationSubscription;
 
   // 动态页面列表
   static const List<Widget> _basePages = [
@@ -1208,7 +1209,23 @@ class MainPageState extends State<MainPage>
 
     await _initializeController();
     _initializeListeners();
+    _initializeAndroidFileAssociationListener();
     _postFrameCallbacks();
+  }
+
+  void _initializeAndroidFileAssociationListener() {
+    if (kIsWeb || !Platform.isAndroid) {
+      return;
+    }
+    _androidFileAssociationSubscription ??=
+        FileAssociationService.openFileStream.listen((filePath) async {
+      if (!mounted) return;
+      if (!await FileAssociationService.validateFilePath(filePath)) {
+        BlurSnackBar.show(context, '无法播放启动文件: ${path.basename(filePath)}');
+        return;
+      }
+      await _handleLaunchFile(filePath);
+    });
   }
 
   void _onWebDAVSettingsChanged() {
@@ -1445,6 +1462,7 @@ class MainPageState extends State<MainPage>
     _tabChangeNotifier
         ?.removeListener(_onTabChangeRequested); // Temporarily remove
     _webdavQuickAccessProvider?.removeListener(_onWebDAVSettingsChanged);
+    _androidFileAssociationSubscription?.cancel();
     globalTabController?.removeListener(_onTabChange);
     _videoPlayerState?.removeListener(_manageHotkeys);
     globalTabController?.dispose();
@@ -1690,7 +1708,8 @@ class MainPageState extends State<MainPage>
             builder: (context, shouldShowAppBar, child) {
               return CustomScaffold(
                 pages: _pages,
-                tabPage: createTabLabels(context, showWebDAVTab: _showWebDAVTab),
+                tabPage:
+                    createTabLabels(context, showWebDAVTab: _showWebDAVTab),
                 pageIsHome: true,
                 shouldShowAppBar: shouldShowAppBar,
                 tabController: globalTabController,

--- a/lib/pages/media_server_detail_page.dart
+++ b/lib/pages/media_server_detail_page.dart
@@ -31,27 +31,31 @@ class MediaServerDetailPage extends StatefulWidget {
   final MediaServerType serverType;
 
   const MediaServerDetailPage({
-    super.key, 
-    required this.mediaId, 
+    super.key,
+    required this.mediaId,
     required this.serverType,
   });
 
   @override
   State<MediaServerDetailPage> createState() => _MediaServerDetailPageState();
-  
-  static Future<WatchHistoryItem?> showJellyfin(BuildContext context, String jellyfinId) {
+
+  static Future<WatchHistoryItem?> showJellyfin(
+      BuildContext context, String jellyfinId) {
     return show(context, jellyfinId, MediaServerType.jellyfin);
   }
 
-  static Future<WatchHistoryItem?> showEmby(BuildContext context, String embyId) {
+  static Future<WatchHistoryItem?> showEmby(
+      BuildContext context, String embyId) {
     return show(context, embyId, MediaServerType.emby);
   }
 
-  static Future<WatchHistoryItem?> show(BuildContext context, String mediaId, MediaServerType serverType) {
+  static Future<WatchHistoryItem?> show(
+      BuildContext context, String mediaId, MediaServerType serverType) {
     // 获取外观设置Provider
-    final appearanceSettings = Provider.of<AppearanceSettingsProvider>(context, listen: false);
+    final appearanceSettings =
+        Provider.of<AppearanceSettingsProvider>(context, listen: false);
     final enableAnimation = appearanceSettings.enablePageAnimation;
-    
+
     return NipaplayWindow.show<WatchHistoryItem>(
       context: context,
       enableAnimation: enableAnimation,
@@ -60,11 +64,12 @@ class MediaServerDetailPage extends StatefulWidget {
   }
 }
 
-class _MediaServerDetailPageState extends State<MediaServerDetailPage> with SingleTickerProviderStateMixin {
+class _MediaServerDetailPageState extends State<MediaServerDetailPage>
+    with SingleTickerProviderStateMixin {
   // 静态Map，用于存储视频的哈希值（ID -> 哈希值）
   static final Map<String, String> _videoHashes = {};
   static final Map<String, Map<String, dynamic>> _videoInfos = {};
-  
+
   // 通用媒体详情（可以是Jellyfin或Emby）
   dynamic _mediaDetail;
   List<dynamic> _seasons = [];
@@ -86,12 +91,17 @@ class _MediaServerDetailPageState extends State<MediaServerDetailPage> with Sing
     if (widget.serverType == MediaServerType.jellyfin) {
       if (actor.primaryImageTag != null) {
         final service = JellyfinService.instance;
-        return service.getImageUrl(actor.id, type: 'Primary', width: 100, quality: 90);
+        return service.getImageUrl(actor.id,
+            type: 'Primary', width: 100, quality: 90);
       }
     } else {
       if (actor.imagePrimaryTag != null && actor.id != null) {
         final service = EmbyService.instance;
-        return service.getImageUrl(actor.id!, type: 'Primary', width: 100, height: 100, tag: actor.imagePrimaryTag);
+        return service.getImageUrl(actor.id!,
+            type: 'Primary',
+            width: 100,
+            height: 100,
+            tag: actor.imagePrimaryTag);
       }
     }
     return null;
@@ -100,23 +110,27 @@ class _MediaServerDetailPageState extends State<MediaServerDetailPage> with Sing
   // 辅助方法：获取剧集缩略图URL
   String _getEpisodeImageUrl(dynamic episode, dynamic service) {
     if (widget.serverType == MediaServerType.jellyfin) {
-      return service.getImageUrl(episode.id, type: 'Primary', width: 300, quality: 90);
+      return service.getImageUrl(episode.id,
+          type: 'Primary', width: 300, quality: 90);
     } else {
       // Emby需要传递tag参数
-      return service.getImageUrl(episode.id, type: 'Primary', width: 300, tag: episode.imagePrimaryTag);
+      return service.getImageUrl(episode.id,
+          type: 'Primary', width: 300, tag: episode.imagePrimaryTag);
     }
   }
 
   // 辅助方法：获取海报URL
   String _getPosterUrl({int width = 300}) {
     if (_mediaDetail?.imagePrimaryTag == null) return '';
-    
+
     if (widget.serverType == MediaServerType.jellyfin) {
       final service = JellyfinService.instance;
-      return service.getImageUrl(_mediaDetail!.id, type: 'Primary', width: width, quality: 95);
+      return service.getImageUrl(_mediaDetail!.id,
+          type: 'Primary', width: width, quality: 95);
     } else {
       final service = EmbyService.instance;
-      return service.getImageUrl(_mediaDetail!.id, type: 'Primary', width: width, tag: _mediaDetail!.imagePrimaryTag);
+      return service.getImageUrl(_mediaDetail!.id,
+          type: 'Primary', width: width, tag: _mediaDetail!.imagePrimaryTag);
     }
   }
 
@@ -159,16 +173,16 @@ class _MediaServerDetailPageState extends State<MediaServerDetailPage> with Sing
 
   Future<void> _loadMediaDetail() async {
     if (!mounted) return;
-    
+
     setState(() {
       _isLoading = true;
       _error = null;
     });
-    
+
     try {
       dynamic service;
       dynamic detail;
-      
+
       if (widget.serverType == MediaServerType.jellyfin) {
         service = JellyfinService.instance;
         detail = await service.getMediaItemDetails(widget.mediaId);
@@ -176,7 +190,7 @@ class _MediaServerDetailPageState extends State<MediaServerDetailPage> with Sing
         service = EmbyService.instance;
         detail = await service.getMediaItemDetails(widget.mediaId);
       }
-      
+
       if (mounted) {
         setState(() {
           _mediaDetail = detail;
@@ -190,9 +204,12 @@ class _MediaServerDetailPageState extends State<MediaServerDetailPage> with Sing
             _tabController = TabController(
                 length: 2,
                 vsync: this,
-                initialIndex: Provider.of<AppearanceSettingsProvider>(context, listen: false)
-                    .animeCardAction == AnimeCardAction.synopsis ? 0 : 1
-            );
+                initialIndex: Provider.of<AppearanceSettingsProvider>(context,
+                                listen: false)
+                            .animeCardAction ==
+                        AnimeCardAction.synopsis
+                    ? 0
+                    : 1);
             _tabController!.addListener(() {
               if (mounted && !_tabController!.indexIsChanging) {
                 setState(() {
@@ -208,16 +225,17 @@ class _MediaServerDetailPageState extends State<MediaServerDetailPage> with Sing
       if (!_isMovie) {
         dynamic seasons;
         if (widget.serverType == MediaServerType.jellyfin) {
-          seasons = await (service as JellyfinService).getSeriesSeasons(widget.mediaId);
+          seasons = await (service as JellyfinService)
+              .getSeriesSeasons(widget.mediaId);
         } else {
           seasons = await (service as EmbyService).getSeasons(widget.mediaId);
         }
-        
+
         if (mounted) {
           setState(() {
             _seasons = seasons;
             _isLoading = false;
-            
+
             // 如果有季，选择第一个季
             if (seasons.isNotEmpty) {
               _selectedSeasonId = seasons.first.id;
@@ -235,7 +253,7 @@ class _MediaServerDetailPageState extends State<MediaServerDetailPage> with Sing
       }
     }
   }
-  
+
   Future<void> _loadEpisodesForSeason(String seasonId) async {
     // 如果已经加载过，不重复加载
     if (_episodesBySeasonId.containsKey(seasonId)) {
@@ -244,13 +262,13 @@ class _MediaServerDetailPageState extends State<MediaServerDetailPage> with Sing
       });
       return;
     }
-    
+
     setState(() {
       _isLoading = true;
       _error = null;
       _selectedSeasonId = seasonId;
     });
-    
+
     try {
       // 确保_mediaDetail不为null且有有效id
       if (_mediaDetail?.id == null) {
@@ -262,7 +280,7 @@ class _MediaServerDetailPageState extends State<MediaServerDetailPage> with Sing
         }
         return;
       }
-      
+
       dynamic episodes;
       if (widget.serverType == MediaServerType.jellyfin) {
         final service = JellyfinService.instance;
@@ -271,7 +289,7 @@ class _MediaServerDetailPageState extends State<MediaServerDetailPage> with Sing
         final service = EmbyService.instance;
         episodes = await service.getSeasonEpisodes(_mediaDetail!.id, seasonId);
       }
-      
+
       if (mounted) {
         setState(() {
           _episodesBySeasonId[seasonId] = episodes;
@@ -287,7 +305,7 @@ class _MediaServerDetailPageState extends State<MediaServerDetailPage> with Sing
       }
     }
   }
-  
+
   Future<WatchHistoryItem?> _createWatchHistoryItem(dynamic episode) async {
     // 根据服务器类型使用相应的匹配器创建可播放的历史记录项
     try {
@@ -297,20 +315,22 @@ class _MediaServerDetailPageState extends State<MediaServerDetailPage> with Sing
       } else {
         matcher = EmbyDandanplayMatcher.instance;
       }
-      
+
       // 先进行预计算和预匹配，不阻塞主流程
-      matcher.precomputeVideoInfoAndMatch(context, episode).then((preMatchResult) {
+      matcher
+          .precomputeVideoInfoAndMatch(context, episode)
+          .then((preMatchResult) {
         final String? videoHash = preMatchResult['videoHash'] as String?;
         final String? fileName = preMatchResult['fileName'] as String?;
         final int? fileSize = preMatchResult['fileSize'] as int?;
-        
+
         if (videoHash != null && videoHash.isNotEmpty) {
           debugPrint('预计算哈希值成功: $videoHash');
-          
+
           // 需要在播放器创建或历史项创建时使用这个哈希值
           _videoHashes[episode.id] = videoHash;
           debugPrint('视频哈希值已缓存: ${episode.id} -> $videoHash');
-          
+
           // 同时保存文件名和文件大小信息
           Map<String, dynamic> videoInfo = {
             'hash': videoHash,
@@ -320,19 +340,21 @@ class _MediaServerDetailPageState extends State<MediaServerDetailPage> with Sing
           _videoInfos[episode.id] = videoInfo;
           debugPrint('视频信息已缓存: ${episode.id} -> $videoInfo');
         }
-        
+
         if (preMatchResult['success'] == true) {
-          debugPrint('预匹配成功: animeId=${preMatchResult['animeId']}, episodeId=${preMatchResult['episodeId']}');
+          debugPrint(
+              '预匹配成功: animeId=${preMatchResult['animeId']}, episodeId=${preMatchResult['episodeId']}');
         } else {
           debugPrint('预匹配未成功: ${preMatchResult['message']}');
         }
       }).catchError((e) {
         debugPrint('预计算过程中出错: $e');
       });
-      
+
       // 继续常规匹配流程
-      final playableItem = await matcher.createPlayableHistoryItem(context, episode);
-      
+      final playableItem =
+          await matcher.createPlayableHistoryItem(context, episode);
+
       // 如果我们有这个视频的信息，添加到历史项中
       if (playableItem != null) {
         // 添加哈希值
@@ -341,15 +363,17 @@ class _MediaServerDetailPageState extends State<MediaServerDetailPage> with Sing
           playableItem.videoHash = videoHash;
           debugPrint('成功将哈希值 $videoHash 添加到历史记录项');
         }
-        
+
         // 存储完整的视频信息，可用于后续弹幕匹配
         if (_videoInfos.containsKey(episode.id)) {
           final videoInfo = _videoInfos[episode.id]!;
-          debugPrint('已准备视频信息: ${videoInfo['fileName']}, 文件大小: ${videoInfo['fileSize']} 字节');
+          debugPrint(
+              '已准备视频信息: ${videoInfo['fileName']}, 文件大小: ${videoInfo['fileSize']} 字节');
         }
       }
-      
-      debugPrint('成功创建可播放历史项: ${playableItem?.animeName} - ${playableItem?.episodeTitle}, animeId=${playableItem?.animeId}, episodeId=${playableItem?.episodeId}');
+
+      debugPrint(
+          '成功创建可播放历史项: ${playableItem?.animeName} - ${playableItem?.episodeTitle}, animeId=${playableItem?.animeId}, episodeId=${playableItem?.episodeId}');
       return playableItem;
     } catch (e) {
       debugPrint('创建可播放历史记录项失败: $e');
@@ -366,7 +390,8 @@ class _MediaServerDetailPageState extends State<MediaServerDetailPage> with Sing
     }
 
     try {
-      final playableItem = await _runDetailAutoMatchTask<WatchHistoryItem?>(() async {
+      final playableItem =
+          await _runDetailAutoMatchTask<WatchHistoryItem?>(() async {
         if (widget.serverType == MediaServerType.jellyfin) {
           final movieInfo = JellyfinMovieInfo(
             id: _mediaDetail!.id,
@@ -431,15 +456,15 @@ class _MediaServerDetailPageState extends State<MediaServerDetailPage> with Sing
       debugPrint('电影播放失败: $e');
     }
   }
-  
+
   String _formatRuntime(int? runTimeTicks) {
     if (runTimeTicks == null) return '';
-    
+
     // Jellyfin和Emby中的RunTimeTicks单位是100纳秒
     final durationInSeconds = runTimeTicks / 10000000;
     final hours = (durationInSeconds / 3600).floor();
     final minutes = ((durationInSeconds % 3600) / 60).floor();
-    
+
     if (hours > 0) {
       return '$hours小时${minutes > 0 ? ' $minutes分钟' : ''}';
     } else {
@@ -475,11 +500,12 @@ class _MediaServerDetailPageState extends State<MediaServerDetailPage> with Sing
       if (i < fullStars) {
         stars.add(Icon(Ionicons.star, color: Colors.yellow[600], size: 16));
       } else if (i == fullStars && halfStar) {
-        stars.add(
-            Icon(Ionicons.star_half, color: Colors.yellow[600], size: 16));
+        stars
+            .add(Icon(Ionicons.star_half, color: Colors.yellow[600], size: 16));
       } else {
         stars.add(Icon(Ionicons.star_outline,
-            color: Colors.yellow[600]?.withOpacity(isDark ? 0.7 : 0.4), size: 16));
+            color: Colors.yellow[600]?.withOpacity(isDark ? 0.7 : 0.4),
+            size: 16));
       }
       if (i < 9) {
         stars.add(const SizedBox(width: 1));
@@ -585,12 +611,13 @@ class _MediaServerDetailPageState extends State<MediaServerDetailPage> with Sing
     final bool isDark = Theme.of(context).brightness == Brightness.dark;
     final Color textColor = isDark ? Colors.white : Colors.black87;
     final Color secondaryTextColor = isDark ? Colors.white70 : Colors.black54;
-    
+
     Widget pageContent;
 
     if (_isLoading && _mediaDetail == null) {
       pageContent = Center(
-        child: CircularProgressIndicator(color: isDark ? Colors.white : Colors.black87),
+        child: CircularProgressIndicator(
+            color: isDark ? Colors.white : Colors.black87),
       );
     } else if (_error != null && _mediaDetail == null) {
       pageContent = Center(
@@ -599,15 +626,17 @@ class _MediaServerDetailPageState extends State<MediaServerDetailPage> with Sing
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              const Icon(Icons.error_outline, size: 48, color: Colors.redAccent),
+              const Icon(Icons.error_outline,
+                  size: 48, color: Colors.redAccent),
               const SizedBox(height: 16),
-              Text('加载详情失败:', locale:Locale("zh-Hans","zh"),
-style: TextStyle(color: textColor.withOpacity(0.8))),
+              Text('加载详情失败:',
+                  locale: Locale("zh-Hans", "zh"),
+                  style: TextStyle(color: textColor.withOpacity(0.8))),
               const SizedBox(height: 8),
               Text(
                 _error!,
-                locale:Locale("zh-Hans","zh"),
-style: TextStyle(color: secondaryTextColor),
+                locale: Locale("zh-Hans", "zh"),
+                style: TextStyle(color: secondaryTextColor),
                 textAlign: TextAlign.center,
               ),
               const SizedBox(height: 20),
@@ -615,14 +644,16 @@ style: TextStyle(color: secondaryTextColor),
                 icon: Icons.refresh,
                 text: '重试',
                 onTap: _loadMediaDetail,
-                padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
                 fontSize: 16,
               ),
               const SizedBox(height: 10),
               TextButton(
                 onPressed: () => Navigator.of(context).pop(),
-                child: Text('关闭', locale:Locale("zh-Hans","zh"),
-style: TextStyle(color: secondaryTextColor)),
+                child: Text('关闭',
+                    locale: Locale("zh-Hans", "zh"),
+                    style: TextStyle(color: secondaryTextColor)),
               ),
             ],
           ),
@@ -630,11 +661,14 @@ style: TextStyle(color: secondaryTextColor)),
       );
     } else if (_mediaDetail == null) {
       // 理论上在成功加载后 _mediaDetail 不会为 null，除非发生意外
-      pageContent = Center(child: Text('未找到媒体详情', locale:Locale("zh-Hans","zh"),
-style: TextStyle(color: secondaryTextColor)));
+      pageContent = Center(
+          child: Text('未找到媒体详情',
+              locale: Locale("zh-Hans", "zh"),
+              style: TextStyle(color: secondaryTextColor)));
     } else {
       // 成功加载，构建详情UI
-      final appearanceSettings = Provider.of<AppearanceSettingsProvider>(context, listen: false);
+      final appearanceSettings =
+          Provider.of<AppearanceSettingsProvider>(context, listen: false);
       final enableAnimation = appearanceSettings.enablePageAnimation;
       final subtitle = _mediaDetail!.originalTitle;
       final bool isDesktopOrTablet = globals.isDesktopOrTablet;
@@ -642,9 +676,8 @@ style: TextStyle(color: secondaryTextColor)));
       pageContent = NipaplayAnimeDetailLayout(
         title: _mediaDetail!.name,
         subtitle: subtitle,
-        sourceLabel: widget.serverType == MediaServerType.jellyfin
-            ? 'Jellyfin'
-            : 'Emby',
+        sourceLabel:
+            widget.serverType == MediaServerType.jellyfin ? 'Jellyfin' : 'Emby',
         sourceLabelUseContainer: false,
         onClose: () => Navigator.of(context).pop(),
         tabController: _tabController,
@@ -652,9 +685,8 @@ style: TextStyle(color: secondaryTextColor)));
         enableAnimation: enableAnimation,
         isDesktopOrTablet: isDesktopOrTablet,
         infoView: RepaintBoundary(child: _buildInfoView()),
-        episodesView: _isMovie
-            ? null
-            : RepaintBoundary(child: _buildEpisodesView()),
+        episodesView:
+            _isMovie ? null : RepaintBoundary(child: _buildEpisodesView()),
         desktopView: (isDesktopOrTablet && !_isMovie)
             ? _buildDesktopTabletLayout()
             : null,
@@ -666,7 +698,8 @@ style: TextStyle(color: secondaryTextColor)));
     final hasBackdrop = backdropUrl.isNotEmpty;
 
     return NipaplayWindowScaffold(
-      backgroundImageUrl: hasBackdrop ? backdropUrl : (posterUrl.isNotEmpty ? posterUrl : null),
+      backgroundImageUrl:
+          hasBackdrop ? backdropUrl : (posterUrl.isNotEmpty ? posterUrl : null),
       blurBackground: !hasBackdrop, // 如果没有横向图而使用竖向图，开启高斯模糊
       onClose: () => Navigator.of(context).pop(),
       child: pageContent,
@@ -676,14 +709,14 @@ style: TextStyle(color: secondaryTextColor)));
   Widget _buildInfoView() {
     if (_mediaDetail == null) return const SizedBox.shrink();
 
-    final summaryText =
-        (_mediaDetail!.overview != null && _mediaDetail!.overview!.trim().isNotEmpty
-                ? _mediaDetail!.overview!
-                : '暂无简介')
-            .replaceAll('<br>', ' ')
-            .replaceAll('<br/>', ' ')
-            .replaceAll('<br />', ' ')
-            .replaceAll('```', '');
+    final summaryText = (_mediaDetail!.overview != null &&
+                _mediaDetail!.overview!.trim().isNotEmpty
+            ? _mediaDetail!.overview!
+            : '暂无简介')
+        .replaceAll('<br>', ' ')
+        .replaceAll('<br/>', ' ')
+        .replaceAll('<br />', ' ')
+        .replaceAll('```', '');
     final posterUrl = _getPosterUrl();
     final backdropUrl = _getBackdropUrl();
     final ratingValue = double.tryParse(_mediaDetail!.communityRating ?? '');
@@ -741,164 +774,165 @@ style: TextStyle(color: secondaryTextColor)));
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-              if (_mediaDetail!.originalTitle != null &&
-                  _mediaDetail!.originalTitle!.isNotEmpty &&
-                  _mediaDetail!.originalTitle != _mediaDetail!.name)
+          if (_mediaDetail!.originalTitle != null &&
+              _mediaDetail!.originalTitle!.isNotEmpty &&
+              _mediaDetail!.originalTitle != _mediaDetail!.name)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 8.0),
+              child: Text(
+                _mediaDetail!.originalTitle!,
+                style: valueStyle.copyWith(
+                  fontSize: 14,
+                  fontStyle: FontStyle.italic,
+                ),
+              ),
+            ),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              if (posterUrl.isNotEmpty)
                 Padding(
-                  padding: const EdgeInsets.only(bottom: 8.0),
-                  child: Text(
-                    _mediaDetail!.originalTitle!,
-                    style: valueStyle.copyWith(
-                      fontSize: 14,
-                      fontStyle: FontStyle.italic,
+                  padding: const EdgeInsets.only(right: 16.0, bottom: 8.0),
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(8),
+                    child: CachedNetworkImageWidget(
+                      imageUrl: posterUrl,
+                      width: 130,
+                      height: 195,
+                      fit: BoxFit.cover,
+                      loadMode: CachedImageLoadMode.legacy,
                     ),
                   ),
                 ),
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
+              Expanded(
+                child: SizedBox(
+                  height: 195,
+                  child: SingleChildScrollView(
+                    padding: const EdgeInsets.only(right: 8.0),
+                    child: Text(summaryText, style: valueStyle),
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Divider(color: textColor.withOpacity(0.15)),
+          const SizedBox(height: 8),
+          if (ratingValue != null && ratingValue > 0) ...[
+            RichText(
+              text: TextSpan(
                 children: [
-                  if (posterUrl.isNotEmpty)
-                    Padding(
-                      padding: const EdgeInsets.only(right: 16.0, bottom: 8.0),
-                      child: ClipRRect(
-                        borderRadius: BorderRadius.circular(8),
-                        child: CachedNetworkImageWidget(
-                          imageUrl: posterUrl,
-                          width: 130,
-                          height: 195,
-                          fit: BoxFit.cover,
-                          loadMode: CachedImageLoadMode.legacy,
-                        ),
-                      ),
-                    ),
-                  Expanded(
-                    child: SizedBox(
-                      height: 195,
-                      child: SingleChildScrollView(
-                        padding: const EdgeInsets.only(right: 8.0),
-                        child: Text(summaryText, style: valueStyle),
-                      ),
+                  TextSpan(text: '评分: ', style: boldWhiteKeyStyle),
+                  WidgetSpan(child: _buildRatingStars(ratingValue)),
+                  TextSpan(
+                    text: ' ${ratingValue.toStringAsFixed(1)} ',
+                    style: TextStyle(
+                      color: Colors.yellow[600],
+                      fontWeight: FontWeight.bold,
+                      fontSize: 14,
                     ),
                   ),
                 ],
               ),
-              const SizedBox(height: 16),
-              Divider(color: textColor.withOpacity(0.15)),
-              const SizedBox(height: 8),
-              if (ratingValue != null && ratingValue > 0) ...[
-                RichText(
-                  text: TextSpan(
-                    children: [
-                      TextSpan(text: '评分: ', style: boldWhiteKeyStyle),
-                      WidgetSpan(child: _buildRatingStars(ratingValue)),
-                      TextSpan(
-                        text: ' ${ratingValue.toStringAsFixed(1)} ',
-                        style: TextStyle(
-                          color: Colors.yellow[600],
-                          fontWeight: FontWeight.bold,
-                          fontSize: 14,
-                        ),
-                      ),
-                    ],
+            ),
+            const SizedBox(height: 6),
+          ],
+          ...infoRows,
+          if (_mediaDetail!.genres.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: _mediaDetail!.genres.map<Widget>((genre) {
+                return Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                  decoration: BoxDecoration(
+                    color: textColor.withOpacity(0.08),
+                    borderRadius: BorderRadius.circular(12),
+                    border: Border.all(
+                        color: textColor.withOpacity(0.12), width: 0.5),
                   ),
-                ),
-                const SizedBox(height: 6),
-              ],
-              ...infoRows,
-              if (_mediaDetail!.genres.isNotEmpty) ...[
-                const SizedBox(height: 8),
-                Wrap(
-                  spacing: 8,
-                  runSpacing: 8,
-                  children: _mediaDetail!.genres.map<Widget>((genre) {
-                    return Container(
-                      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
-                      decoration: BoxDecoration(
-                        color: textColor.withOpacity(0.08),
-                        borderRadius: BorderRadius.circular(12),
-                        border: Border.all(color: textColor.withOpacity(0.12), width: 0.5),
-                      ),
-                      child: Text(
-                        genre,
-                        style: TextStyle(color: secondaryTextColor, fontSize: 12),
-                      ),
-                    );
-                  }).toList(),
-                ),
-              ],
-              if (_mediaDetail!.cast.isNotEmpty) ...[
-                const SizedBox(height: 12),
-                if (sectionTitleStyle != null)
-                  Text('演员', style: sectionTitleStyle),
-                const SizedBox(height: 8),
-                SizedBox(
-                  height: 100,
-                  child: ListView.builder(
-                    scrollDirection: Axis.horizontal,
-                    itemCount: _mediaDetail!.cast.length,
-                    itemBuilder: (context, index) {
-                      final actor = _mediaDetail!.cast[index];
-                      final actorImage = _getActorImageUrl(actor);
+                  child: Text(
+                    genre,
+                    style: TextStyle(color: secondaryTextColor, fontSize: 12),
+                  ),
+                );
+              }).toList(),
+            ),
+          ],
+          if (_mediaDetail!.cast.isNotEmpty) ...[
+            const SizedBox(height: 12),
+            if (sectionTitleStyle != null) Text('演员', style: sectionTitleStyle),
+            const SizedBox(height: 8),
+            SizedBox(
+              height: 100,
+              child: ListView.builder(
+                scrollDirection: Axis.horizontal,
+                itemCount: _mediaDetail!.cast.length,
+                itemBuilder: (context, index) {
+                  final actor = _mediaDetail!.cast[index];
+                  final actorImage = _getActorImageUrl(actor);
 
-                      return Padding(
-                        padding: const EdgeInsets.only(right: 12),
-                        child: Column(
-                          children: [
-                            CircleAvatar(
-                              radius: 30,
-                              backgroundColor: Colors.grey.shade800,
-                              backgroundImage:
-                                  actorImage != null ? NetworkImage(actorImage) : null,
-                              child: actorImage == null
-                                  ? Icon(Icons.person,
-                                      color: secondaryTextColor)
-                                  : null,
-                            ),
-                            const SizedBox(height: 4),
-                            SizedBox(
-                              width: 70,
-                              child: Text(
-                                actor.name,
-                                style: TextStyle(
-                                    fontSize: 12, color: secondaryTextColor),
-                                textAlign: TextAlign.center,
-                                maxLines: 2,
-                                overflow: TextOverflow.ellipsis,
-                              ),
-                            ),
-                          ],
+                  return Padding(
+                    padding: const EdgeInsets.only(right: 12),
+                    child: Column(
+                      children: [
+                        CircleAvatar(
+                          radius: 30,
+                          backgroundColor: Colors.grey.shade800,
+                          backgroundImage: actorImage != null
+                              ? NetworkImage(actorImage)
+                              : null,
+                          child: actorImage == null
+                              ? Icon(Icons.person, color: secondaryTextColor)
+                              : null,
                         ),
-                      );
-                    },
-                  ),
-                ),
-              ],
-              if (_isMovie) ...[
-                const SizedBox(height: 16),
-                Row(
-                  children: [
-                    BlurButton(
-                      icon: Icons.play_arrow,
-                      text: '播放',
-                      foregroundColor: const Color(0xFF3B82F6),
-                      hoverForegroundColor: const Color(0xFF60A5FA),
-                      onTap: () {
-                        if (_isDetailAutoMatching) {
-                          BlurSnackBar.show(context, '正在自动匹配，请稍候');
-                          return;
-                        }
-                        _playMovie();
-                      },
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 24, vertical: 12),
-                      fontSize: 18,
+                        const SizedBox(height: 4),
+                        SizedBox(
+                          width: 70,
+                          child: Text(
+                            actor.name,
+                            style: TextStyle(
+                                fontSize: 12, color: secondaryTextColor),
+                            textAlign: TextAlign.center,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                      ],
                     ),
-                  ],
+                  );
+                },
+              ),
+            ),
+          ],
+          if (_isMovie) ...[
+            const SizedBox(height: 16),
+            Row(
+              children: [
+                BlurButton(
+                  icon: Icons.play_arrow,
+                  text: '播放',
+                  foregroundColor: const Color(0xFF3B82F6),
+                  hoverForegroundColor: const Color(0xFF60A5FA),
+                  onTap: () {
+                    if (_isDetailAutoMatching) {
+                      BlurSnackBar.show(context, '正在自动匹配，请稍候');
+                      return;
+                    }
+                    _playMovie();
+                  },
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+                  fontSize: 18,
                 ),
               ],
-            ],
-          ),
-        );
+            ),
+          ],
+        ],
+      ),
+    );
   }
 
   Widget _buildDesktopTabletLayout() {
@@ -922,6 +956,7 @@ style: TextStyle(color: secondaryTextColor)));
       ),
     );
   }
+
   Widget _buildEpisodesView() {
     final bool isDark = Theme.of(context).brightness == Brightness.dark;
     final Color textColor = isDark ? Colors.white : Colors.black87;
@@ -929,10 +964,11 @@ style: TextStyle(color: secondaryTextColor)));
     const Color accentColor = Color(0xFFFF2E55);
 
     // 移除原有的 Positioned 返回按钮，因为顶部已经有了全局关闭按钮
-    return Column( // 不再需要 Stack，因为返回按钮已全局处理
+    return Column(
+      // 不再需要 Stack，因为返回按钮已全局处理
       children: [
         // const SizedBox(height: 16), // 顶部间距可以根据整体布局调整，TabBar外部已有间距
-        
+
         // 季节选择器
         if (_seasons.isNotEmpty)
           Padding(
@@ -948,25 +984,35 @@ style: TextStyle(color: secondaryTextColor)));
                   final bool enableSeasonHover = !globals.isTouch;
                   final Color seasonTextColor =
                       isSelected ? accentColor : secondaryTextColor;
-                  
-                  return Padding(
-                    padding: const EdgeInsets.only(right: 12),
-                    child: MouseRegion(
-                      cursor: enableSeasonHover
-                          ? SystemMouseCursors.click
-                          : SystemMouseCursors.basic,
-                      child: GestureDetector(
-                        onTap: () => _loadEpisodesForSeason(season.id),
-                        behavior: HitTestBehavior.opaque,
-                        child: Padding(
-                          padding: const EdgeInsets.symmetric(
-                              horizontal: 4, vertical: 4),
-                          child: Text(
-                            season.name,
-                            style: TextStyle(
-                              color: seasonTextColor,
-                              fontWeight:
-                                  isSelected ? FontWeight.w600 : FontWeight.w400,
+
+                  return ConstrainedBox(
+                    constraints: const BoxConstraints(maxWidth: 180),
+                    child: Padding(
+                      padding: const EdgeInsets.only(right: 12),
+                      child: Tooltip(
+                        message: season.name,
+                        waitDuration: const Duration(milliseconds: 500),
+                        child: MouseRegion(
+                          cursor: enableSeasonHover
+                              ? SystemMouseCursors.click
+                              : SystemMouseCursors.basic,
+                          child: GestureDetector(
+                            onTap: () => _loadEpisodesForSeason(season.id),
+                            behavior: HitTestBehavior.opaque,
+                            child: Padding(
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 4, vertical: 4),
+                              child: Text(
+                                season.name,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: TextStyle(
+                                  color: seasonTextColor,
+                                  fontWeight: isSelected
+                                      ? FontWeight.w600
+                                      : FontWeight.w400,
+                                ),
+                              ),
                             ),
                           ),
                         ),
@@ -977,10 +1023,15 @@ style: TextStyle(color: secondaryTextColor)));
               ),
             ),
           ),
-        
+
         if (_seasons.isNotEmpty) // 仅当有季节选择器时显示分割线
-          Divider(height: 1, thickness: 1, color: textColor.withOpacity(0.1), indent: 16, endIndent: 16),
-        
+          Divider(
+              height: 1,
+              thickness: 1,
+              color: textColor.withOpacity(0.1),
+              indent: 16,
+              endIndent: 16),
+
         // 剧集列表
         Expanded(
           child: _buildEpisodesListForSelectedSeason(),
@@ -988,48 +1039,59 @@ style: TextStyle(color: secondaryTextColor)));
       ],
     );
   }
-  
+
   Widget _buildEpisodesListForSelectedSeason() {
     final bool isDark = Theme.of(context).brightness == Brightness.dark;
     final Color textColor = isDark ? Colors.white : Colors.black87;
     final Color secondaryTextColor = isDark ? Colors.white70 : Colors.black54;
     const Color accentColor = Color(0xFFFF2E55);
 
-    if (_selectedSeasonId == null && _seasons.isNotEmpty) { // 如果有季但没有选择，提示选择
+    if (_selectedSeasonId == null && _seasons.isNotEmpty) {
+      // 如果有季但没有选择，提示选择
       return Center(
-        child: Text('请选择一个季', locale:Locale("zh-Hans","zh"),
-style: TextStyle(color: secondaryTextColor)),
+        child: Text('请选择一个季',
+            locale: Locale("zh-Hans", "zh"),
+            style: TextStyle(color: secondaryTextColor)),
       );
     }
-    if (_selectedSeasonId == null && _seasons.isEmpty && !_isLoading) { // 如果没有季且不在加载中
-        return Center(
-        child: Text('该剧集没有季节信息', locale:Locale("zh-Hans","zh"),
-style: TextStyle(color: secondaryTextColor)),
+    if (_selectedSeasonId == null && _seasons.isEmpty && !_isLoading) {
+      // 如果没有季且不在加载中
+      return Center(
+        child: Text('该剧集没有季节信息',
+            locale: Locale("zh-Hans", "zh"),
+            style: TextStyle(color: secondaryTextColor)),
       );
     }
-    
-    if (_isLoading && (_episodesBySeasonId[_selectedSeasonId ?? ''] == null || _episodesBySeasonId[_selectedSeasonId ?? '']!.isEmpty)) {
+
+    if (_isLoading &&
+        (_episodesBySeasonId[_selectedSeasonId ?? ''] == null ||
+            _episodesBySeasonId[_selectedSeasonId ?? '']!.isEmpty)) {
       return Center(
         child: CircularProgressIndicator(color: textColor),
       );
     }
-    
-    if (_error != null && _selectedSeasonId != null) { // 仅在尝试加载特定季出错时显示
+
+    if (_error != null && _selectedSeasonId != null) {
+      // 仅在尝试加载特定季出错时显示
       return Center(
         child: Padding(
           padding: const EdgeInsets.all(16.0),
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              const Icon(Icons.error_outline, size: 48, color: Colors.redAccent),
+              const Icon(Icons.error_outline,
+                  size: 48, color: Colors.redAccent),
               const SizedBox(height: 16),
-              Text('加载剧集失败: $_error', style: TextStyle(color: secondaryTextColor), textAlign: TextAlign.center),
+              Text('加载剧集失败: $_error',
+                  style: TextStyle(color: secondaryTextColor),
+                  textAlign: TextAlign.center),
               const SizedBox(height: 16),
               BlurButton(
                 icon: Icons.refresh,
                 text: '重试',
                 onTap: () => _loadEpisodesForSeason(_selectedSeasonId!),
-                padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
                 fontSize: 16,
               ),
             ],
@@ -1037,23 +1099,28 @@ style: TextStyle(color: secondaryTextColor)),
         ),
       );
     }
-    
+
     final episodes = _episodesBySeasonId[_selectedSeasonId] ?? [];
-    
-    if (episodes.isEmpty && !_isLoading && _selectedSeasonId != null) { // 确保不是在加载中，并且确实选择了季
+
+    if (episodes.isEmpty && !_isLoading && _selectedSeasonId != null) {
+      // 确保不是在加载中，并且确实选择了季
       return Center(
-        child: Text('该季没有剧集', locale:Locale("zh-Hans","zh"),
-style: TextStyle(color: secondaryTextColor)),
+        child: Text('该季没有剧集',
+            locale: Locale("zh-Hans", "zh"),
+            style: TextStyle(color: secondaryTextColor)),
       );
     }
-     if (episodes.isEmpty && _isLoading) { // 如果仍在加载，显示加载指示器
+    if (episodes.isEmpty && _isLoading) {
+      // 如果仍在加载，显示加载指示器
       return Center(child: CircularProgressIndicator(color: textColor));
     }
-    if (episodes.isEmpty && _selectedSeasonId == null && _seasons.isEmpty) { // 处理没有季的情况
-        return Center(child: Text('没有可显示的剧集', locale:Locale("zh-Hans","zh"),
-style: TextStyle(color: secondaryTextColor)));
+    if (episodes.isEmpty && _selectedSeasonId == null && _seasons.isEmpty) {
+      // 处理没有季的情况
+      return Center(
+          child: Text('没有可显示的剧集',
+              locale: Locale("zh-Hans", "zh"),
+              style: TextStyle(color: secondaryTextColor)));
     }
-
 
     dynamic service;
     if (widget.serverType == MediaServerType.jellyfin) {
@@ -1061,7 +1128,7 @@ style: TextStyle(color: secondaryTextColor)));
     } else {
       service = EmbyService.instance;
     }
-    
+
     return SettingsNoRippleTheme(
       child: ListView.builder(
         padding: const EdgeInsets.only(top: 8, bottom: 24),
@@ -1077,9 +1144,8 @@ style: TextStyle(color: secondaryTextColor)));
               playHoverEnabled && _hoveredEpisodeId == episode.id;
           final Color playIconColor =
               isEpisodeHovered ? accentColor : secondaryTextColor;
-          final Color titleColor =
-              isEpisodeHovered ? accentColor : textColor;
-          
+          final Color titleColor = isEpisodeHovered ? accentColor : textColor;
+
           return MouseRegion(
             cursor: playHoverEnabled
                 ? SystemMouseCursors.click
@@ -1105,7 +1171,8 @@ style: TextStyle(color: secondaryTextColor)));
                   borderRadius: BorderRadius.circular(4),
                   child: episodeImageUrl.isNotEmpty
                       ? CachedNetworkImageWidget(
-                          key: ValueKey(episode.id), // 为 CachedNetworkImageWidget 添加 Key
+                          key: ValueKey(
+                              episode.id), // 为 CachedNetworkImageWidget 添加 Key
                           imageUrl: episodeImageUrl,
                           fit: BoxFit.cover,
                           errorBuilder: (context, error) {
@@ -1123,8 +1190,7 @@ style: TextStyle(color: secondaryTextColor)));
                           },
                         )
                       : Container(
-                          color:
-                              isDark ? Colors.grey[800] : Colors.grey[300],
+                          color: isDark ? Colors.grey[800] : Colors.grey[300],
                           child: Center(
                             child: Icon(
                               Ionicons.film_outline, // 使用 Ionicons
@@ -1189,25 +1255,25 @@ style: TextStyle(color: secondaryTextColor)));
                 }
                 try {
                   BlurSnackBar.show(context, '准备播放: ${episode.name}');
-                  
+
                   debugPrint('准备创建播放会话');
-                  
+
                   // 显示加载指示器
                   if (mounted) {
                     BlurSnackBar.show(context, '正在匹配弹幕信息...');
                   }
-                  
+
                   // 使用JellyfinDandanplayMatcher创建增强的WatchHistoryItem
                   // 这一步会显示匹配对话框，阻塞直到用户完成选择或跳过
                   final historyItem =
                       await _runDetailAutoMatchTask<WatchHistoryItem?>(
                           () => _createWatchHistoryItem(episode));
                   if (historyItem == null) return; // 用户关闭弹窗，什么都不做
-                  
+
                   // 用户已完成匹配选择，现在可以继续播放流程
                   debugPrint(
                       '成功获取历史记录项: ${historyItem.animeName} - ${historyItem.episodeTitle}, animeId=${historyItem.animeId}, episodeId=${historyItem.episodeId}');
-                  
+
                   // 调试：检查 historyItem 的弹幕 ID
                   if (historyItem.animeId == null ||
                       historyItem.episodeId == null) {
@@ -1220,7 +1286,7 @@ style: TextStyle(color: secondaryTextColor)));
                     debugPrint('  animeId: ${historyItem.animeId}');
                     debugPrint('  episodeId: ${historyItem.episodeId}');
                   }
-                  
+
                   // 创建一个专门用于流媒体播放的历史记录项，使用稳定的jellyfin://或emby://协议
                   final playableHistoryItem = WatchHistoryItem(
                     filePath:
@@ -1258,8 +1324,7 @@ style: TextStyle(color: secondaryTextColor)));
                       final embyPath = playableHistoryItem.filePath
                           .replaceFirst('emby://', '');
                       final parts = embyPath.split('/');
-                      final embyId =
-                          parts.isNotEmpty ? parts.last : embyPath;
+                      final embyId = parts.isNotEmpty ? parts.last : embyPath;
                       playbackSession =
                           await EmbyService.instance.createPlaybackSession(
                         itemId: embyId,
@@ -1284,11 +1349,11 @@ style: TextStyle(color: secondaryTextColor)));
                       return;
                     }
                   }
-                  
+
                   // 获取必要的服务引用
                   final videoPlayerState =
                       Provider.of<VideoPlayerState>(context, listen: false);
-                  
+
                   // 在页面关闭前，获取TabChangeNotifier
                   // 注意：通过listen: false方式获取，避免建立依赖关系
                   TabChangeNotifier? tabChangeNotifier;
@@ -1298,27 +1363,27 @@ style: TextStyle(color: secondaryTextColor)));
                   } catch (e) {
                     debugPrint('无法获取TabChangeNotifier: $e');
                   }
-                  
+
                   // *** 关键修改：立即切换页面和关闭详情页，像本地视频播放一样 ***
                   // 1. 立即切换到播放页面，显示加载中
                   if (tabChangeNotifier != null) {
                     debugPrint('立即切换到播放页面');
                     tabChangeNotifier.changeTab(1);
                   }
-                  
+
                   // 2. 立即关闭详情页面
                   Navigator.of(context).pop();
                   debugPrint('详情页面已立即关闭');
-                  
+
                   // 3. 显示开始播放的提示（这个提示会在播放页面显示）
                   if (mounted) {
                     BlurSnackBar.show(
                         context, '开始播放: ${historyItem.episodeTitle}');
                   }
-                  
+
                   // 4. 异步初始化播放器（页面已切换，用户能看到加载中）
                   debugPrint('开始异步初始化播放器...');
-                  
+
                   // 使用异步方式初始化播放器，不阻塞UI
                   Future.delayed(const Duration(milliseconds: 100), () async {
                     try {
@@ -1329,8 +1394,8 @@ style: TextStyle(color: secondaryTextColor)));
                           .startsWith('jellyfin://')) {
                         final jellyfinId = playableHistoryItem.filePath
                             .replaceFirst('jellyfin://', '');
-                        playbackSession =
-                            await JellyfinService.instance.createPlaybackSession(
+                        playbackSession = await JellyfinService.instance
+                            .createPlaybackSession(
                           itemId: jellyfinId,
                           startPositionMs: playableHistoryItem.lastPosition > 0
                               ? playableHistoryItem.lastPosition
@@ -1341,8 +1406,7 @@ style: TextStyle(color: secondaryTextColor)));
                         final embyPath = playableHistoryItem.filePath
                             .replaceFirst('emby://', '');
                         final parts = embyPath.split('/');
-                        final embyId =
-                            parts.isNotEmpty ? parts.last : embyPath;
+                        final embyId = parts.isNotEmpty ? parts.last : embyPath;
                         playbackSession =
                             await EmbyService.instance.createPlaybackSession(
                           itemId: embyId,
@@ -1358,7 +1422,7 @@ style: TextStyle(color: secondaryTextColor)));
                         playbackSession: playbackSession,
                       );
                       debugPrint('异步初始化播放器 - 完成');
-                      
+
                       // 开始播放
                       debugPrint('异步播放 - 开始播放视频');
                       videoPlayerState.play();

--- a/lib/pages/webdav_browser_page.dart
+++ b/lib/pages/webdav_browser_page.dart
@@ -8,6 +8,7 @@ import 'package:nipaplay/themes/nipaplay/widgets/webdav_connection_dialog.dart';
 import 'package:nipaplay/models/watch_history_model.dart';
 import 'package:nipaplay/models/playable_item.dart';
 import 'package:nipaplay/services/playback_service.dart';
+import 'package:nipaplay/utils/webdav_file_sorter.dart';
 import 'package:kmbal_ionicons/kmbal_ionicons.dart';
 
 /// WebDAV 文件浏览器页面
@@ -46,7 +47,8 @@ class _WebDAVBrowserPageState extends State<WebDAVBrowserPage> {
     if (!mounted) return;
 
     // 加载快捷设置
-    final provider = Provider.of<WebDAVQuickAccessProvider>(context, listen: false);
+    final provider =
+        Provider.of<WebDAVQuickAccessProvider>(context, listen: false);
     await provider.loadSettings();
 
     if (!mounted) return;
@@ -87,15 +89,14 @@ class _WebDAVBrowserPageState extends State<WebDAVBrowserPage> {
       );
 
       // 应用排序预设
-      final provider = Provider.of<WebDAVQuickAccessProvider>(context, listen: false);
-      _sortFiles(files, provider.sortPreset);
+      final provider =
+          Provider.of<WebDAVQuickAccessProvider>(context, listen: false);
+      WebDAVFileSorter.sort(files, provider.sortPreset);
 
       // 检查是否需要自动进入 Season 文件夹
       if (provider.autoEnterSeasonFolder) {
-        final folderNames = files
-            .where((f) => f.isDirectory)
-            .map((f) => f.name)
-            .toList();
+        final folderNames =
+            files.where((f) => f.isDirectory).map((f) => f.name).toList();
         final matchFolder = provider.findMatchingSeasonFolder(folderNames);
 
         if (matchFolder != null && mounted) {
@@ -128,66 +129,6 @@ class _WebDAVBrowserPageState extends State<WebDAVBrowserPage> {
     }
   }
 
-  /// 根据排序预设对文件列表排序
-  void _sortFiles(List<WebDAVFile> files, WebDAVSortPreset preset) {
-    switch (preset) {
-      case WebDAVSortPreset.defaultValue:
-        // 默认：文件夹在前，各自按名称 A-Z
-        files.sort((a, b) {
-          if (a.isDirectory && !b.isDirectory) return -1;
-          if (!a.isDirectory && b.isDirectory) return 1;
-          return a.name.toLowerCase().compareTo(b.name.toLowerCase());
-        });
-        break;
-
-      case WebDAVSortPreset.nameAsc:
-        // 名称 A-Z（混合排序）
-        files.sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
-        break;
-
-      case WebDAVSortPreset.nameDesc:
-        // 名称 Z-A（混合排序）
-        files.sort((a, b) => b.name.toLowerCase().compareTo(a.name.toLowerCase()));
-        break;
-
-      case WebDAVSortPreset.modifiedDesc:
-        // 最新修改
-        files.sort((a, b) {
-          final aTime = a.lastModified ?? DateTime(1970);
-          final bTime = b.lastModified ?? DateTime(1970);
-          return bTime.compareTo(aTime);
-        });
-        break;
-
-      case WebDAVSortPreset.modifiedAsc:
-        // 最旧修改
-        files.sort((a, b) {
-          final aTime = a.lastModified ?? DateTime(1970);
-          final bTime = b.lastModified ?? DateTime(1970);
-          return aTime.compareTo(bTime);
-        });
-        break;
-
-      case WebDAVSortPreset.sizeDesc:
-        // 最大文件
-        files.sort((a, b) {
-          final aSize = a.size ?? 0;
-          final bSize = b.size ?? 0;
-          return bSize.compareTo(aSize);
-        });
-        break;
-
-      case WebDAVSortPreset.sizeAsc:
-        // 最小文件
-        files.sort((a, b) {
-          final aSize = a.size ?? 0;
-          final bSize = b.size ?? 0;
-          return aSize.compareTo(bSize);
-        });
-        break;
-    }
-  }
-
   void _navigateToDirectory(String path) {
     if (_currentPath != '/') {
       _pathHistory.add(_currentPath);
@@ -206,7 +147,8 @@ class _WebDAVBrowserPageState extends State<WebDAVBrowserPage> {
       _loadDirectory();
     } else if (_currentPath != '/') {
       // 返回上一级目录（而不是直接跳到根目录）
-      final segments = _currentPath.split('/').where((s) => s.isNotEmpty).toList();
+      final segments =
+          _currentPath.split('/').where((s) => s.isNotEmpty).toList();
       if (segments.isNotEmpty) {
         segments.removeLast();
         final parentPath = segments.isEmpty ? '/' : '/' + segments.join('/');
@@ -292,9 +234,11 @@ class _WebDAVBrowserPageState extends State<WebDAVBrowserPage> {
 
         // 如果添加前没有服务器，添加后只有一个服务器，则自动设置为默认服务器
         if (connectionsBefore == 0 && connectionsAfter.length == 1) {
-          final provider = Provider.of<WebDAVQuickAccessProvider>(context, listen: false);
+          final provider =
+              Provider.of<WebDAVQuickAccessProvider>(context, listen: false);
           await provider.setDefaultServerName(newConnection.name);
-          BlurSnackBar.show(context, '已将 ${newConnection.name} 设置为默认 WebDAV 服务器');
+          BlurSnackBar.show(
+              context, '已将 ${newConnection.name} 设置为默认 WebDAV 服务器');
         }
 
         // 自动选择新添加的服务器并加载目录
@@ -311,7 +255,8 @@ class _WebDAVBrowserPageState extends State<WebDAVBrowserPage> {
   @override
   Widget build(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    final backgroundColor = isDark ? const Color(0xFF1A1A1A) : const Color(0xFFF5F5F5);
+    final backgroundColor =
+        isDark ? const Color(0xFF1A1A1A) : const Color(0xFFF5F5F5);
     final cardColor = isDark ? const Color(0xFF2A2A2A) : Colors.white;
     final textColor = isDark ? Colors.white : Colors.black87;
     final secondaryTextColor = isDark ? Colors.white60 : Colors.black54;
@@ -394,7 +339,8 @@ class _WebDAVBrowserPageState extends State<WebDAVBrowserPage> {
             Expanded(
               child: _isLoading
                   ? const Center(
-                      child: CircularProgressIndicator(color: Color(0xFFFF2E55)),
+                      child:
+                          CircularProgressIndicator(color: Color(0xFFFF2E55)),
                     )
                   : _currentFiles.isEmpty
                       ? Center(
@@ -405,21 +351,21 @@ class _WebDAVBrowserPageState extends State<WebDAVBrowserPage> {
                         )
                       : ListView.builder(
                           padding: const EdgeInsets.all(16),
-                        itemCount: _currentFiles.length,
-                        itemBuilder: (context, index) {
-                          final file = _currentFiles[index];
-                          return _buildFileItem(
-                            file: file,
-                            cardColor: cardColor,
-                            textColor: textColor,
-                            secondaryTextColor: secondaryTextColor,
-                            accentColor: accentColor,
-                          );
-                        },
-                      ),
-          ),
-        ],
-      ),
+                          itemCount: _currentFiles.length,
+                          itemBuilder: (context, index) {
+                            final file = _currentFiles[index];
+                            return _buildFileItem(
+                              file: file,
+                              cardColor: cardColor,
+                              textColor: textColor,
+                              secondaryTextColor: secondaryTextColor,
+                              accentColor: accentColor,
+                            );
+                          },
+                        ),
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -504,7 +450,8 @@ class _WebDAVBrowserPageState extends State<WebDAVBrowserPage> {
             ],
           ),
           // 路径面包屑导航（根据设置显示）
-          if (Provider.of<WebDAVQuickAccessProvider>(context).showPathBreadcrumb) ...[
+          if (Provider.of<WebDAVQuickAccessProvider>(context)
+              .showPathBreadcrumb) ...[
             const SizedBox(height: 12),
             _buildPathBreadcrumb(
               textColor: textColor,
@@ -523,7 +470,8 @@ class _WebDAVBrowserPageState extends State<WebDAVBrowserPage> {
     required Color accentColor,
   }) {
     // 将路径分割成片段
-    final segments = _currentPath.split('/').where((s) => s.isNotEmpty).toList();
+    final segments =
+        _currentPath.split('/').where((s) => s.isNotEmpty).toList();
     final hasSegments = segments.isNotEmpty;
 
     return SizedBox(
@@ -544,7 +492,8 @@ class _WebDAVBrowserPageState extends State<WebDAVBrowserPage> {
                   style: TextStyle(
                     color: !hasSegments ? accentColor : secondaryTextColor,
                     fontSize: 13,
-                    fontWeight: !hasSegments ? FontWeight.w600 : FontWeight.normal,
+                    fontWeight:
+                        !hasSegments ? FontWeight.w600 : FontWeight.normal,
                   ),
                 ),
               ),
@@ -566,13 +515,15 @@ class _WebDAVBrowserPageState extends State<WebDAVBrowserPage> {
                     onTap: isLast ? null : () => _navigateToPath(path),
                     borderRadius: BorderRadius.circular(4),
                     child: Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 4, vertical: 4),
                       child: Text(
                         segment,
                         style: TextStyle(
                           color: isLast ? accentColor : secondaryTextColor,
                           fontSize: 13,
-                          fontWeight: isLast ? FontWeight.w600 : FontWeight.normal,
+                          fontWeight:
+                              isLast ? FontWeight.w600 : FontWeight.normal,
                         ),
                       ),
                     ),
@@ -617,7 +568,8 @@ class _WebDAVBrowserPageState extends State<WebDAVBrowserPage> {
     final videoUrl = _currentConnection != null
         ? WebDAVService.instance.getFileUrl(_currentConnection!, file.path)
         : null;
-    final historyProvider = Provider.of<WatchHistoryProvider>(context, listen: false);
+    final historyProvider =
+        Provider.of<WatchHistoryProvider>(context, listen: false);
     WatchHistoryItem? historyItem;
     if (videoUrl != null) {
       try {
@@ -677,7 +629,9 @@ class _WebDAVBrowserPageState extends State<WebDAVBrowserPage> {
                     // 文件大小和播放进度
                     Row(
                       children: [
-                        if (!isDirectory && file.size != null && file.size! > 0) ...[
+                        if (!isDirectory &&
+                            file.size != null &&
+                            file.size! > 0) ...[
                           Text(
                             _formatFileSize(file.size!),
                             style: TextStyle(
@@ -688,7 +642,8 @@ class _WebDAVBrowserPageState extends State<WebDAVBrowserPage> {
                           if (seasonEpisode != null) ...[
                             const SizedBox(width: 8),
                             Container(
-                              padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 1),
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 5, vertical: 1),
                               decoration: BoxDecoration(
                                 color: Colors.blue.withOpacity(0.15),
                                 borderRadius: BorderRadius.circular(4),
@@ -710,7 +665,8 @@ class _WebDAVBrowserPageState extends State<WebDAVBrowserPage> {
                           if (hasProgress) ...[
                             const SizedBox(width: 8),
                             Container(
-                              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 6, vertical: 2),
                               decoration: BoxDecoration(
                                 color: accentColor.withOpacity(0.1),
                                 borderRadius: BorderRadius.circular(4),
@@ -753,7 +709,8 @@ class _WebDAVBrowserPageState extends State<WebDAVBrowserPage> {
                         child: LinearProgressIndicator(
                           value: historyItem.watchProgress,
                           backgroundColor: secondaryTextColor.withOpacity(0.2),
-                          valueColor: AlwaysStoppedAnimation<Color>(accentColor),
+                          valueColor:
+                              AlwaysStoppedAnimation<Color>(accentColor),
                           minHeight: 3,
                         ),
                       ),
@@ -857,7 +814,8 @@ class _ServerSelectorSheet extends StatelessWidget {
                   connection.name,
                   style: TextStyle(
                     color: textColor,
-                    fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+                    fontWeight:
+                        isSelected ? FontWeight.bold : FontWeight.normal,
                   ),
                 ),
                 subtitle: Text(

--- a/lib/services/emby_service.dart
+++ b/lib/services/emby_service.dart
@@ -84,8 +84,8 @@ class EmbyService extends MediaServerServiceBase
         defaultQuality: quality,
         settings: settings,
       );
-      DebugLogService().addLog(
-          'Emby: 已加载转码偏好 缓存 enabled=$enabled, quality=$quality');
+      DebugLogService()
+          .addLog('Emby: 已加载转码偏好 缓存 enabled=$enabled, quality=$quality');
     } catch (e) {
       DebugLogService().addLog('Emby: 加载转码偏好失败，使用默认值: $e');
       updateTranscodeCache(
@@ -238,11 +238,13 @@ class EmbyService extends MediaServerServiceBase
       String url, String username, String password) async {
     try {
       // 获取服务器信息
-      final configResponse = await http
-          .get(
-            Uri.parse('$url/emby/System/Info/Public'),
-          )
-          .timeout(const Duration(seconds: 5));
+      final configResponse = await sendRequestFollowingRedirects(
+        Uri.parse('$url/emby/System/Info/Public'),
+        method: 'GET',
+        headers: const {},
+        timeout: const Duration(seconds: 5),
+        redirectLogLabel: 'EmbyService',
+      );
 
       return configResponse.statusCode == 200;
     } catch (e) {
@@ -254,8 +256,9 @@ class EmbyService extends MediaServerServiceBase
   Future<void> _performAuthentication(
       String serverUrl, String username, String password) async {
     final clientInfo = await getClientInfo();
-    final authResponse = await http.post(
+    final authResponse = await sendRequestFollowingRedirects(
       Uri.parse('$serverUrl/emby/Users/AuthenticateByName'),
+      method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'X-Emby-Authorization': clientInfo,
@@ -264,6 +267,8 @@ class EmbyService extends MediaServerServiceBase
         'Username': username,
         'Pw': password,
       }),
+      timeout: const Duration(seconds: 30),
+      redirectLogLabel: 'EmbyService',
     );
 
     if (authResponse.statusCode != 200) {
@@ -279,11 +284,13 @@ class EmbyService extends MediaServerServiceBase
   /// 如果无法获取，将抛出异常
   Future<String> _getEmbyServerId(String url) async {
     try {
-      final response = await http
-          .get(
-            Uri.parse('$url/emby/System/Info/Public'),
-          )
-          .timeout(const Duration(seconds: 5));
+      final response = await sendRequestFollowingRedirects(
+        Uri.parse('$url/emby/System/Info/Public'),
+        method: 'GET',
+        headers: const {},
+        timeout: const Duration(seconds: 5),
+        redirectLogLabel: 'EmbyService',
+      );
 
       if (response.statusCode == 200) {
         final data = json.decode(response.body);
@@ -302,11 +309,13 @@ class EmbyService extends MediaServerServiceBase
   /// 获取服务器名称
   Future<String?> _getServerName(String url) async {
     try {
-      final response = await http
-          .get(
-            Uri.parse('$url/emby/System/Info/Public'),
-          )
-          .timeout(const Duration(seconds: 5));
+      final response = await sendRequestFollowingRedirects(
+        Uri.parse('$url/emby/System/Info/Public'),
+        method: 'GET',
+        headers: const {},
+        timeout: const Duration(seconds: 5),
+        redirectLogLabel: 'EmbyService',
+      );
 
       if (response.statusCode == 200) {
         final data = json.decode(response.body);
@@ -439,9 +448,8 @@ class EmbyService extends MediaServerServiceBase
         final data = json.decode(response.body);
         final List<dynamic> items = data['Items'] ?? [];
 
-        final results = items
-            .map((item) => EmbyMediaItem.fromJson(item))
-            .toList();
+        final results =
+            items.map((item) => EmbyMediaItem.fromJson(item)).toList();
 
         results.sort((a, b) {
           if (a.isFolder != b.isFolder) {
@@ -704,7 +712,8 @@ class EmbyService extends MediaServerServiceBase
   /// 获取 Resume 列表用于同步播放记录
   Future<List<Map<String, dynamic>>> fetchResumeItems({int limit = 5}) async {
     if (!_isConnected || _userId == null) {
-      debugPrint('EmbyService.fetchResumeItems -> skip, connected=$_isConnected userId=$_userId');
+      debugPrint(
+          'EmbyService.fetchResumeItems -> skip, connected=$_isConnected userId=$_userId');
       return [];
     }
 
@@ -1055,10 +1064,10 @@ class EmbyService extends MediaServerServiceBase
             : JellyfinVideoQuality.original);
 
     final enableTranscoding = transcodeEnabledCache &&
-      effectiveQuality != JellyfinVideoQuality.original;
+        effectiveQuality != JellyfinVideoQuality.original;
 
     final maxStreamingBitrate =
-      enableTranscoding ? effectiveQuality.bitrate : null;
+        enableTranscoding ? effectiveQuality.bitrate : null;
     final resolvedPlaySessionId = playSessionId;
 
     final deviceProfile = PlaybackDeviceProfileBuilder.build(
@@ -1149,7 +1158,7 @@ class EmbyService extends MediaServerServiceBase
     String? requestedMediaSourceId,
   }) {
     final playSessionId =
-      forcedPlaySessionId ?? data['PlaySessionId']?.toString();
+        forcedPlaySessionId ?? data['PlaySessionId']?.toString();
     final rawSources = data['MediaSources'];
     final sources = <PlaybackMediaSource>[];
     if (rawSources is List) {
@@ -1178,7 +1187,9 @@ class EmbyService extends MediaServerServiceBase
 
     bool useTranscoding = false;
     String? chosenUrl;
-    if (!forceDirectPlay && transcodingUrl != null && transcodingUrl.isNotEmpty) {
+    if (!forceDirectPlay &&
+        transcodingUrl != null &&
+        transcodingUrl.isNotEmpty) {
       if (preferTranscoding ||
           directStreamUrl == null ||
           directStreamUrl.isEmpty) {
@@ -1219,11 +1230,17 @@ class EmbyService extends MediaServerServiceBase
   }
 
   String _resolvePlaybackUrl(String url) {
-    if (url.startsWith('http://') || url.startsWith('https://')) {
-      return url;
+    final uri = Uri.tryParse(url);
+    if (uri != null && (uri.scheme == 'http' || uri.scheme == 'https')) {
+      if (uri.host.isNotEmpty) {
+        return url;
+      }
+      if (_serverUrl != null && _serverUrl!.isNotEmpty) {
+        return Uri.parse(_serverUrl!).resolveUri(uri).toString();
+      }
     }
     final normalized = url.startsWith('/') ? url : '/$url';
-    return '$_serverUrl$normalized';
+    return Uri.parse(_serverUrl!).resolve(normalized).toString();
   }
 
   String? _resolveSubtitleMethod({
@@ -1692,9 +1709,23 @@ class EmbyService extends MediaServerServiceBase
       } else if (collectionType == 'movies') {
         includeItemTypes = ['Movie'];
       } else if (collectionType == 'mixed') {
-        includeItemTypes = ['Folder', 'Series', 'Season', 'Episode', 'Movie', 'Video'];
+        includeItemTypes = [
+          'Folder',
+          'Series',
+          'Season',
+          'Episode',
+          'Movie',
+          'Video'
+        ];
       } else {
-        includeItemTypes = ['Folder', 'Series', 'Season', 'Episode', 'Movie', 'Video'];
+        includeItemTypes = [
+          'Folder',
+          'Series',
+          'Season',
+          'Episode',
+          'Movie',
+          'Video'
+        ];
       }
 
       return await searchMediaItems(

--- a/lib/services/emby_service.dart
+++ b/lib/services/emby_service.dart
@@ -1230,17 +1230,7 @@ class EmbyService extends MediaServerServiceBase
   }
 
   String _resolvePlaybackUrl(String url) {
-    final uri = Uri.tryParse(url);
-    if (uri != null && (uri.scheme == 'http' || uri.scheme == 'https')) {
-      if (uri.host.isNotEmpty) {
-        return url;
-      }
-      if (_serverUrl != null && _serverUrl!.isNotEmpty) {
-        return Uri.parse(_serverUrl!).resolveUri(uri).toString();
-      }
-    }
-    final normalized = url.startsWith('/') ? url : '/$url';
-    return Uri.parse(_serverUrl!).resolve(normalized).toString();
+    return resolveServerRelativeUrl(_serverUrl!, url);
   }
 
   String? _resolveSubtitleMethod({

--- a/lib/services/file_association_service.dart
+++ b/lib/services/file_association_service.dart
@@ -1,15 +1,27 @@
 import 'dart:io';
+import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 class FileAssociationService {
-  static const MethodChannel _channel = MethodChannel('file_association_channel');
+  static const MethodChannel _channel =
+      MethodChannel('file_association_channel');
+  static final StreamController<String> _openFileController =
+      StreamController<String>.broadcast();
+  static bool _handlerInitialized = false;
+
+  static Stream<String> get openFileStream {
+    _ensureHandlerInitialized();
+    return _openFileController.stream;
+  }
 
   /// 获取从系统传入的文件路径（仅Android）
   static Future<String?> getOpenFileUri() async {
     if (!Platform.isAndroid) {
       return null;
     }
+
+    _ensureHandlerInitialized();
 
     try {
       final result = await _channel.invokeMethod('getOpenFileUri');
@@ -20,13 +32,35 @@ class FileAssociationService {
     }
   }
 
+  static void _ensureHandlerInitialized() {
+    if (_handlerInitialized) return;
+    _handlerInitialized = true;
+    _channel.setMethodCallHandler((call) async {
+      if (call.method == 'onOpenFileUri') {
+        final value = call.arguments;
+        if (value is String && value.isNotEmpty) {
+          _openFileController.add(value);
+        }
+      }
+    });
+  }
+
   /// 检查文件是否为支持的视频格式
   static bool isSupportedVideoFile(String filePath) {
     final supportedExtensions = [
-      '.mp4', '.mkv', '.avi', '.mov', '.webm', '.wmv', 
-      '.m4v', '.3gp', '.flv', '.ts', '.m2ts'
+      '.mp4',
+      '.mkv',
+      '.avi',
+      '.mov',
+      '.webm',
+      '.wmv',
+      '.m4v',
+      '.3gp',
+      '.flv',
+      '.ts',
+      '.m2ts'
     ];
-    
+
     final extension = filePath.toLowerCase().split('.').last;
     return supportedExtensions.any((ext) => ext.endsWith(extension));
   }
@@ -41,4 +75,4 @@ class FileAssociationService {
       return false;
     }
   }
-} 
+}

--- a/lib/services/jellyfin_service.dart
+++ b/lib/services/jellyfin_service.dart
@@ -1230,17 +1230,7 @@ class JellyfinService extends MediaServerServiceBase
   }
 
   String _resolvePlaybackUrl(String url) {
-    final uri = Uri.tryParse(url);
-    if (uri != null && (uri.scheme == 'http' || uri.scheme == 'https')) {
-      if (uri.host.isNotEmpty) {
-        return url;
-      }
-      if (_serverUrl != null && _serverUrl!.isNotEmpty) {
-        return Uri.parse(_serverUrl!).resolveUri(uri).toString();
-      }
-    }
-    final normalized = url.startsWith('/') ? url : '/$url';
-    return Uri.parse(_serverUrl!).resolve(normalized).toString();
+    return resolveServerRelativeUrl(_serverUrl!, url);
   }
 
   String? _resolveSubtitleMethod({

--- a/lib/services/jellyfin_service.dart
+++ b/lib/services/jellyfin_service.dart
@@ -88,8 +88,8 @@ class JellyfinService extends MediaServerServiceBase
         defaultQuality: quality,
         settings: settings,
       );
-      DebugLogService().addLog(
-          'Jellyfin: 已加载转码偏好 缓存 enabled=$enabled, quality=$quality');
+      DebugLogService()
+          .addLog('Jellyfin: 已加载转码偏好 缓存 enabled=$enabled, quality=$quality');
     } catch (e) {
       DebugLogService().addLog('Jellyfin: 加载转码偏好失败，使用默认值: $e');
       updateTranscodeCache(
@@ -257,11 +257,13 @@ class JellyfinService extends MediaServerServiceBase
       String url, String username, String password) async {
     try {
       // 获取服务器信息
-      final configResponse = await http
-          .get(
-            Uri.parse('$url/System/Info/Public'),
-          )
-          .timeout(const Duration(seconds: 5));
+      final configResponse = await sendRequestFollowingRedirects(
+        Uri.parse('$url/System/Info/Public'),
+        method: 'GET',
+        headers: const {},
+        timeout: const Duration(seconds: 5),
+        redirectLogLabel: 'JellyfinService',
+      );
 
       return configResponse.statusCode == 200;
     } catch (e) {
@@ -273,8 +275,9 @@ class JellyfinService extends MediaServerServiceBase
   Future<void> _performAuthentication(
       String serverUrl, String username, String password) async {
     final clientInfo = await getClientInfo();
-    final authResponse = await http.post(
+    final authResponse = await sendRequestFollowingRedirects(
       Uri.parse('$serverUrl/Users/AuthenticateByName'),
+      method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'X-Emby-Authorization': clientInfo,
@@ -283,6 +286,8 @@ class JellyfinService extends MediaServerServiceBase
         'Username': username,
         'Pw': password,
       }),
+      timeout: const Duration(seconds: 30),
+      redirectLogLabel: 'JellyfinService',
     );
 
     if (authResponse.statusCode != 200) {
@@ -297,11 +302,13 @@ class JellyfinService extends MediaServerServiceBase
   /// 获取Jellyfin服务器ID，如果无法获取将抛出异常
   Future<String> _getJellyfinServerId(String url) async {
     try {
-      final response = await http
-          .get(
-            Uri.parse('$url/System/Info/Public'),
-          )
-          .timeout(const Duration(seconds: 5));
+      final response = await sendRequestFollowingRedirects(
+        Uri.parse('$url/System/Info/Public'),
+        method: 'GET',
+        headers: const {},
+        timeout: const Duration(seconds: 5),
+        redirectLogLabel: 'JellyfinService',
+      );
 
       if (response.statusCode == 200) {
         final data = json.decode(response.body);
@@ -320,11 +327,13 @@ class JellyfinService extends MediaServerServiceBase
   /// 获取服务器名称
   Future<String?> _getServerName(String url) async {
     try {
-      final response = await http
-          .get(
-            Uri.parse('$url/System/Info/Public'),
-          )
-          .timeout(const Duration(seconds: 5));
+      final response = await sendRequestFollowingRedirects(
+        Uri.parse('$url/System/Info/Public'),
+        method: 'GET',
+        headers: const {},
+        timeout: const Duration(seconds: 5),
+        redirectLogLabel: 'JellyfinService',
+      );
 
       if (response.statusCode == 200) {
         final data = json.decode(response.body);
@@ -424,9 +433,8 @@ class JellyfinService extends MediaServerServiceBase
         final data = json.decode(response.body);
         final List<dynamic> items = data['Items'] ?? [];
 
-        final results = items
-            .map((item) => JellyfinMediaItem.fromJson(item))
-            .toList();
+        final results =
+            items.map((item) => JellyfinMediaItem.fromJson(item)).toList();
 
         results.sort((a, b) {
           if (a.isFolder != b.isFolder) {
@@ -1057,9 +1065,9 @@ class JellyfinService extends MediaServerServiceBase
     }
 
     final enableTranscoding = transcodeEnabledCache &&
-      effectiveQuality != JellyfinVideoQuality.original;
+        effectiveQuality != JellyfinVideoQuality.original;
     final maxStreamingBitrate =
-      enableTranscoding ? effectiveQuality.bitrate : null;
+        enableTranscoding ? effectiveQuality.bitrate : null;
     final resolvedPlaySessionId = playSessionId;
 
     final deviceProfile = PlaybackDeviceProfileBuilder.build(
@@ -1150,7 +1158,7 @@ class JellyfinService extends MediaServerServiceBase
     String? requestedMediaSourceId,
   }) {
     final playSessionId =
-      forcedPlaySessionId ?? data['PlaySessionId']?.toString();
+        forcedPlaySessionId ?? data['PlaySessionId']?.toString();
     final rawSources = data['MediaSources'];
     final sources = <PlaybackMediaSource>[];
     if (rawSources is List) {
@@ -1179,7 +1187,9 @@ class JellyfinService extends MediaServerServiceBase
 
     bool useTranscoding = false;
     String? chosenUrl;
-    if (!forceDirectPlay && transcodingUrl != null && transcodingUrl.isNotEmpty) {
+    if (!forceDirectPlay &&
+        transcodingUrl != null &&
+        transcodingUrl.isNotEmpty) {
       if (preferTranscoding ||
           directStreamUrl == null ||
           directStreamUrl.isEmpty) {
@@ -1220,11 +1230,17 @@ class JellyfinService extends MediaServerServiceBase
   }
 
   String _resolvePlaybackUrl(String url) {
-    if (url.startsWith('http://') || url.startsWith('https://')) {
-      return url;
+    final uri = Uri.tryParse(url);
+    if (uri != null && (uri.scheme == 'http' || uri.scheme == 'https')) {
+      if (uri.host.isNotEmpty) {
+        return url;
+      }
+      if (_serverUrl != null && _serverUrl!.isNotEmpty) {
+        return Uri.parse(_serverUrl!).resolveUri(uri).toString();
+      }
     }
     final normalized = url.startsWith('/') ? url : '/$url';
-    return '$_serverUrl$normalized';
+    return Uri.parse(_serverUrl!).resolve(normalized).toString();
   }
 
   String? _resolveSubtitleMethod({
@@ -1256,9 +1272,8 @@ class JellyfinService extends MediaServerServiceBase
     String? mediaSourceId,
     String? playSessionId,
   }) {
-    final resolvedMediaSourceId = (mediaSourceId?.isNotEmpty ?? false)
-        ? mediaSourceId!
-        : itemId;
+    final resolvedMediaSourceId =
+        (mediaSourceId?.isNotEmpty ?? false) ? mediaSourceId! : itemId;
     final params = <String, String>{
       'static': 'true',
       'MediaSourceId': resolvedMediaSourceId,
@@ -1467,11 +1482,12 @@ class JellyfinService extends MediaServerServiceBase
     }
 
     int? resolvedIndex = subtitleStreamIndex;
-    final needsServerSubtitle = transcodeSettingsCache.subtitle.enableTranscoding &&
-        transcodeSettingsCache.subtitle.deliveryMethod !=
-            JellyfinSubtitleDeliveryMethod.external &&
-        transcodeSettingsCache.subtitle.deliveryMethod !=
-            JellyfinSubtitleDeliveryMethod.drop;
+    final needsServerSubtitle =
+        transcodeSettingsCache.subtitle.enableTranscoding &&
+            transcodeSettingsCache.subtitle.deliveryMethod !=
+                JellyfinSubtitleDeliveryMethod.external &&
+            transcodeSettingsCache.subtitle.deliveryMethod !=
+                JellyfinSubtitleDeliveryMethod.drop;
 
     if (resolvedIndex == null && needsServerSubtitle) {
       try {
@@ -1781,9 +1797,23 @@ class JellyfinService extends MediaServerServiceBase
       } else if (collectionType == 'movies') {
         includeItemTypes = ['Movie'];
       } else if (collectionType == 'mixed') {
-        includeItemTypes = ['Folder', 'Series', 'Season', 'Episode', 'Movie', 'Video'];
+        includeItemTypes = [
+          'Folder',
+          'Series',
+          'Season',
+          'Episode',
+          'Movie',
+          'Video'
+        ];
       } else {
-        includeItemTypes = ['Folder', 'Series', 'Season', 'Episode', 'Movie', 'Video'];
+        includeItemTypes = [
+          'Folder',
+          'Series',
+          'Season',
+          'Episode',
+          'Movie',
+          'Video'
+        ];
       }
 
       return await searchMediaItems(
@@ -1872,5 +1902,4 @@ class JellyfinService extends MediaServerServiceBase
     return makeAuthenticatedRequest(endpoint,
         method: method, body: body, timeout: timeout);
   }
-
 }

--- a/lib/services/media_server_service_base.dart
+++ b/lib/services/media_server_service_base.dart
@@ -640,6 +640,10 @@ abstract class MediaServerServiceBase {
       if (nextUri == null) {
         return response;
       }
+
+      if (!isAllowedRedirectTarget(currentUri, nextUri)) {
+        throw Exception('拒绝跨域重定向: $currentUri -> $nextUri');
+      }
       redirectCount += 1;
       if (redirectCount > _maxRedirects) {
         throw Exception('重定向次数过多: $currentUri');
@@ -697,6 +701,74 @@ abstract class MediaServerServiceBase {
       return null;
     }
     return currentUri.resolve(location.trim());
+  }
+
+  @protected
+  bool isAllowedRedirectTarget(Uri currentUri, Uri nextUri) {
+    final scheme = nextUri.scheme.toLowerCase();
+    if (scheme != 'http' && scheme != 'https') {
+      return false;
+    }
+
+    return currentUri.scheme.toLowerCase() == nextUri.scheme.toLowerCase() &&
+        currentUri.host.toLowerCase() == nextUri.host.toLowerCase() &&
+        currentUri.port == nextUri.port;
+  }
+
+  @protected
+  String resolveServerRelativeUrl(String serverUrl, String rawUrl) {
+    final baseUri = Uri.parse(serverUrl);
+    final trimmedRawUrl = rawUrl.trim();
+    if (trimmedRawUrl.isEmpty) {
+      return baseUri.toString();
+    }
+
+    final parsed = Uri.tryParse(trimmedRawUrl);
+    if (parsed != null &&
+        (parsed.scheme == 'http' || parsed.scheme == 'https') &&
+        parsed.host.isNotEmpty) {
+      return trimmedRawUrl;
+    }
+
+    final relativeText = trimmedRawUrl.startsWith('/')
+        ? trimmedRawUrl.substring(1)
+        : trimmedRawUrl;
+    final relativeUri = Uri.parse(relativeText);
+
+    final baseSegments = _normalizedPathSegments(baseUri.pathSegments);
+    final relativeSegments = _normalizedPathSegments(relativeUri.pathSegments);
+
+    final useRelativeAsAbsolute = baseSegments.isNotEmpty &&
+        _startsWithPathSegments(relativeSegments, baseSegments);
+    final mergedSegments = useRelativeAsAbsolute
+        ? relativeSegments
+        : <String>[...baseSegments, ...relativeSegments];
+
+    final mergedPath =
+        mergedSegments.isEmpty ? '/' : '/${mergedSegments.join('/')}';
+    return baseUri
+        .replace(
+          path: mergedPath,
+          query: relativeUri.hasQuery ? relativeUri.query : null,
+          fragment: relativeUri.hasFragment ? relativeUri.fragment : null,
+        )
+        .toString();
+  }
+
+  bool _startsWithPathSegments(List<String> path, List<String> prefix) {
+    if (prefix.length > path.length) {
+      return false;
+    }
+    for (var i = 0; i < prefix.length; i++) {
+      if (path[i] != prefix[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  List<String> _normalizedPathSegments(List<String> pathSegments) {
+    return pathSegments.where((segment) => segment.isNotEmpty).toList();
   }
 
   Uri _buildRequestUri(String path, {String? baseUrl}) {

--- a/lib/services/media_server_service_base.dart
+++ b/lib/services/media_server_service_base.dart
@@ -13,6 +13,8 @@ import 'media_server_device_id_service.dart';
 import 'dart:io' if (dart.library.io) 'dart:io';
 
 abstract class MediaServerServiceBase {
+  static const int _maxRedirects = 5;
+
   final MultiAddressServerService _multiAddressService =
       MultiAddressServerService.instance;
 
@@ -152,7 +154,8 @@ abstract class MediaServerServiceBase {
         final packageInfo = await PackageInfo.fromPlatform();
         appName =
             packageInfo.appName.isNotEmpty ? packageInfo.appName : 'NipaPlay';
-        version = packageInfo.version.isNotEmpty ? packageInfo.version : '1.4.9';
+        version =
+            packageInfo.version.isNotEmpty ? packageInfo.version : '1.4.9';
 
         platform = 'Flutter';
         if (!kIsWeb && !kDebugMode) {
@@ -296,8 +299,9 @@ abstract class MediaServerServiceBase {
 
     final normalizedUrl = normalizeUrl(serverUrl);
     final logService = DebugLogService();
-    final addressLabel =
-        (addressName == null || addressName.trim().isEmpty) ? '默认' : addressName.trim();
+    final addressLabel = (addressName == null || addressName.trim().isEmpty)
+        ? '默认'
+        : addressName.trim();
     logService.addLog(
       '$serviceName: 开始连接服务器 $normalizedUrl (用户: $username, 地址名: $addressLabel)',
       tag: 'Network',
@@ -467,8 +471,7 @@ abstract class MediaServerServiceBase {
         DebugLogService()
             .addLog('$serviceNameService: 已删除服务器配置文件 $currentProfileId');
       } catch (e) {
-        DebugLogService()
-            .addLog('$serviceNameService: 删除服务器配置文件失败: $e');
+        DebugLogService().addLog('$serviceNameService: 删除服务器配置文件失败: $e');
       }
     }
   }
@@ -498,32 +501,13 @@ abstract class MediaServerServiceBase {
 
     http.Response response;
     try {
-      switch (method.toUpperCase()) {
-        case 'GET':
-          response =
-              await http.get(uri, headers: headers).timeout(requestTimeout);
-          break;
-        case 'POST':
-          response = await http
-              .post(uri,
-                  headers: headers,
-                  body: body != null ? json.encode(body) : null)
-              .timeout(requestTimeout);
-          break;
-        case 'PUT':
-          response = await http
-              .put(uri,
-                  headers: headers,
-                  body: body != null ? json.encode(body) : null)
-              .timeout(requestTimeout);
-          break;
-        case 'DELETE':
-          response =
-              await http.delete(uri, headers: headers).timeout(requestTimeout);
-          break;
-        default:
-          throw Exception('不支持的 HTTP 方法: $method');
-      }
+      response = await _sendAuthenticatedRequest(
+        uri,
+        method: method,
+        headers: headers,
+        body: body,
+        timeout: requestTimeout,
+      );
     } catch (e) {
       if (e is TimeoutException) {
         throw Exception('请求$serviceName服务器超时: ${e.message}');
@@ -562,33 +546,13 @@ abstract class MediaServerServiceBase {
 
       try {
         http.Response response;
-        switch (method.toUpperCase()) {
-          case 'GET':
-            response =
-                await http.get(uri, headers: headers).timeout(requestTimeout);
-            break;
-          case 'POST':
-            response = await http
-                .post(uri,
-                    headers: headers,
-                    body: body != null ? json.encode(body) : null)
-                .timeout(requestTimeout);
-            break;
-          case 'PUT':
-            response = await http
-                .put(uri,
-                    headers: headers,
-                    body: body != null ? json.encode(body) : null)
-                .timeout(requestTimeout);
-            break;
-          case 'DELETE':
-            response = await http
-                .delete(uri, headers: headers)
-                .timeout(requestTimeout);
-            break;
-          default:
-            throw Exception('不支持的 HTTP 方法: $method');
-        }
+        response = await _sendAuthenticatedRequest(
+          uri,
+          method: method,
+          headers: headers,
+          body: body,
+          timeout: requestTimeout,
+        );
 
         if (response.statusCode < 400) {
           if (currentAddressId != address.id) {
@@ -628,6 +592,111 @@ abstract class MediaServerServiceBase {
     await _multiAddressService.updateProfile(currentProfile!);
 
     throw lastError ?? Exception('所有地址连接失败');
+  }
+
+  Future<http.Response> _sendAuthenticatedRequest(
+    Uri uri, {
+    required String method,
+    required Map<String, String> headers,
+    Map<String, dynamic>? body,
+    required Duration timeout,
+  }) async {
+    return sendRequestFollowingRedirects(
+      uri,
+      method: method,
+      headers: headers,
+      body: body != null ? json.encode(body) : null,
+      timeout: timeout,
+    );
+  }
+
+  @protected
+  Future<http.Response> sendRequestFollowingRedirects(
+    Uri uri, {
+    required String method,
+    required Map<String, String> headers,
+    String? body,
+    required Duration timeout,
+    String? redirectLogLabel,
+  }) async {
+    var currentUri = uri;
+    var currentMethod = method.toUpperCase();
+    var redirectCount = 0;
+
+    while (true) {
+      final response = await _sendSingleRequest(
+        currentUri,
+        method: currentMethod,
+        headers: headers,
+        body: body,
+        timeout: timeout,
+      );
+
+      if (!_isRedirectStatus(response.statusCode)) {
+        return response;
+      }
+
+      final nextUri = _resolveRedirectUri(currentUri, response);
+      if (nextUri == null) {
+        return response;
+      }
+      redirectCount += 1;
+      if (redirectCount > _maxRedirects) {
+        throw Exception('重定向次数过多: $currentUri');
+      }
+
+      if (response.statusCode == 303) {
+        currentMethod = 'GET';
+      }
+      DebugLogService().addLog(
+          '${redirectLogLabel ?? serviceNameService}: 跟随HTTP ${response.statusCode}重定向: $currentUri -> $nextUri');
+      currentUri = nextUri;
+    }
+  }
+
+  Future<http.Response> _sendSingleRequest(
+    Uri uri, {
+    required String method,
+    required Map<String, String> headers,
+    String? body,
+    required Duration timeout,
+  }) async {
+    final request = http.Request(method, uri)
+      ..followRedirects = false
+      ..headers.addAll(headers);
+
+    switch (method) {
+      case 'GET':
+      case 'DELETE':
+        break;
+      case 'POST':
+      case 'PUT':
+        if (body != null) {
+          request.body = body;
+        }
+        break;
+      default:
+        throw Exception('不支持的 HTTP 方法: $method');
+    }
+
+    final streamedResponse = await request.send().timeout(timeout);
+    return http.Response.fromStream(streamedResponse).timeout(timeout);
+  }
+
+  bool _isRedirectStatus(int statusCode) {
+    return statusCode == 301 ||
+        statusCode == 302 ||
+        statusCode == 303 ||
+        statusCode == 307 ||
+        statusCode == 308;
+  }
+
+  Uri? _resolveRedirectUri(Uri currentUri, http.Response response) {
+    final location = response.headers['location'];
+    if (location == null || location.trim().isEmpty) {
+      return null;
+    }
+    return currentUri.resolve(location.trim());
   }
 
   Uri _buildRequestUri(String path, {String? baseUrl}) {
@@ -751,9 +820,8 @@ abstract class MediaServerServiceBase {
         final originalUrl = serverUrl;
         serverUrl = address.normalizedUrl;
 
-        final authResponse =
-            await makeAuthenticatedRequest(systemInfoPath)
-                .timeout(const Duration(seconds: 5));
+        final authResponse = await makeAuthenticatedRequest(systemInfoPath)
+            .timeout(const Duration(seconds: 5));
 
         if (authResponse.statusCode == 200) {
           currentAddressId = address.id;
@@ -803,7 +871,8 @@ abstract class MediaServerServiceBase {
     selectedLibraryIds = libraryIds;
 
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setStringList('${prefsKeyPrefix}_selected_libraries', libraryIds);
+    await prefs.setStringList(
+        '${prefsKeyPrefix}_selected_libraries', libraryIds);
   }
 
   void setTranscodePreferences(

--- a/lib/themes/cupertino/pages/cupertino_media_server_detail_page.dart
+++ b/lib/themes/cupertino/pages/cupertino_media_server_detail_page.dart
@@ -18,7 +18,7 @@ import 'package:nipaplay/services/jellyfin_dandanplay_matcher.dart';
 import 'package:nipaplay/services/jellyfin_service.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/cached_network_image_widget.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/network_media_server_dialog.dart'
-  show MediaServerType;
+    show MediaServerType;
 import 'package:nipaplay/themes/nipaplay/widgets/blur_dialog.dart';
 import 'package:nipaplay/services/playback_service.dart';
 import 'package:nipaplay/models/playable_item.dart';
@@ -389,8 +389,10 @@ class _CupertinoMediaServerDetailPageState
           ),
         );
         if (historyItem != null) {
-          final jellyfinId = historyItem.filePath.replaceFirst('jellyfin://', '');
-          playbackSession = await JellyfinService.instance.createPlaybackSession(
+          final jellyfinId =
+              historyItem.filePath.replaceFirst('jellyfin://', '');
+          playbackSession =
+              await JellyfinService.instance.createPlaybackSession(
             itemId: jellyfinId,
             startPositionMs:
                 historyItem.lastPosition > 0 ? historyItem.lastPosition : null,
@@ -491,8 +493,8 @@ class _CupertinoMediaServerDetailPageState
     final posterUrl = _getPosterUrl();
     final episodeCount = _isMovie
         ? 1
-        : _episodesBySeasonId.values.fold<int>(
-            0, (sum, list) => sum + list.length);
+        : _episodesBySeasonId.values
+            .fold<int>(0, (sum, list) => sum + list.length);
 
     return SharedRemoteAnimeSummary(
       animeId: widget.mediaId.hashCode,
@@ -524,8 +526,8 @@ class _CupertinoMediaServerDetailPageState
       return const [];
     }
     return _seasons
-        .map((season) =>
-            CupertinoDetailSeason(id: season.id, name: season.name))
+        .map(
+            (season) => CupertinoDetailSeason(id: season.id, name: season.name))
         .toList();
   }
 
@@ -1079,16 +1081,14 @@ class _CupertinoMediaServerDetailPageState
           },
           children: <int, Widget>{
             0: Padding(
-              padding:
-                  const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+              padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
               child: Text(
                 '简介',
                 style: TextStyle(color: segmentLabelColor),
               ),
             ),
             1: Padding(
-              padding:
-                  const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+              padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
               child: Text(
                 '剧集',
                 style: TextStyle(color: segmentLabelColor),
@@ -1398,25 +1398,26 @@ class _CupertinoMediaServerDetailPageState
                 padding: const EdgeInsets.only(right: 10),
                 child: GestureDetector(
                   onTap: () => _loadEpisodesForSeason(season.id),
-                  child: AnimatedContainer(
-                    duration: const Duration(milliseconds: 200),
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 16,
-                      vertical: 8,
-                    ),
-                    decoration: BoxDecoration(
-                      color: selected
-                          ? activeColor
-                          : chipBackgroundColor,
-                      borderRadius: BorderRadius.circular(20),
-                    ),
-                    child: Text(
-                      season.name,
-                      style: TextStyle(
-                        color: selected
-                            ? CupertinoColors.white
-                            : labelColor,
-                        fontSize: 14,
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(maxWidth: 180),
+                    child: AnimatedContainer(
+                      duration: const Duration(milliseconds: 200),
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 16,
+                        vertical: 8,
+                      ),
+                      decoration: BoxDecoration(
+                        color: selected ? activeColor : chipBackgroundColor,
+                        borderRadius: BorderRadius.circular(20),
+                      ),
+                      child: Text(
+                        season.name,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          color: selected ? CupertinoColors.white : labelColor,
+                          fontSize: 14,
+                        ),
                       ),
                     ),
                   ),

--- a/lib/themes/cupertino/widgets/cupertino_shared_anime_detail_page.dart
+++ b/lib/themes/cupertino/widgets/cupertino_shared_anime_detail_page.dart
@@ -186,7 +186,8 @@ class _CupertinoSharedAnimeDetailPageState
       }
       _maybeLoadVividCover();
     });
-    BangumiApiService.loginStatusNotifier.addListener(_onBangumiLoginStatusChanged);
+    BangumiApiService.loginStatusNotifier
+        .addListener(_onBangumiLoginStatusChanged);
   }
 
   @override
@@ -891,8 +892,7 @@ class _CupertinoSharedAnimeDetailPageState
             ? widget.anime.nameCn!
             : widget.anime.name;
 
-    final action =
-        await showCupertinoDialog<_CupertinoEpisodeCleanupAction>(
+    final action = await showCupertinoDialog<_CupertinoEpisodeCleanupAction>(
       context: context,
       builder: (dialogContext) {
         return CupertinoAlertDialog(
@@ -940,9 +940,7 @@ class _CupertinoSharedAnimeDetailPageState
         );
         if (!mounted) return;
         _showSnack(
-          affectedCount > 0
-              ? '已清除 $affectedCount 条扫描结果'
-              : '没有可清除的扫描结果',
+          affectedCount > 0 ? '已清除 $affectedCount 条扫描结果' : '没有可清除的扫描结果',
           type: affectedCount > 0
               ? AdaptiveSnackBarType.success
               : AdaptiveSnackBarType.info,
@@ -953,9 +951,7 @@ class _CupertinoSharedAnimeDetailPageState
         );
         if (!mounted) return;
         _showSnack(
-          affectedCount > 0
-              ? '已删除 $affectedCount 条观看记录'
-              : '没有可删除的观看记录',
+          affectedCount > 0 ? '已删除 $affectedCount 条观看记录' : '没有可删除的观看记录',
           type: affectedCount > 0
               ? AdaptiveSnackBarType.success
               : AdaptiveSnackBarType.info,
@@ -965,8 +961,7 @@ class _CupertinoSharedAnimeDetailPageState
       await _refreshWatchHistoryProvider();
     } catch (e) {
       if (mounted) {
-        _showSnack('操作失败: ${e.toString()}',
-            type: AdaptiveSnackBarType.error);
+        _showSnack('操作失败: ${e.toString()}', type: AdaptiveSnackBarType.error);
       }
     } finally {
       if (mounted) {
@@ -2573,24 +2568,29 @@ class _CupertinoSharedAnimeDetailPageState
         itemBuilder: (context, index) {
           final season = seasons[index];
           final isSelected = season.id == selectedId;
-          return CupertinoButton(
-            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
-            minSize: 0,
-            color: isSelected
-                ? selectedColor.withOpacity(0.15)
-                : backgroundColor,
-            borderRadius: BorderRadius.circular(12),
-            onPressed: widget.onSeasonChanged == null
-                ? null
-                : () => widget.onSeasonChanged!(season.id),
-            child: Text(
-              season.name,
-              style: TextStyle(
-                fontSize: 12,
-                color: isSelected
-                    ? selectedColor
-                    : CupertinoDynamicColor.resolve(
-                        CupertinoColors.label, context),
+          return ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 160),
+            child: CupertinoButton(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+              minSize: 0,
+              color: isSelected
+                  ? selectedColor.withOpacity(0.15)
+                  : backgroundColor,
+              borderRadius: BorderRadius.circular(12),
+              onPressed: widget.onSeasonChanged == null
+                  ? null
+                  : () => widget.onSeasonChanged!(season.id),
+              child: Text(
+                season.name,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  fontSize: 12,
+                  color: isSelected
+                      ? selectedColor
+                      : CupertinoDynamicColor.resolve(
+                          CupertinoColors.label, context),
+                ),
               ),
             ),
           );
@@ -2809,8 +2809,8 @@ class _CupertinoSharedAnimeDetailPageState
                                             color: resolvedCardColor,
                                             child: const Icon(
                                               CupertinoIcons.person,
-                                              color:
-                                                  CupertinoColors.secondaryLabel,
+                                              color: CupertinoColors
+                                                  .secondaryLabel,
                                             ),
                                           ),
                                         )
@@ -2818,7 +2818,8 @@ class _CupertinoSharedAnimeDetailPageState
                                           color: resolvedCardColor,
                                           child: const Icon(
                                             CupertinoIcons.person,
-                                            color: CupertinoColors.secondaryLabel,
+                                            color:
+                                                CupertinoColors.secondaryLabel,
                                           ),
                                         ),
                                 ),
@@ -2855,7 +2856,8 @@ class _CupertinoSharedAnimeDetailPageState
                       child: CupertinoActivityIndicator(),
                     ),
                   )
-                else if (widget.enableBangumiFeatures && _bangumiAnime != null) ...[
+                else if (widget.enableBangumiFeatures &&
+                    _bangumiAnime != null) ...[
                   // 制作信息
                   if (_bangumiAnime!.metadata != null &&
                       _bangumiAnime!.metadata!.isNotEmpty) ...[
@@ -3356,7 +3358,8 @@ class _CupertinoSharedAnimeDetailPageState
               ),
               const Spacer(),
               CupertinoButton(
-                padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
                 minSize: 0,
                 onPressed: () {
                   setState(() {
@@ -3923,7 +3926,8 @@ class _CupertinoSharedAnimeDetailPageState
 
   @override
   void dispose() {
-    BangumiApiService.loginStatusNotifier.removeListener(_onBangumiLoginStatusChanged);
+    BangumiApiService.loginStatusNotifier
+        .removeListener(_onBangumiLoginStatusChanged);
     _scrollController.dispose();
     super.dispose();
   }

--- a/lib/themes/nipaplay/widgets/hover_scale_text_button.dart
+++ b/lib/themes/nipaplay/widgets/hover_scale_text_button.dart
@@ -53,7 +53,8 @@ class _HoverScaleTextButtonState extends State<HoverScaleTextButton> {
         _isHovered && isEnabled ? widget.hoverColor : resolvedBaseColor;
     final TextStyle defaultStyle =
         Theme.of(context).textTheme.labelLarge ?? const TextStyle(fontSize: 14);
-    final TextStyle effectiveBaseStyle = childTextStyle ?? widget.textStyle ?? defaultStyle;
+    final TextStyle effectiveBaseStyle =
+        childTextStyle ?? widget.textStyle ?? defaultStyle;
 
     final Widget content = _buildContent(
       textColor: textColor,
@@ -67,12 +68,12 @@ class _HoverScaleTextButtonState extends State<HoverScaleTextButton> {
       child: GestureDetector(
         onTap: widget.onPressed,
         behavior: HitTestBehavior.opaque,
-        child: AnimatedScale(
-          scale: _isHovered && isEnabled ? widget.hoverScale : 1.0,
-          duration: widget.duration,
-          curve: widget.curve,
-          child: Padding(
-            padding: widget.padding,
+        child: Padding(
+          padding: widget.padding,
+          child: AnimatedScale(
+            scale: _isHovered && isEnabled ? widget.hoverScale : 1.0,
+            duration: widget.duration,
+            curve: widget.curve,
             child: content,
           ),
         ),

--- a/lib/themes/nipaplay/widgets/library_management_tab.dart
+++ b/lib/themes/nipaplay/widgets/library_management_tab.dart
@@ -11,14 +11,12 @@ import 'package:glassmorphism/glassmorphism.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_snackbar.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/hover_scale_text_button.dart';
 import 'package:nipaplay/services/scan_service.dart';
-import 'package:path_provider/path_provider.dart';
 import 'package:kmbal_ionicons/kmbal_ionicons.dart'; // Import Ionicons
 import 'package:nipaplay/services/file_picker_service.dart';
 import 'package:nipaplay/utils/storage_service.dart'; // 导入StorageService
 import 'package:permission_handler/permission_handler.dart'; // 导入权限处理库
 import 'package:nipaplay/utils/android_storage_helper.dart'; // 导入Android存储辅助类
 import 'package:nipaplay/providers/appearance_settings_provider.dart';
-import 'package:nipaplay/utils/globals.dart'; // 导入全局变量和设备检测函数
 // Import MethodChannel
 import 'package:shared_preferences/shared_preferences.dart'; // Import SharedPreferences
 import 'package:nipaplay/services/manual_danmaku_matcher.dart'; // 导入手动弹幕匹配器
@@ -424,10 +422,12 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
       // 获取Android版本
       final int sdkVersion = await AndroidStorageHelper.getAndroidSDKVersion();
 
-      // Android 13+：使用媒体API扫描视频文件
+      // Android 13+ 先申请视频媒体权限，但仍允许用户手动选择目录。
       if (sdkVersion >= 33) {
-        await _scanAndroidMediaFolders();
-        return;
+        final videoStatus = await Permission.videos.request();
+        if (!videoStatus.isGranted && mounted) {
+          BlurSnackBar.show(context, '未授予视频媒体权限，将继续尝试通过系统文件夹选择器授权。');
+        }
       }
 
       // Android 13以下：允许自由选择文件夹
@@ -455,8 +455,7 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
         // 使用原生方法检查目录权限
         final dirCheck = await AndroidStorageHelper.checkDirectoryPermissions(
             selectedDirectory);
-        accessCheck =
-            dirCheck['canRead'] == true && dirCheck['canWrite'] == true;
+        accessCheck = dirCheck['canRead'] == true;
         debugPrint('Android目录权限检查结果: $dirCheck');
       } else {
         // 非Android平台使用Flutter方法检查
@@ -554,8 +553,11 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
       try {
         // 尝试读取文件夹内容以检查权限
         final dir = io.Directory(selectedDirectory);
-        await dir.list().first.timeout(const Duration(seconds: 2),
-            onTimeout: () {
+        await dir
+            .list(recursive: false, followLinks: false)
+            .take(1)
+            .toList()
+            .timeout(const Duration(seconds: 2), onTimeout: () {
           throw TimeoutException('无法访问文件夹');
         });
       } catch (e) {
@@ -1458,161 +1460,6 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
     } catch (e) {
       if (mounted) {
         BlurSnackBar.show(context, '检查权限状态失败: $e');
-      }
-    }
-  }
-
-  // 新增：用于Android 13+扫描媒体文件夹的方法
-  Future<void> _scanAndroidMediaFolders() async {
-    try {
-      // 请求媒体权限
-      await Permission.photos.request();
-      await Permission.videos.request();
-      await Permission.audio.request();
-
-      bool hasMediaPermissions = await Permission.photos.isGranted &&
-          await Permission.videos.isGranted &&
-          await Permission.audio.isGranted;
-
-      if (!hasMediaPermissions && mounted) {
-        BlurDialog.show<void>(
-          context: context,
-          title: "需要媒体权限",
-          content:
-              "NipaPlay需要访问媒体文件权限才能扫描视频文件。\n\n请在系统设置中允许NipaPlay访问照片、视频和音频权限。",
-          actions: <Widget>[
-            HoverScaleTextButton(
-              child: const Text("稍后再说",
-                  locale: Locale("zh-Hans", "zh"),
-                  style: TextStyle(color: Colors.white70)),
-              onPressed: () {
-                Navigator.of(context).pop();
-              },
-            ),
-            HoverScaleTextButton(
-              child: const Text("打开设置",
-                  locale: Locale("zh-Hans", "zh"),
-                  style: TextStyle(color: Colors.lightBlueAccent)),
-              onPressed: () {
-                Navigator.of(context).pop();
-                openAppSettings();
-              },
-            ),
-          ],
-        );
-        return;
-      }
-
-      // 显示加载提示
-      if (mounted) {
-        BlurSnackBar.show(context, '正在扫描视频文件夹，请稍候...');
-      }
-
-      // 获取系统媒体文件夹
-      final scanService = Provider.of<ScanService>(context, listen: false);
-      String? moviesPath;
-
-      // 尝试获取Movies目录路径
-      try {
-        final externalDirs = await getExternalStorageDirectories();
-        if (externalDirs != null && externalDirs.isNotEmpty) {
-          String baseDir = externalDirs[0].path;
-          baseDir = baseDir.substring(0, baseDir.indexOf('Android'));
-          final moviesDir = io.Directory('${baseDir}Movies');
-
-          if (await moviesDir.exists()) {
-            moviesPath = moviesDir.path;
-            debugPrint('找到Movies目录: $moviesPath');
-          }
-        }
-      } catch (e) {
-        debugPrint('无法获取Movies目录: $e');
-      }
-
-      // 如果没有找到Movies目录，尝试其他常用媒体目录
-      if (moviesPath == null) {
-        try {
-          final externalDirs = await getExternalStorageDirectories();
-          if (externalDirs != null && externalDirs.isNotEmpty) {
-            String baseDir = externalDirs[0].path;
-            baseDir = baseDir.substring(0, baseDir.indexOf('Android'));
-
-            // 检查DCIM目录
-            final dcimDir = io.Directory('${baseDir}DCIM');
-            if (await dcimDir.exists()) {
-              moviesPath = dcimDir.path;
-              debugPrint('找到DCIM目录: $moviesPath');
-            } else {
-              // 尝试Download目录
-              final downloadDir = io.Directory('${baseDir}Download');
-              if (await downloadDir.exists()) {
-                moviesPath = downloadDir.path;
-                debugPrint('找到Download目录: $moviesPath');
-              }
-            }
-          }
-        } catch (e) {
-          debugPrint('无法获取备选媒体目录: $e');
-        }
-      }
-
-      // 如果仍然没有找到任何媒体目录，提示用户
-      if (moviesPath == null && mounted) {
-        BlurDialog.show<void>(
-          context: context,
-          title: "未找到视频文件夹",
-          content: "无法找到系统视频文件夹。建议使用\"管理所有文件\"权限或手动选择文件夹。",
-          actions: <Widget>[
-            HoverScaleTextButton(
-              child: const Text("取消",
-                  locale: Locale("zh-Hans", "zh"),
-                  style: TextStyle(color: Colors.white70)),
-              onPressed: () {
-                Navigator.of(context).pop();
-              },
-            ),
-            HoverScaleTextButton(
-              child: const Text("开启完整权限",
-                  locale: Locale("zh-Hans", "zh"),
-                  style: TextStyle(color: Colors.lightBlueAccent)),
-              onPressed: () {
-                Navigator.of(context).pop();
-                AndroidStorageHelper.requestManageExternalStoragePermission();
-              },
-            ),
-          ],
-        );
-        return;
-      }
-
-      // 扫描找到的文件夹
-      if (moviesPath != null) {
-        try {
-          // 检查目录权限
-          final dirPerms =
-              await AndroidStorageHelper.checkDirectoryPermissions(moviesPath);
-          if (dirPerms['canRead'] == true) {
-            await scanService.startDirectoryScan(moviesPath,
-                skipPreviouslyMatchedUnwatched: false);
-            if (mounted) {
-              BlurSnackBar.show(context, '已扫描视频文件夹: ${p.basename(moviesPath)}');
-            }
-          } else {
-            if (mounted) {
-              BlurSnackBar.show(context, '无法读取视频文件夹，请检查权限设置');
-            }
-          }
-        } catch (e) {
-          if (mounted) {
-            BlurSnackBar.show(context,
-                '扫描视频文件夹失败: ${e.toString().substring(0, min(e.toString().length, 50))}');
-          }
-        }
-      }
-    } catch (e) {
-      if (mounted) {
-        BlurSnackBar.show(context,
-            '扫描视频文件夹时出错: ${e.toString().substring(0, min(e.toString().length, 50))}');
       }
     }
   }

--- a/lib/themes/nipaplay/widgets/tooltip_bubble.dart
+++ b/lib/themes/nipaplay/widgets/tooltip_bubble.dart
@@ -116,6 +116,8 @@ class _TooltipBubbleState extends State<TooltipBubble> {
       fontSize: 12,
       fontWeight: FontWeight.w500,
     );
+    final screenWidth = MediaQuery.of(context).size.width;
+    final maxWidth = (screenWidth - 20).clamp(80.0, 320.0);
     final textScaleFactor = MediaQuery.of(context).textScaleFactor;
     final textPainter = TextPainter(
       text: TextSpan(
@@ -125,29 +127,42 @@ class _TooltipBubbleState extends State<TooltipBubble> {
       textDirection: TextDirection.ltr,
       maxLines: 1,
       textScaleFactor: textScaleFactor,
-    )..layout(minWidth: 0, maxWidth: double.infinity);
+    )..layout(minWidth: 0, maxWidth: maxWidth - widget.padding * 2);
 
     // 增加额外的宽度，确保组合键能够完整显示
     final String lowerText = widget.text.toLowerCase();
+    double width;
     if (Platform.isWindows &&
         lowerText.contains('(') &&
         lowerText.contains(')')) {
       // 只在 Windows 端，如果文本包含括号（通常是快捷键），增加额外宽度
-      return textPainter.width + widget.padding * 2 + 20;
+      width = textPainter.width + widget.padding * 2 + 20;
     } else if (lowerText.contains('shift') ||
         lowerText.contains('ctrl') ||
         lowerText.contains('command') ||
         lowerText.contains('tab') ||
         lowerText.contains('alt') ||
         lowerText.contains('esc')) {
-      return textPainter.width + widget.padding * 2 + 20;
+      width = textPainter.width + widget.padding * 2 + 20;
     } else {
-      return textPainter.width + widget.padding * 2 + 4;
+      width = textPainter.width + widget.padding * 2 + 4;
     }
+    return width.clamp(48.0, maxWidth);
   }
 
   double _getBubbleHeight() {
-    return 30; // 固定高度，因为文字只有一行
+    const textStyle = TextStyle(
+      fontSize: 12,
+      fontWeight: FontWeight.w500,
+    );
+    final textScaleFactor = MediaQuery.of(context).textScaleFactor;
+    final textPainter = TextPainter(
+      text: TextSpan(text: widget.text, style: textStyle),
+      textDirection: TextDirection.ltr,
+      maxLines: 2,
+      textScaleFactor: textScaleFactor,
+    )..layout(maxWidth: _getBubbleWidth() - widget.padding * 2);
+    return (textPainter.height + 12).clamp(30.0, 48.0);
   }
 
   void _hideOverlay() {
@@ -220,8 +235,9 @@ class _TooltipBubbleState extends State<TooltipBubble> {
             child: Text(
               widget.text,
               style: textStyle,
-              maxLines: 1,
-              overflow: TextOverflow.visible,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              textAlign: TextAlign.center,
             ),
           ),
         ),
@@ -263,9 +279,9 @@ class _TooltipBubbleState extends State<TooltipBubble> {
                 child: Text(
                   widget.text,
                   style: textStyle,
-                  maxLines: 1,
-                  overflow: TextOverflow.visible,
-                  //textAlign: TextAlign.center,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  textAlign: TextAlign.center,
                 ),
               ),
             ),

--- a/lib/themes/nipaplay/widgets/video_upload_ui.dart
+++ b/lib/themes/nipaplay/widgets/video_upload_ui.dart
@@ -553,8 +553,8 @@ class _VideoUploadUIState extends State<VideoUploadUI>
         Future.microtask(() async {
           await videoState.initializePlayer(fileName, actualPlayUrl: url);
         });
-      } else if (globals.isPhone) {
-        // 手机端弹窗选择来源
+      } else if (io.Platform.isAndroid || io.Platform.isIOS) {
+        // 移动端弹窗选择来源，iPad 也需要显式相册入口。
         final source = await BlurDialog.show<String>(
           context: context,
           title: '选择来源',
@@ -739,8 +739,7 @@ class _VideoUploadUIState extends State<VideoUploadUI>
       videoState.setPreInitLoadingState('正在准备视频文件...');
 
       final picker = ImagePicker();
-      // 使用 pickMedia 因为你需要视频
-      final XFile? picked = await picker.pickMedia();
+      final XFile? picked = await picker.pickVideo(source: ImageSource.gallery);
       if (!mounted) return; // 再次检查 mounted
 
       if (picked != null) {

--- a/lib/utils/webdav_file_sorter.dart
+++ b/lib/utils/webdav_file_sorter.dart
@@ -1,0 +1,115 @@
+import 'package:nipaplay/providers/webdav_quick_access_provider.dart';
+import 'package:nipaplay/services/webdav_service.dart';
+
+class WebDAVFileSorter {
+  const WebDAVFileSorter._();
+
+  static void sort(List<WebDAVFile> files, WebDAVSortPreset preset) {
+    files.sort((a, b) => compare(a, b, preset));
+  }
+
+  static int compare(
+    WebDAVFile a,
+    WebDAVFile b,
+    WebDAVSortPreset preset,
+  ) {
+    switch (preset) {
+      case WebDAVSortPreset.defaultValue:
+        if (a.isDirectory != b.isDirectory) {
+          return a.isDirectory ? -1 : 1;
+        }
+        return naturalCompare(a.name, b.name);
+
+      case WebDAVSortPreset.nameAsc:
+        return naturalCompare(a.name, b.name);
+
+      case WebDAVSortPreset.nameDesc:
+        return naturalCompare(b.name, a.name);
+
+      case WebDAVSortPreset.modifiedDesc:
+        return _compareDateThenName(
+          b.lastModified,
+          a.lastModified,
+          a,
+          b,
+        );
+
+      case WebDAVSortPreset.modifiedAsc:
+        return _compareDateThenName(
+          a.lastModified,
+          b.lastModified,
+          a,
+          b,
+        );
+
+      case WebDAVSortPreset.sizeDesc:
+        return _compareNumberThenName(
+          b.size ?? 0,
+          a.size ?? 0,
+          a,
+          b,
+        );
+
+      case WebDAVSortPreset.sizeAsc:
+        return _compareNumberThenName(
+          a.size ?? 0,
+          b.size ?? 0,
+          a,
+          b,
+        );
+    }
+  }
+
+  static int naturalCompare(String a, String b) {
+    final aParts = _tokenize(a);
+    final bParts = _tokenize(b);
+    final minLength =
+        aParts.length < bParts.length ? aParts.length : bParts.length;
+
+    for (var i = 0; i < minLength; i++) {
+      final aPart = aParts[i];
+      final bPart = bParts[i];
+
+      final aNum = int.tryParse(aPart);
+      final bNum = int.tryParse(bPart);
+      if (aNum != null && bNum != null) {
+        final cmp = aNum.compareTo(bNum);
+        if (cmp != 0) return cmp;
+        final lengthCmp = aPart.length.compareTo(bPart.length);
+        if (lengthCmp != 0) return lengthCmp;
+      } else {
+        final cmp = aPart.toLowerCase().compareTo(bPart.toLowerCase());
+        if (cmp != 0) return cmp;
+      }
+    }
+
+    return aParts.length.compareTo(bParts.length);
+  }
+
+  static int _compareDateThenName(
+    DateTime? first,
+    DateTime? second,
+    WebDAVFile a,
+    WebDAVFile b,
+  ) {
+    final cmp = (first ?? DateTime.fromMillisecondsSinceEpoch(0)).compareTo(
+      second ?? DateTime.fromMillisecondsSinceEpoch(0),
+    );
+    return cmp != 0 ? cmp : naturalCompare(a.name, b.name);
+  }
+
+  static int _compareNumberThenName(
+    int first,
+    int second,
+    WebDAVFile a,
+    WebDAVFile b,
+  ) {
+    final cmp = first.compareTo(second);
+    return cmp != 0 ? cmp : naturalCompare(a.name, b.name);
+  }
+
+  static List<String> _tokenize(String value) {
+    final matches = RegExp(r'(\d+)|(\D+)').allMatches(value);
+    return matches.map((match) => match.group(0) ?? '').toList();
+  }
+}

--- a/test/media_server_service_base_test.dart
+++ b/test/media_server_service_base_test.dart
@@ -1,0 +1,158 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nipaplay/models/server_profile_model.dart';
+import 'package:nipaplay/services/media_server_service_base.dart';
+
+class _TestMediaServerService extends MediaServerServiceBase {
+  @override
+  String get serviceName => 'Test';
+
+  @override
+  String get serviceType => 'test';
+
+  @override
+  String get prefsKeyPrefix => 'test';
+
+  @override
+  String get serverNameFallback => 'Test Server';
+
+  @override
+  String get notConnectedMessage => 'Not connected';
+
+  @override
+  String? serverUrl;
+
+  @override
+  String? username;
+
+  @override
+  String? password;
+
+  @override
+  String? accessToken;
+
+  @override
+  String? userId;
+
+  @override
+  bool isConnected = false;
+
+  @override
+  bool isReady = false;
+
+  @override
+  List<String> selectedLibraryIds = <String>[];
+
+  @override
+  ServerProfile? currentProfile;
+
+  @override
+  String? currentAddressId;
+
+  @override
+  String normalizeRequestPath(String path) => path;
+
+  @override
+  Future<bool> testConnection(
+      String url, String username, String password) async {
+    return true;
+  }
+
+  @override
+  Future<void> performAuthentication(
+      String serverUrl, String username, String password) async {}
+
+  @override
+  Future<String> getServerId(String url) async => 'server-id';
+
+  @override
+  Future<String?> getServerName(String url) async => 'server-name';
+
+  @override
+  Future<void> loadAvailableLibraries() async {}
+
+  @override
+  Future<void> loadTranscodeSettings() async {}
+
+  @override
+  void clearServiceData() {}
+
+  String resolveRelative(String baseUrl, String rawUrl) {
+    return resolveServerRelativeUrl(baseUrl, rawUrl);
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('resolveServerRelativeUrl', () {
+    final service = _TestMediaServerService();
+
+    test('preserves base path when resolving root-like relative path', () {
+      final result = service.resolveRelative(
+        'https://host/emby',
+        '/Videos/1/stream?api_key=abc',
+      );
+      expect(result, 'https://host/emby/Videos/1/stream?api_key=abc');
+    });
+
+    test('keeps absolute url unchanged', () {
+      final result = service.resolveRelative(
+        'https://host/emby',
+        'https://cdn.example.com/video.m3u8',
+      );
+      expect(result, 'https://cdn.example.com/video.m3u8');
+    });
+
+    test('avoids duplicating base path when response already includes it', () {
+      final result = service.resolveRelative(
+        'https://host/emby',
+        '/emby/Videos/1/stream',
+      );
+      expect(result, 'https://host/emby/Videos/1/stream');
+    });
+  });
+
+  group('isAllowedRedirectTarget', () {
+    final service = _TestMediaServerService();
+
+    test('allows same-origin redirect', () {
+      final allowed = service.isAllowedRedirectTarget(
+        Uri.parse('https://host/emby/start'),
+        Uri.parse('https://host/emby/final'),
+      );
+      expect(allowed, isTrue);
+    });
+
+    test('blocks different host', () {
+      final allowed = service.isAllowedRedirectTarget(
+        Uri.parse('https://host/emby/start'),
+        Uri.parse('https://evil.example.com/steal'),
+      );
+      expect(allowed, isFalse);
+    });
+
+    test('blocks different scheme', () {
+      final allowed = service.isAllowedRedirectTarget(
+        Uri.parse('https://host/emby/start'),
+        Uri.parse('http://host/emby/start'),
+      );
+      expect(allowed, isFalse);
+    });
+
+    test('blocks different port', () {
+      final allowed = service.isAllowedRedirectTarget(
+        Uri.parse('https://host:8443/emby/start'),
+        Uri.parse('https://host/emby/start'),
+      );
+      expect(allowed, isFalse);
+    });
+
+    test('blocks non-http scheme', () {
+      final allowed = service.isAllowedRedirectTarget(
+        Uri.parse('https://host/emby/start'),
+        Uri.parse('ftp://host/file'),
+      );
+      expect(allowed, isFalse);
+    });
+  });
+}

--- a/test/webdav_file_sorter_test.dart
+++ b/test/webdav_file_sorter_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nipaplay/providers/webdav_quick_access_provider.dart';
+import 'package:nipaplay/services/webdav_service.dart';
+import 'package:nipaplay/utils/webdav_file_sorter.dart';
+
+void main() {
+  group('WebDAVFileSorter', () {
+    test('keeps folders first and sorts names naturally by default', () {
+      final files = [
+        WebDAVFile(
+            name: 'Episode 10.mkv',
+            path: '/Episode 10.mkv',
+            isDirectory: false),
+        WebDAVFile(name: 'Season 2', path: '/Season 2', isDirectory: true),
+        WebDAVFile(
+            name: 'Episode 2.mkv', path: '/Episode 2.mkv', isDirectory: false),
+        WebDAVFile(name: 'Season 10', path: '/Season 10', isDirectory: true),
+      ];
+
+      WebDAVFileSorter.sort(files, WebDAVSortPreset.defaultValue);
+
+      expect(
+        files.map((file) => file.name),
+        ['Season 2', 'Season 10', 'Episode 2.mkv', 'Episode 10.mkv'],
+      );
+    });
+
+    test('sorts by modified time with stable name fallback', () {
+      final files = [
+        WebDAVFile(
+          name: 'Episode 10.mkv',
+          path: '/Episode 10.mkv',
+          isDirectory: false,
+          lastModified: DateTime(2026, 1, 1),
+        ),
+        WebDAVFile(
+          name: 'Episode 2.mkv',
+          path: '/Episode 2.mkv',
+          isDirectory: false,
+          lastModified: DateTime(2026, 1, 1),
+        ),
+        WebDAVFile(
+          name: 'Episode 1.mkv',
+          path: '/Episode 1.mkv',
+          isDirectory: false,
+          lastModified: DateTime(2026, 1, 2),
+        ),
+      ];
+
+      WebDAVFileSorter.sort(files, WebDAVSortPreset.modifiedDesc);
+
+      expect(
+        files.map((file) => file.name),
+        ['Episode 1.mkv', 'Episode 2.mkv', 'Episode 10.mkv'],
+      );
+    });
+  });
+}

--- a/test/webdav_quick_access_provider_test.dart
+++ b/test/webdav_quick_access_provider_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nipaplay/providers/webdav_quick_access_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group('WebDAVQuickAccessProvider', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    test('loads WebDAV as effective default tab when enabled', () async {
+      SharedPreferences.setMockInitialValues({
+        'show_webdav_tab': true,
+        'default_home_tab': WebDAVQuickAccessProvider.tabWebDAV,
+      });
+
+      final provider = WebDAVQuickAccessProvider();
+      await provider.loadSettings();
+
+      expect(provider.defaultHomeTab, WebDAVQuickAccessProvider.tabWebDAV);
+      expect(provider.effectiveDefaultHomeTab,
+          WebDAVQuickAccessProvider.tabWebDAV);
+    });
+
+    test('falls back to home when WebDAV default tab is disabled', () async {
+      SharedPreferences.setMockInitialValues({
+        'show_webdav_tab': false,
+        'default_home_tab': WebDAVQuickAccessProvider.tabWebDAV,
+      });
+
+      final provider = WebDAVQuickAccessProvider();
+      await provider.loadSettings();
+
+      expect(provider.defaultHomeTab, WebDAVQuickAccessProvider.tabWebDAV);
+      expect(
+          provider.effectiveDefaultHomeTab, WebDAVQuickAccessProvider.tabHome);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Fix Android file-manager video open handling and running-app intents.
- Follow Emby/Jellyfin redirects for auth/API/playback URLs.
- Add natural WebDAV sorting and focused tests.
- Constrain tooltip/season labels and improve Android/iOS media selection flows.

## Closes
Closes #429
Closes #425
Closes #393
Closes #297
Closes #332
Closes #426
Closes #456

## Tests
- flutter test test/webdav_file_sorter_test.dart test/webdav_quick_access_provider_test.dart
- git diff --check
- dart analyze ... has existing warnings/info in the repo
- Android assembleDebug blocked by media-kit jar MD5 verification