### PR TITLE
Set no-shadow as default danmaku shadow style on mobile

### DIFF
--- a/lib/utils/video_player_state.dart
+++ b/lib/utils/video_player_state.dart
@@ -462,7 +462,9 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
   final String _danmakuOutlineStyleKey = 'danmaku_outline_style';
   DanmakuOutlineStyle _danmakuOutlineStyle = DanmakuOutlineStyle.uniform;
   final String _danmakuShadowStyleKey = 'danmaku_shadow_style';
-  DanmakuShadowStyle _danmakuShadowStyle = DanmakuShadowStyle.strong;
+  DanmakuShadowStyle _danmakuShadowStyle = globals.isMobilePlatform
+      ? DanmakuShadowStyle.none
+      : DanmakuShadowStyle.strong;
   static const double minSubtitleScale = 0.5;
   static const double maxSubtitleScale = 2.5;
   static const double defaultSubtitleScale = 1.0;

--- a/lib/utils/video_player_state/video_player_state_preferences.dart
+++ b/lib/utils/video_player_state/video_player_state_preferences.dart
@@ -1211,7 +1211,9 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     if (index == null ||
         index < 0 ||
         index >= DanmakuShadowStyle.values.length) {
-      return DanmakuShadowStyle.strong;
+      return globals.isMobilePlatform
+          ? DanmakuShadowStyle.none
+          : DanmakuShadowStyle.strong;
     }
     return DanmakuShadowStyle.values[index];
   }


### PR DESCRIPTION
## Summary
- set default danmaku shadow style to none on mobile platforms (iOS/Android)
- keep desktop default as strong
- apply this default both for in-memory init and prefs fallback resolution

## Notes
- existing user preference is preserved if already stored
- this change affects only first-time or missing-preference behavior