### PR TITLE
Fix remote access settings lifecycle crashes

### DIFF
--- a/lib/themes/nipaplay/pages/settings/remote_access_page.dart
+++ b/lib/themes/nipaplay/pages/settings/remote_access_page.dart
@@ -1,5 +1,4 @@
 // remote_access_page.dart
-import 'dart:developer';
 import 'package:flutter/material.dart';
 import 'package:kmbal_ionicons/kmbal_ionicons.dart';
 import 'package:nipaplay/providers/service_provider.dart';
@@ -50,15 +49,16 @@ class _RemoteAccessPageState extends State<RemoteAccessPage> {
     await _loadTrustedDevices();
 
     if (mounted) {
+      final shouldUpdateUrls = server.isRunning;
       setState(() {
         _webServerEnabled = server.isRunning;
         _receiverEnabled = receiverEnabled;
         _autoStartEnabled = server.autoStart;
         _currentPort = server.port;
-        if (_webServerEnabled) {
-          _updateAccessUrls();
-        }
       });
+      if (shouldUpdateUrls) {
+        _updateAccessUrls();
+      }
     }
   }
 
@@ -121,6 +121,7 @@ class _RemoteAccessPageState extends State<RemoteAccessPage> {
   Future<void> _fetchPublicIp() async {
     if (!_webServerEnabled) return;
 
+    if (!mounted) return;
     setState(() {
       _isLoadingPublicIp = true;
     });
@@ -137,6 +138,7 @@ class _RemoteAccessPageState extends State<RemoteAccessPage> {
         final ip = response.body.trim();
         // 确保是有效的IP地址
         if (ip.isNotEmpty && !ip.contains('<') && !ip.contains('>')) {
+          if (!mounted || !_webServerEnabled) return;
           setState(() {
             _publicIpUrl = 'http://$ip:$_currentPort';
             _isLoadingPublicIp = false;
@@ -149,6 +151,7 @@ class _RemoteAccessPageState extends State<RemoteAccessPage> {
       }
     } catch (e) {
       debugPrint('获取公网IP出错: $e');
+      if (!mounted || !_webServerEnabled) return;
       setState(() {
         _publicIpUrl = null;
         _isLoadingPublicIp = false;

--- a/lib/themes/nipaplay/pages/settings_page.dart
+++ b/lib/themes/nipaplay/pages/settings_page.dart
@@ -79,6 +79,7 @@ class _SettingsPageState extends State<SettingsPage>
   late TabController _tabController;
   static Color get _selectedColor => AppAccentColors.current;
   String? _selectedEntryId;
+  bool _didApplyInitialEntry = false;
 
   @override
   void initState() {
@@ -89,7 +90,13 @@ class _SettingsPageState extends State<SettingsPage>
       currentPage = const AboutPage();
       _selectedEntryId = NipaplaySettingEntryIds.about;
     }
+  }
 
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_didApplyInitialEntry) return;
+    _didApplyInitialEntry = true;
     _applyInitialEntry();
   }
 


### PR DESCRIPTION
## Summary
- move initial settings entry resolution from initState to didChangeDependencies to avoid inherited-widget access before initialization
- guard remote access public IP async updates with mounted and service-state checks
- move updateAccessUrls call out of setState closure during initial state load

## Problem fixed
- dependOnInheritedWidgetOfExactType LocalizationsScope called before SettingsPage initState completed
- setState called after dispose in RemoteAccessPage fetchPublicIp

## Validation
- flutter analyze lib/themes/nipaplay/pages/settings_page.dart lib/themes/nipaplay/pages/settings/remote_access_page.dart
- no new analyzer errors introduced by this change; only existing prefer_const_constructors infos in remote_access_page