### PR TITLE
ci(windows): fix fvp mdk-sdk download URL

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -18,7 +18,7 @@ jobs:
       version: ${{ steps.setup.outputs.version }}
       artifact-name: release-Windows-x64
     env:
-      FVP_DEPS_URL: https://github.com/wang-bin/mdk-sdk/releases/latest/download/
+      FVP_DEPS_URL: https://sourceforge.net/projects/mdk-sdk/files/nightly
       FVP_DEPS_LATEST: 1
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- Fix Windows CI failure in fvp dependency download
- Switch FVP_DEPS_URL for Windows workflow from GitHub latest releases to SourceForge nightly

## Root Cause
fvp 0.33.1 expects mdk-sdk-windows-desktop-vs2022-x64.7z, but wang-bin/mdk-sdk latest GitHub release currently no longer contains that filename, causing a 404 and extraction failure.

## Validation
- Verified SourceForge nightly URL currently serves mdk-sdk-windows-desktop-vs2022-x64.7z
- Change is scoped to .github/workflows/build-windows.yml only

## Notes
This is a targeted Windows-only CI fix; other platform workflows are unchanged.