### PR TITLE
fix(linux): remove per-frame EGL context switches in media_kit video path

### DIFF
--- a/packages/media_kit_video/linux/texture_gl.cc
+++ b/packages/media_kit_video/linux/texture_gl.cc
@@ -11,38 +11,10 @@
 #include <epoxy/gl.h>
 #include <epoxy/egl.h>
 
-// EGLImage extension function pointers
-typedef EGLImageKHR (*PFNEGLCREATEIMAGEKHRPROC)(EGLDisplay dpy, EGLContext ctx, EGLenum target, EGLClientBuffer buffer, const EGLint *attrib_list);
-typedef EGLBoolean (*PFNEGLDESTROYIMAGEKHRPROC)(EGLDisplay dpy, EGLImageKHR image);
-typedef void (*PFNGLEGLIMAGETARGETTEXTURE2DOESPROC)(GLenum target, GLeglImageOES image);
-
-// Define the extension functions
-#ifndef eglCreateImageKHR
-static PFNEGLCREATEIMAGEKHRPROC eglCreateImageKHR = NULL;
-#endif
-#ifndef eglDestroyImageKHR
-static PFNEGLDESTROYIMAGEKHRPROC eglDestroyImageKHR = NULL;
-#endif
-#ifndef glEGLImageTargetTexture2DOES
-static PFNGLEGLIMAGETARGETTEXTURE2DOESPROC glEGLImageTargetTexture2DOES = NULL;
-#endif
-
-static void init_egl_image_extensions() {
-  static gboolean initialized = FALSE;
-  if (!initialized) {
-    eglCreateImageKHR = (PFNEGLCREATEIMAGEKHRPROC)eglGetProcAddress("eglCreateImageKHR");
-    eglDestroyImageKHR = (PFNEGLDESTROYIMAGEKHRPROC)eglGetProcAddress("eglDestroyImageKHR");
-    glEGLImageTargetTexture2DOES = (PFNGLEGLIMAGETARGETTEXTURE2DOESPROC)eglGetProcAddress("glEGLImageTargetTexture2DOES");
-    initialized = TRUE;
-  }
-}
-
 struct _TextureGL {
   FlTextureGL parent_instance;
-  guint32 name;              // Flutter's texture name
-  guint32 fbo;               // mpv's FBO
-  guint32 mpv_texture;       // mpv's texture
-  EGLImageKHR egl_image;     // EGLImage for sharing between contexts
+  guint32 name;              // Flutter-owned texture name
+  guint32 fbo;               // FBO attached to |name|
   guint32 current_width;
   guint32 current_height;
   VideoOutput* video_output;
@@ -53,8 +25,6 @@ G_DEFINE_TYPE(TextureGL, texture_gl, fl_texture_gl_get_type())
 static void texture_gl_init(TextureGL* self) {
   self->name = 0;
   self->fbo = 0;
-  self->mpv_texture = 0;
-  self->egl_image = EGL_NO_IMAGE_KHR;
   self->current_width = 1;
   self->current_height = 1;
   self->video_output = NULL;
@@ -62,49 +32,17 @@ static void texture_gl_init(TextureGL* self) {
 
 static void texture_gl_dispose(GObject* object) {
   TextureGL* self = TEXTURE_GL(object);
-  VideoOutput* video_output = self->video_output;
-  
-  // Save current context
-  EGLDisplay current_display = eglGetCurrentDisplay();
-  EGLContext current_context = eglGetCurrentContext();
-  EGLSurface current_draw = eglGetCurrentSurface(EGL_DRAW);
-  EGLSurface current_read = eglGetCurrentSurface(EGL_READ);
-  
-  // Clean up Flutter's texture (in Flutter's context)
+
   if (self->name != 0) {
     glDeleteTextures(1, &self->name);
     self->name = 0;
   }
-  
-  // Clean up EGLImage
-  if (self->egl_image != EGL_NO_IMAGE_KHR && video_output != NULL) {
-    EGLDisplay egl_display = video_output_get_egl_display(video_output);
-    eglDestroyImageKHR(egl_display, self->egl_image);
-    self->egl_image = EGL_NO_IMAGE_KHR;
+
+  if (self->fbo != 0) {
+    glDeleteFramebuffers(1, &self->fbo);
+    self->fbo = 0;
   }
-  
-  // Clean up mpv's OpenGL resources (in mpv's isolated context)
-  if (video_output != NULL) {
-    EGLDisplay egl_display = video_output_get_egl_display(video_output);
-    EGLContext egl_context = video_output_get_egl_context(video_output);
-    
-    if (egl_context != EGL_NO_CONTEXT) {
-      eglMakeCurrent(egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE, egl_context);
-      
-      if (self->mpv_texture != 0) {
-        glDeleteTextures(1, &self->mpv_texture);
-        self->mpv_texture = 0;
-      }
-      if (self->fbo != 0) {
-        glDeleteFramebuffers(1, &self->fbo);
-        self->fbo = 0;
-      }
-      
-      // Restore previous context
-      eglMakeCurrent(current_display, current_draw, current_read, current_context);
-    }
-  }
-  
+
   self->current_width = 1;
   self->current_height = 1;
   self->video_output = NULL;
@@ -117,10 +55,46 @@ static void texture_gl_class_init(TextureGLClass* klass) {
 }
 
 TextureGL* texture_gl_new(VideoOutput* video_output) {
-  init_egl_image_extensions();
   TextureGL* self = TEXTURE_GL(g_object_new(texture_gl_get_type(), NULL));
   self->video_output = video_output;
   return self;
+}
+
+static void texture_gl_create_or_resize(TextureGL* self,
+                                        guint32 required_width,
+                                        guint32 required_height) {
+  GLint previous_fbo = 0;
+  GLint previous_texture = 0;
+  glGetIntegerv(GL_FRAMEBUFFER_BINDING, &previous_fbo);
+  glGetIntegerv(GL_TEXTURE_BINDING_2D, &previous_texture);
+
+  if (self->name != 0) {
+    glDeleteTextures(1, &self->name);
+    self->name = 0;
+  }
+  if (self->fbo != 0) {
+    glDeleteFramebuffers(1, &self->fbo);
+    self->fbo = 0;
+  }
+
+  glGenTextures(1, &self->name);
+  glBindTexture(GL_TEXTURE_2D, self->name);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, required_width, required_height,
+               0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+
+  glGenFramebuffers(1, &self->fbo);
+  glBindFramebuffer(GL_FRAMEBUFFER, self->fbo);
+  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                         GL_TEXTURE_2D, self->name, 0);
+  glBindFramebuffer(GL_FRAMEBUFFER, previous_fbo);
+  glBindTexture(GL_TEXTURE_2D, previous_texture);
+
+  self->current_width = required_width;
+  self->current_height = required_height;
 }
 
 gboolean texture_gl_populate_texture(FlTextureGL* texture,
@@ -136,134 +110,64 @@ gboolean texture_gl_populate_texture(FlTextureGL* texture,
   gint32 required_height = (guint32)video_output_get_height(video_output);
   
   if (required_width > 0 && required_height > 0) {
-    gboolean first_frame = self->name == 0 || self->fbo == 0 || self->mpv_texture == 0;
+    gboolean first_frame = self->name == 0 || self->fbo == 0;
     gboolean resize = self->current_width != required_width ||
                       self->current_height != required_height;
-    
+
     if (first_frame || resize) {
-      // Save Flutter's current EGL context
-      EGLDisplay flutter_display = eglGetCurrentDisplay();
-      EGLContext flutter_context = eglGetCurrentContext();
-      EGLSurface flutter_draw = eglGetCurrentSurface(EGL_DRAW);
-      EGLSurface flutter_read = eglGetCurrentSurface(EGL_READ);
-      
-      EGLDisplay egl_display = video_output_get_egl_display(video_output);
-      EGLContext egl_context = video_output_get_egl_context(video_output);
-      
-      // Switch to mpv's isolated context to create/resize mpv's texture and FBO
-      eglMakeCurrent(egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE, egl_context);
-      
-      // Free previous resources in mpv's context
-      if (!first_frame) {
-        glDeleteTextures(1, &self->mpv_texture);
-        glDeleteFramebuffers(1, &self->fbo);
-        if (self->egl_image != EGL_NO_IMAGE_KHR) {
-          eglDestroyImageKHR(egl_display, self->egl_image);
-        }
-      }
-      
-      // Create mpv's FBO and texture
-      glGenFramebuffers(1, &self->fbo);
-      glBindFramebuffer(GL_FRAMEBUFFER, self->fbo);
-      
-      glGenTextures(1, &self->mpv_texture);
-      glBindTexture(GL_TEXTURE_2D, self->mpv_texture);
-      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-      glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, required_width, required_height,
-                   0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
-      
-      // Attach mpv's texture to FBO
-      glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
-                             GL_TEXTURE_2D, self->mpv_texture, 0);
-      
-      // Create EGLImage from mpv's texture
-      EGLint egl_image_attribs[] = { EGL_NONE };
-      self->egl_image = eglCreateImageKHR(
-          egl_display,
-          egl_context,
-          EGL_GL_TEXTURE_2D_KHR,
-          (EGLClientBuffer)(guintptr)self->mpv_texture,
-          egl_image_attribs);
-      
-      glBindFramebuffer(GL_FRAMEBUFFER, 0);
-      glBindTexture(GL_TEXTURE_2D, 0);
-      
-      // Flush to ensure mpv's texture is ready
-      glFlush();
-      
-      // Switch back to Flutter's context to create/update Flutter's texture
-      eglMakeCurrent(flutter_display, flutter_draw, flutter_read, flutter_context);
-      
-      // Free previous Flutter texture
-      if (!first_frame && self->name != 0) {
-        glDeleteTextures(1, &self->name);
-      }
-      
-      // Create Flutter's texture from EGLImage
-      glGenTextures(1, &self->name);
-      glBindTexture(GL_TEXTURE_2D, self->name);
-      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-      glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, self->egl_image);
-      glBindTexture(GL_TEXTURE_2D, 0);
-      
-      self->current_width = required_width;
-      self->current_height = required_height;
-      
-      // Notify Flutter about dimension change
+      texture_gl_create_or_resize(self, required_width, required_height);
+
+      // Notify Flutter about dimension change.
       video_output_notify_texture_update(video_output);
-      
-      // Flutter's context is already current, so we're ready to render
     }
-    
-    // Save Flutter's current context
-    EGLDisplay flutter_display = eglGetCurrentDisplay();
-    EGLContext flutter_context = eglGetCurrentContext();
-    EGLSurface flutter_draw = eglGetCurrentSurface(EGL_DRAW);
-    EGLSurface flutter_read = eglGetCurrentSurface(EGL_READ);
-    
-    EGLDisplay egl_display = video_output_get_egl_display(video_output);
-    EGLContext egl_context = video_output_get_egl_context(video_output);
+
     mpv_render_context* render_context = video_output_get_render_context(video_output);
-    
-    // Switch to mpv's isolated context for rendering
-    eglMakeCurrent(egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE, egl_context);
-    
-    // Bind mpv's FBO
+
+    GLint previous_fbo = 0;
+    GLint previous_viewport[4] = {0, 0, 0, 0};
+    GLint previous_scissor_box[4] = {0, 0, 0, 0};
+    GLfloat previous_clear_color[4] = {0.f, 0.f, 0.f, 0.f};
+    GLboolean scissor_enabled = glIsEnabled(GL_SCISSOR_TEST);
+
+    glGetIntegerv(GL_FRAMEBUFFER_BINDING, &previous_fbo);
+    glGetIntegerv(GL_VIEWPORT, previous_viewport);
+    glGetIntegerv(GL_SCISSOR_BOX, previous_scissor_box);
+    glGetFloatv(GL_COLOR_CLEAR_VALUE, previous_clear_color);
+
     glBindFramebuffer(GL_FRAMEBUFFER, self->fbo);
-    
-    // Render mpv frame to mpv's texture
+
     mpv_opengl_fbo fbo{(gint32)self->fbo, required_width, required_height, 0};
     int flip_y = 0;
+    int block_for_target_time = 0;
     mpv_render_param params[] = {
         {MPV_RENDER_PARAM_OPENGL_FBO, &fbo},
         {MPV_RENDER_PARAM_FLIP_Y, &flip_y},
+        {MPV_RENDER_PARAM_BLOCK_FOR_TARGET_TIME, &block_for_target_time},
         {MPV_RENDER_PARAM_INVALID, NULL},
     };
     mpv_render_context_render(render_context, params);
-    
-    // Unbind FBO
-    glBindFramebuffer(GL_FRAMEBUFFER, 0);
-    
-    // Flush to ensure rendering is complete
-    glFlush();
-    
-    // Restore Flutter's context
-    eglMakeCurrent(flutter_display, flutter_draw, flutter_read, flutter_context);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, previous_fbo);
+    glViewport(previous_viewport[0], previous_viewport[1],
+               previous_viewport[2], previous_viewport[3]);
+    if (scissor_enabled) {
+      glEnable(GL_SCISSOR_TEST);
+    } else {
+      glDisable(GL_SCISSOR_TEST);
+    }
+    glScissor(previous_scissor_box[0], previous_scissor_box[1],
+              previous_scissor_box[2], previous_scissor_box[3]);
+    glClearColor(previous_clear_color[0], previous_clear_color[1],
+                 previous_clear_color[2], previous_clear_color[3]);
   }
-  
+
   *target = GL_TEXTURE_2D;
   *name = self->name;
   *width = self->current_width;
   *height = self->current_height;
-  
+
   if (self->name == 0) {
-    // First frame not yet available - create dummy texture in Flutter's context
+    // First frame not yet available.
     glGenTextures(1, &self->name);
     glBindTexture(GL_TEXTURE_2D, self->name);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 1, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);

--- a/packages/media_kit_video/linux/video_output.cc
+++ b/packages/media_kit_video/linux/video_output.cc
@@ -18,9 +18,9 @@
 struct _VideoOutput {
   GObject parent_instance;
   TextureGL* texture_gl;
-  EGLDisplay egl_display; /* EGL display for mpv rendering (shared with flutter). */
-  EGLContext egl_context; /* Isolated EGL context (non-shared). */
-  EGLSurface egl_surface; /* Place holder surface for activating egl context */
+  EGLDisplay egl_display; /* EGL display shared with Flutter. */
+  EGLContext egl_context; /* Flutter EGL context used by mpv render API. */
+  EGLSurface egl_surface; /* Unused placeholder kept for ABI stability. */
   guint8* pixel_buffer;
   TextureSW* texture_sw;
   GMutex mutex; /* Only used in S/W rendering. */
@@ -50,33 +50,13 @@ static void video_output_dispose(GObject* object) {
   if (self->texture_gl) {
     fl_texture_registrar_unregister_texture(self->texture_registrar,
                                             FL_TEXTURE(self->texture_gl));
-    
-    // Save Flutter's current context before cleanup
-    EGLDisplay current_display = eglGetCurrentDisplay();
-    EGLContext flutter_context = eglGetCurrentContext();
-    EGLSurface flutter_draw_surface = eglGetCurrentSurface(EGL_DRAW);
-    EGLSurface flutter_read_surface = eglGetCurrentSurface(EGL_READ);
-    
-    // Free mpv_render_context with our own isolated EGL context
+
+    // The mpv OpenGL renderer is bound to Flutter's current EGL context.
     if (self->render_context != NULL) {
-      if (self->egl_context != EGL_NO_CONTEXT) {
-        eglMakeCurrent(self->egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE, self->egl_context);
-      }
       mpv_render_context_free(self->render_context);
       self->render_context = NULL;
-      
-      // Restore Flutter's context
-      if (flutter_context != EGL_NO_CONTEXT) {
-        eglMakeCurrent(current_display, flutter_draw_surface, flutter_read_surface, flutter_context);
-      }
     }
-    
-    // Clean up EGL resources
-    if (self->egl_context != EGL_NO_CONTEXT) {
-      eglDestroyContext(self->egl_display, self->egl_context);
-      self->egl_context = EGL_NO_CONTEXT;
-    }
-    
+
     g_object_unref(self->texture_gl);
   }
   // S/W
@@ -140,114 +120,64 @@ VideoOutput* video_output_new(FlTextureRegistrar* texture_registrar,
   // mpv_set_option_string(self->handle, "video-timing-offset", "0");
   gboolean hardware_acceleration_supported = FALSE;
   if (self->configuration.enable_hardware_acceleration) {
-    // Get Flutter's current EGL display (DO NOT share context)
+    // Reuse Flutter's current EGL context to avoid per-frame context switches.
     EGLDisplay flutter_display = eglGetCurrentDisplay();
     EGLContext flutter_context = eglGetCurrentContext();
-    EGLSurface flutter_draw_surface = eglGetCurrentSurface(EGL_DRAW);
-    EGLSurface flutter_read_surface = eglGetCurrentSurface(EGL_READ);
-    
+
     if (flutter_display != EGL_NO_DISPLAY && flutter_context != EGL_NO_CONTEXT) {
       self->egl_display = flutter_display;
-      
-      // Bind OpenGL ES API (Flutter uses OpenGL ES on Linux)
+      self->egl_context = flutter_context;
+
+      // Bind OpenGL ES API (Flutter uses OpenGL ES on Linux).
       eglBindAPI(EGL_OPENGL_ES_API);
-      
-      // Query Flutter's EGL config and reuse it for compatibility
-      EGLConfig config = NULL;
-      EGLint config_id = 0;
-      
-      if (eglQueryContext(self->egl_display, flutter_context, EGL_CONFIG_ID, &config_id)) {
-        g_print("media_kit: VideoOutput: Flutter's EGL config ID: %d\n", config_id);
-        
-        // Get Flutter's exact config
-        EGLint num_configs = 0;
-        EGLint config_attribs[] = { EGL_CONFIG_ID, config_id, EGL_NONE };
-        
-        if (eglChooseConfig(self->egl_display, config_attribs, &config, 1, &num_configs) && num_configs > 0) {
-          g_print("media_kit: VideoOutput: Using Flutter's EGL config.\n");
-        } else {
-          g_printerr("media_kit: VideoOutput: Failed to get Flutter's EGL config by ID.\n");
-          config = NULL;
-        }
-      } else {
-        g_printerr("media_kit: VideoOutput: Failed to query Flutter's EGL config ID.\n");
-      }
-      
-      if (config != NULL) {        
-        // Create an isolated EGL context (NOT shared with Flutter)
-        // This prevents OpenGL state pollution and resource contention
-        EGLint context_attribs[] = {
-            EGL_CONTEXT_CLIENT_VERSION, 2,
-            EGL_NONE,
+
+      self->texture_gl = texture_gl_new(self);
+
+      if (fl_texture_registrar_register_texture(
+              texture_registrar, FL_TEXTURE(self->texture_gl))) {
+        mpv_opengl_init_params gl_init_params{
+            [](auto, auto name) {
+              return (void*)eglGetProcAddress(name);
+            },
+            NULL,
         };
-        
-        self->egl_context = eglCreateContext(self->egl_display, config, 
-                                             EGL_NO_CONTEXT, context_attribs);
-        
-        if (self->egl_context != EGL_NO_CONTEXT) {
-          // Make our isolated context current for initialization (surfaceless)
-          if (eglMakeCurrent(self->egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE, self->egl_context)) {
-            // Create texture with our isolated context
-            self->texture_gl = texture_gl_new(self);
-            
-            if (fl_texture_registrar_register_texture(
-                    texture_registrar, FL_TEXTURE(self->texture_gl))) {
-              // Initialize mpv with our isolated EGL context
-              mpv_opengl_init_params gl_init_params{
-                  [](auto, auto name) {
-                    return (void*)eglGetProcAddress(name);
-                  },
-                  NULL,
-              };
-              
-              mpv_render_param params[] = {
-                  {MPV_RENDER_PARAM_API_TYPE, (void*)MPV_RENDER_API_TYPE_OPENGL},
-                  {MPV_RENDER_PARAM_OPENGL_INIT_PARAMS, (void*)&gl_init_params},
-                  {MPV_RENDER_PARAM_INVALID, (void*)0},
-                  {MPV_RENDER_PARAM_INVALID, (void*)0},
-              };
-              
-              // VAAPI acceleration requires passing X11/Wayland display
-              GdkDisplay* display = gdk_display_get_default();
-              if (GDK_IS_WAYLAND_DISPLAY(display)) {
-                params[2].type = MPV_RENDER_PARAM_WL_DISPLAY;
-                params[2].data = gdk_wayland_display_get_wl_display(display);
-              } else if (GDK_IS_X11_DISPLAY(display)) {
-                params[2].type = MPV_RENDER_PARAM_X11_DISPLAY;
-                params[2].data = gdk_x11_display_get_xdisplay(display);
-              }
-              
-              if (mpv_render_context_create(&self->render_context, self->handle, params) == 0) {
-                mpv_render_context_set_update_callback(
-                    self->render_context,
-                    [](void* data) {
-                      VideoOutput* self = (VideoOutput*)data;
-                      if (self->destroyed) {
-                        return;
-                      }
-                      fl_texture_registrar_mark_texture_frame_available(
-                          self->texture_registrar, FL_TEXTURE(self->texture_gl));
-                    },
-                    self);
-                hardware_acceleration_supported = TRUE;
-                g_print("media_kit: VideoOutput: H/W rendering with isolated EGL context.\n");
-              } else {
-                g_printerr("media_kit: VideoOutput: Failed to create mpv_render_context.\n");
-              }
-            } else {
-              g_printerr("media_kit: VideoOutput: Failed to register texture.\n");
-            }
-            
-            // Restore Flutter's context
-            eglMakeCurrent(flutter_display, flutter_draw_surface, flutter_read_surface, flutter_context);
-          } else {
-            g_printerr("media_kit: VideoOutput: Failed to make isolated EGL context current. Error: 0x%x\n", eglGetError());
-          }
+
+        mpv_render_param params[] = {
+            {MPV_RENDER_PARAM_API_TYPE, (void*)MPV_RENDER_API_TYPE_OPENGL},
+            {MPV_RENDER_PARAM_OPENGL_INIT_PARAMS, (void*)&gl_init_params},
+            {MPV_RENDER_PARAM_INVALID, (void*)0},
+            {MPV_RENDER_PARAM_INVALID, (void*)0},
+        };
+
+        // VAAPI acceleration requires passing X11/Wayland display.
+        GdkDisplay* display = gdk_display_get_default();
+        if (GDK_IS_WAYLAND_DISPLAY(display)) {
+          params[2].type = MPV_RENDER_PARAM_WL_DISPLAY;
+          params[2].data = gdk_wayland_display_get_wl_display(display);
+        } else if (GDK_IS_X11_DISPLAY(display)) {
+          params[2].type = MPV_RENDER_PARAM_X11_DISPLAY;
+          params[2].data = gdk_x11_display_get_xdisplay(display);
+        }
+
+        if (mpv_render_context_create(&self->render_context, self->handle, params) == 0) {
+          mpv_render_context_set_update_callback(
+              self->render_context,
+              [](void* data) {
+                VideoOutput* self = (VideoOutput*)data;
+                if (self->destroyed) {
+                  return;
+                }
+                fl_texture_registrar_mark_texture_frame_available(
+                    self->texture_registrar, FL_TEXTURE(self->texture_gl));
+              },
+              self);
+          hardware_acceleration_supported = TRUE;
+          g_print("media_kit: VideoOutput: H/W rendering on Flutter EGL context.\n");
         } else {
-          g_printerr("media_kit: VideoOutput: Failed to create isolated EGL context. Error: 0x%x\n", eglGetError());
+          g_printerr("media_kit: VideoOutput: Failed to create mpv_render_context.\n");
         }
       } else {
-        g_printerr("media_kit: VideoOutput: Could not obtain Flutter's EGL config.\n");
+        g_printerr("media_kit: VideoOutput: Failed to register texture.\n");
       }
     } else {
       g_printerr("media_kit: VideoOutput: EGL display or context is invalid.\n");

--- a/packages/media_kit_video/linux/video_output.cc
+++ b/packages/media_kit_video/linux/video_output.cc
@@ -20,7 +20,9 @@ struct _VideoOutput {
   TextureGL* texture_gl;
   EGLDisplay egl_display; /* EGL display shared with Flutter. */
   EGLContext egl_context; /* Flutter EGL context used by mpv render API. */
-  EGLSurface egl_surface; /* Unused placeholder kept for ABI stability. */
+  EGLSurface egl_draw_surface; /* Flutter draw surface for mpv renderer teardown. */
+  EGLSurface egl_read_surface; /* Flutter read surface for mpv renderer teardown. */
+  EGLSurface egl_surface; /* Flutter draw surface kept for ABI stability. */
   guint8* pixel_buffer;
   TextureSW* texture_sw;
   GMutex mutex; /* Only used in S/W rendering. */
@@ -37,25 +39,60 @@ struct _VideoOutput {
 
 G_DEFINE_TYPE(VideoOutput, video_output, G_TYPE_OBJECT)
 
+static void video_output_free_hw_render_context(VideoOutput* self) {
+  if (self->render_context == NULL) {
+    return;
+  }
+
+  EGLDisplay previous_display = eglGetCurrentDisplay();
+  EGLContext previous_context = eglGetCurrentContext();
+  EGLSurface previous_draw = eglGetCurrentSurface(EGL_DRAW);
+  EGLSurface previous_read = eglGetCurrentSurface(EGL_READ);
+
+  gboolean restore_context = previous_context != self->egl_context;
+  gboolean made_context_current = !restore_context;
+
+  if (!made_context_current && self->egl_display != EGL_NO_DISPLAY &&
+      self->egl_context != EGL_NO_CONTEXT) {
+    made_context_current = eglMakeCurrent(self->egl_display,
+                                          self->egl_draw_surface,
+                                          self->egl_read_surface,
+                                          self->egl_context);
+    if (!made_context_current) {
+      g_printerr(
+          "media_kit: VideoOutput: Failed to make EGL context current before "
+          "freeing mpv_render_context. Error: 0x%x\n",
+          eglGetError());
+    }
+  }
+
+  if (made_context_current) {
+    mpv_render_context_set_update_callback(self->render_context, NULL, NULL);
+    mpv_render_context_free(self->render_context);
+    self->render_context = NULL;
+  }
+
+  if (restore_context && made_context_current) {
+    if (previous_context != EGL_NO_CONTEXT) {
+      eglMakeCurrent(previous_display, previous_draw, previous_read,
+                     previous_context);
+    } else {
+      eglMakeCurrent(self->egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE,
+                     EGL_NO_CONTEXT);
+    }
+  }
+}
+
 static void video_output_dispose(GObject* object) {
   VideoOutput* self = VIDEO_OUTPUT(object);
   self->destroyed = TRUE;
-  
-  // Make sure that no more callbacks are invoked from mpv.
-  if (self->render_context) {
-    mpv_render_context_set_update_callback(self->render_context, NULL, NULL);
-  }
 
   // H/W
   if (self->texture_gl) {
     fl_texture_registrar_unregister_texture(self->texture_registrar,
                                             FL_TEXTURE(self->texture_gl));
 
-    // The mpv OpenGL renderer is bound to Flutter's current EGL context.
-    if (self->render_context != NULL) {
-      mpv_render_context_free(self->render_context);
-      self->render_context = NULL;
-    }
+    video_output_free_hw_render_context(self);
 
     g_object_unref(self->texture_gl);
   }
@@ -66,11 +103,12 @@ static void video_output_dispose(GObject* object) {
     g_free(self->pixel_buffer);
     g_object_unref(self->texture_sw);
     if (self->render_context != NULL) {
+      mpv_render_context_set_update_callback(self->render_context, NULL, NULL);
       mpv_render_context_free(self->render_context);
       self->render_context = NULL;
     }
   }
-  
+
   g_mutex_clear(&self->mutex);
   G_OBJECT_CLASS(video_output_parent_class)->dispose(object);
 }
@@ -83,6 +121,8 @@ static void video_output_init(VideoOutput* self) {
   self->texture_gl = NULL;
   self->egl_display = EGL_NO_DISPLAY;
   self->egl_context = EGL_NO_CONTEXT;
+  self->egl_draw_surface = EGL_NO_SURFACE;
+  self->egl_read_surface = EGL_NO_SURFACE;
   self->egl_surface = EGL_NO_SURFACE;
   self->texture_sw = NULL;
   self->pixel_buffer = NULL;
@@ -123,10 +163,15 @@ VideoOutput* video_output_new(FlTextureRegistrar* texture_registrar,
     // Reuse Flutter's current EGL context to avoid per-frame context switches.
     EGLDisplay flutter_display = eglGetCurrentDisplay();
     EGLContext flutter_context = eglGetCurrentContext();
+    EGLSurface flutter_draw_surface = eglGetCurrentSurface(EGL_DRAW);
+    EGLSurface flutter_read_surface = eglGetCurrentSurface(EGL_READ);
 
     if (flutter_display != EGL_NO_DISPLAY && flutter_context != EGL_NO_CONTEXT) {
       self->egl_display = flutter_display;
       self->egl_context = flutter_context;
+      self->egl_draw_surface = flutter_draw_surface;
+      self->egl_read_surface = flutter_read_surface;
+      self->egl_surface = flutter_draw_surface;
 
       // Bind OpenGL ES API (Flutter uses OpenGL ES on Linux).
       eglBindAPI(EGL_OPENGL_ES_API);
@@ -159,7 +204,8 @@ VideoOutput* video_output_new(FlTextureRegistrar* texture_registrar,
           params[2].data = gdk_x11_display_get_xdisplay(display);
         }
 
-        if (mpv_render_context_create(&self->render_context, self->handle, params) == 0) {
+        if (mpv_render_context_create(&self->render_context, self->handle,
+                                      params) == 0) {
           mpv_render_context_set_update_callback(
               self->render_context,
               [](void* data) {

--- a/packages/media_kit_video/linux/video_output.cc
+++ b/packages/media_kit_video/linux/video_output.cc
@@ -44,6 +44,8 @@ static void video_output_free_hw_render_context(VideoOutput* self) {
     return;
   }
 
+  mpv_render_context_set_update_callback(self->render_context, NULL, NULL);
+
   EGLDisplay previous_display = eglGetCurrentDisplay();
   EGLContext previous_context = eglGetCurrentContext();
   EGLSurface previous_draw = eglGetCurrentSurface(EGL_DRAW);
@@ -67,7 +69,6 @@ static void video_output_free_hw_render_context(VideoOutput* self) {
   }
 
   if (made_context_current) {
-    mpv_render_context_set_update_callback(self->render_context, NULL, NULL);
     mpv_render_context_free(self->render_context);
     self->render_context = NULL;
   }


### PR DESCRIPTION
## Summary
- reuse Flutter's current EGL/GL context for mpv rendering on Linux
- remove per-frame EGL context switches from the media_kit texture path
- render mpv output directly into the Flutter texture-backed FBO

## Why
The previous Linux rendering path switched between Flutter and mpv EGL contexts for every frame. On Mesa/NVIDIA this stalls the raster thread during playback and becomes especially visible during resize and fullscreen transitions.

## Changes
- create the mpv render context against the active Flutter EGL context
- remove the cross-context `EGLImage` bridge in `texture_gl.cc`
- bind mpv rendering directly to the texture/FBO returned to Flutter
- disable extra target-time blocking in the mpv render call
- restore the GL state that Flutter depends on after mpv renders

## Validation
- `flutter build linux --debug`
- local C++ syntax validation for `packages/media_kit_video/linux`
