### PR TITLE
feat: Cupertino 开发者设置支持系统资源监控开关

### DIFF
--- a/lib/themes/cupertino/pages/settings/pages/cupertino_developer_options_page.dart
+++ b/lib/themes/cupertino/pages/settings/pages/cupertino_developer_options_page.dart
@@ -77,6 +77,25 @@ class CupertinoDeveloperOptionsPage extends StatelessWidget {
                     children: [
                       CupertinoSettingsTile(
                         leading: Icon(
+                          CupertinoIcons.speedometer,
+                          color: resolveSettingsIconColor(context),
+                        ),
+                        title: const Text('显示系统资源监控'),
+                        subtitle: const Text('在界面右上角显示 CPU、内存和帧率信息'),
+                        trailing: AdaptiveSwitch(
+                          value: devOptions.showSystemResources,
+                          onChanged: (value) async {
+                            await devOptions.setShowSystemResources(value);
+                          },
+                        ),
+                        onTap: () async {
+                          final newValue = !devOptions.showSystemResources;
+                          await devOptions.setShowSystemResources(newValue);
+                        },
+                        backgroundColor: resolveSettingsTileBackground(context),
+                      ),
+                      CupertinoSettingsTile(
+                        leading: Icon(
                           CupertinoIcons.command,
                           color: resolveSettingsIconColor(context),
                         ),


### PR DESCRIPTION
## 背景
Cupertino 主题的开发者设置页面缺少系统资源监控开关，导致无法在该主题下直接启用顶部性能监视（CPU/内存/FPS）显示。

## 变更
- 在 CupertinoDeveloperOptionsPage 新增设置项
- 标题：显示系统资源监控
- 描述：在界面右上角显示 CPU、内存和帧率信息
- 交互：支持 switch 切换和整行点击切换
- 开关复用 DeveloperOptionsProvider.setShowSystemResources，并沿用现有持久化逻辑

## 验证
- flutter analyze lib/themes/cupertino/pages/settings/pages/cupertino_developer_options_page.dart
- 结果：No issues found