### PR TITLE
feat: WebDAV bgmid 快速匹配，跳过哈希计算直接获取弹幕

### DIFF
--- a/lib/pages/webdav_browser_page.dart
+++ b/lib/pages/webdav_browser_page.dart
@@ -8,6 +8,7 @@ import 'package:nipaplay/themes/nipaplay/widgets/webdav_connection_dialog.dart';
 import 'package:nipaplay/models/watch_history_model.dart';
 import 'package:nipaplay/models/playable_item.dart';
 import 'package:nipaplay/services/playback_service.dart';
+import 'package:nipaplay/services/dandanplay_service_io.dart';
 import 'package:nipaplay/utils/webdav_file_sorter.dart';
 import 'package:kmbal_ionicons/kmbal_ionicons.dart';
 import 'package:nipaplay/utils/app_accent_color.dart';
@@ -22,6 +23,13 @@ class WebDAVBrowserPage extends StatefulWidget {
 }
 
 class _WebDAVBrowserPageState extends State<WebDAVBrowserPage> {
+  // 静态正则表达式常量，用于提取集数（避免重复创建）
+  static final _seasonEpisodeRegex = RegExp(r'[Ss](\d{1,2})[Ee](\d{1,3})');
+  static final _chineseEpisodeRegex = RegExp(r'第(\d{1,3})[话集]');
+  static final _epNumberRegex = RegExp(r'[Ee][Pp]?(\d{1,3})');
+  static final _bracketNumberRegex = RegExp(r'[\[【](\d{1,3})[\]】]');
+  static final _delimiterNumberRegex = RegExp(r'[-_](\d{1,3})[-_\.\[]');
+
   // 当前选中的服务器连接
   WebDAVConnection? _currentConnection;
   // 当前路径
@@ -164,7 +172,7 @@ class _WebDAVBrowserPageState extends State<WebDAVBrowserPage> {
   /// 是否可以返回上一级
   bool get _canNavigateBack => _currentPath != '/';
 
-  void _playVideo(WebDAVFile file) {
+  void _playVideo(WebDAVFile file) async {
     if (_currentConnection == null) return;
 
     final videoUrl = WebDAVService.instance.getFileUrl(
@@ -172,26 +180,115 @@ class _WebDAVBrowserPageState extends State<WebDAVBrowserPage> {
       file.path,
     );
 
+    final provider =
+        Provider.of<WebDAVQuickAccessProvider>(context, listen: false);
+    int? quickMatchEpisodeId;
+    int? quickMatchAnimeId;
+    String? quickMatchAnimeTitle;
+
+    if (provider.bgmIdQuickMatch) {
+      // 使用用户自定义正则从完整 URL 中匹配 bgmid
+      try {
+        final regex = RegExp(provider.bgmIdMatchPattern);
+        final bgmidMatch = regex.firstMatch(videoUrl);
+
+        if (bgmidMatch != null && bgmidMatch.groupCount >= 1) {
+          final bgmid = int.tryParse(bgmidMatch.group(1)!);
+
+          if (bgmid != null) {
+            final result = await DandanplayService.getBangumiByBgmId(bgmid);
+
+            if (result != null && result['bangumi'] != null) {
+              final bangumi = result['bangumi'] as Map<String, dynamic>;
+              final episodes = bangumi['episodes'] as List<dynamic>?;
+
+              quickMatchAnimeId = bangumi['animeId'] as int?;
+              quickMatchAnimeTitle = bangumi['animeTitle'] as String?;
+
+              final episodeNumber = _extractEpisodeNumber(file.name);
+
+              if (episodes != null && episodeNumber != null) {
+                for (final ep in episodes) {
+                  final epNum =
+                      int.tryParse(ep['episodeNumber']?.toString() ?? '');
+                  if (epNum == episodeNumber) {
+                    quickMatchEpisodeId = ep['episodeId'] as int?;
+                    break;
+                  }
+                }
+              }
+
+              debugPrint(
+                  '[WebDAV] 快速匹配结果: bgmid=$bgmid, episodeNumber=$episodeNumber, episodeId=$quickMatchEpisodeId');
+            }
+          }
+        }
+      } catch (e) {
+        // 正则无效或匹配失败，静默回退原有流程
+        debugPrint('[WebDAV] 快速匹配失败（使用规则: ${provider.bgmIdMatchPattern}）: $e');
+      }
+    }
+
     // 创建观看历史项用于播放
     final historyItem = WatchHistoryItem(
-      animeName: file.name.replaceAll(RegExp(r'\.[^.]+$'), ''),
+      animeName: quickMatchAnimeTitle ??
+          file.name.replaceAll(RegExp(r'\.[^.]+$'), ''),
       episodeTitle: file.name,
       filePath: videoUrl,
       watchProgress: 0,
       lastPosition: 0,
       duration: 0,
       lastWatchTime: DateTime.now(),
+      episodeId: quickMatchEpisodeId,
+      animeId: quickMatchAnimeId,
     );
 
     // 使用 PlaybackService 播放视频
     final playableItem = PlayableItem(
       videoPath: videoUrl,
-      title: file.name.replaceAll(RegExp(r'\.[^.]+$'), ''),
+      title: quickMatchAnimeTitle ??
+          file.name.replaceAll(RegExp(r'\.[^.]+$'), ''),
       subtitle: file.name,
       historyItem: historyItem,
     );
 
     PlaybackService().play(playableItem);
+  }
+
+  /// 从文件名中提取集数
+  /// 支持多种格式：S01E12、第12集、EP12、[12]、_12_ 等
+  int? _extractEpisodeNumber(String fileName) {
+    // 尝试匹配 S01E12 格式
+    final seasonEpisodeMatch = _seasonEpisodeRegex.firstMatch(fileName);
+    if (seasonEpisodeMatch != null) {
+      return int.tryParse(seasonEpisodeMatch.group(2)!);
+    }
+
+    // 尝试匹配 第N集/第N话 格式
+    final chineseMatch = _chineseEpisodeRegex.firstMatch(fileName);
+    if (chineseMatch != null) {
+      return int.tryParse(chineseMatch.group(1)!);
+    }
+
+    // 尝试匹配 EP12 / E12 格式
+    final epMatch = _epNumberRegex.firstMatch(fileName);
+    if (epMatch != null) {
+      return int.tryParse(epMatch.group(1)!);
+    }
+
+    // 尝试匹配 [12] 或 【12】 格式
+    final bracketMatch = _bracketNumberRegex.firstMatch(fileName);
+    if (bracketMatch != null) {
+      return int.tryParse(bracketMatch.group(1)!);
+    }
+
+    // 尝试匹配 -12- 或 _12_ 格式（在分隔符之间的数字）
+    final delimiterMatch = _delimiterNumberRegex.firstMatch(fileName);
+    if (delimiterMatch != null) {
+      return int.tryParse(delimiterMatch.group(1)!);
+    }
+
+    return null;
   }
 
   void _showServerSelector() {

--- a/lib/providers/webdav_quick_access_provider.dart
+++ b/lib/providers/webdav_quick_access_provider.dart
@@ -52,6 +52,8 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
       'webdav_auto_enter_season_folder';
   static const String _keySeasonFolderPattern = 'webdav_season_folder_pattern';
   static const String _keyShowPathBreadcrumb = 'webdav_show_path_breadcrumb';
+  static const String _keyBgmIdQuickMatch = 'webdav_bgmid_quick_match';
+  static const String _keyBgmIdMatchPattern = 'webdav_bgmid_match_pattern';
   static const String _legacyDefaultPageIndexKey = 'default_page_index';
 
   // Tab 名称常量
@@ -81,6 +83,8 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
   bool _autoEnterSeasonFolder = false;
   String _seasonFolderPattern = 'Season*';
   bool _showPathBreadcrumb = true;
+  bool _bgmIdQuickMatch = false; // 默认关闭，用户需明确启用
+  String _bgmIdMatchPattern = 'bgmid=(\\d+)'; // 默认正则规则
   bool _isLoaded = false;
 
   // Getters
@@ -92,6 +96,8 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
   bool get autoEnterSeasonFolder => _autoEnterSeasonFolder;
   String get seasonFolderPattern => _seasonFolderPattern;
   bool get showPathBreadcrumb => _showPathBreadcrumb;
+  bool get bgmIdQuickMatch => _bgmIdQuickMatch;
+  String get bgmIdMatchPattern => _bgmIdMatchPattern;
   bool get isLoaded => _isLoaded;
 
   /// 获取有效的默认 Tab（处理 WebDAV 关闭时的回落）
@@ -190,6 +196,9 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
       _seasonFolderPattern =
           prefs.getString(_keySeasonFolderPattern) ?? 'Season*';
       _showPathBreadcrumb = prefs.getBool(_keyShowPathBreadcrumb) ?? true;
+      _bgmIdQuickMatch = prefs.getBool(_keyBgmIdQuickMatch) ?? false;
+      _bgmIdMatchPattern =
+          prefs.getString(_keyBgmIdMatchPattern) ?? 'bgmid=(\\d+)';
 
       _isLoaded = true;
       notifyListeners();
@@ -351,6 +360,45 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
     }
   }
 
+  /// 设置是否启用 bgmid 快速匹配
+  Future<void> setBgmIdQuickMatch(bool value) async {
+    if (_bgmIdQuickMatch == value) return;
+
+    _bgmIdQuickMatch = value;
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool(_keyBgmIdQuickMatch, value);
+      notifyListeners();
+    } catch (e) {
+      debugPrint('保存 bgmid 快速匹配设置失败: $e');
+    }
+  }
+
+  /// 设置 bgmid 匹配正则表达式
+  /// 用户自定义正则规则，必须包含捕获组提取数字
+  Future<void> setBgmIdMatchPattern(String pattern) async {
+    if (_bgmIdMatchPattern == pattern) return;
+
+    // 验证正则是否有效
+    try {
+      RegExp(pattern);
+    } catch (e) {
+      debugPrint('无效的正则表达式: $pattern, 错误: $e');
+      return;
+    }
+
+    _bgmIdMatchPattern = pattern;
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_keyBgmIdMatchPattern, pattern);
+      notifyListeners();
+    } catch (e) {
+      debugPrint('保存 bgmid 匹配规则失败: $e');
+    }
+  }
+
   /// 检查文件夹名称是否匹配模式（支持通配符 * 和 ?）
   bool matchesSeasonPattern(String folderName) {
     if (_seasonFolderPattern.isEmpty) return false;
@@ -428,6 +476,8 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
     _autoEnterSeasonFolder = false;
     _seasonFolderPattern = 'Season*';
     _showPathBreadcrumb = true;
+    _bgmIdQuickMatch = false;
+    _bgmIdMatchPattern = 'bgmid=(\\d+)';
 
     try {
       final prefs = await SharedPreferences.getInstance();
@@ -439,6 +489,8 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
       await prefs.remove(_keyAutoEnterSeasonFolder);
       await prefs.remove(_keySeasonFolderPattern);
       await prefs.remove(_keyShowPathBreadcrumb);
+      await prefs.remove(_keyBgmIdQuickMatch);
+      await prefs.remove(_keyBgmIdMatchPattern);
       notifyListeners();
     } catch (e) {
       debugPrint('重置 WebDAV 快捷设置失败: $e');

--- a/lib/services/dandanplay_service_io.dart
+++ b/lib/services/dandanplay_service_io.dart
@@ -1829,6 +1829,51 @@ class DandanplayService {
     }
   }
 
+  /// 通过 Bangumi.tv subjectId 获取番剧详情
+  ///
+  /// 调用 /api/v2/bangumi/bgmtv/{bgmtvSubjectId} 接口
+  /// 返回包含 animeId、episodes 等信息的完整响应
+  static Future<Map<String, dynamic>?> getBangumiByBgmId(int bgmtvSubjectId) async {
+    try {
+      final appSecret = await getAppSecret();
+      final timestamp = (DateTime.now().toUtc().millisecondsSinceEpoch / 1000)
+          .round();
+      final apiPath = '/api/v2/bangumi/bgmtv/$bgmtvSubjectId';
+
+      final headers = {
+        'Accept': 'application/json',
+        'User-Agent': userAgent,
+        'X-AppId': appId,
+        'X-Signature': generateSignature(appId, timestamp, apiPath, appSecret),
+        'X-Timestamp': '$timestamp',
+      };
+
+      if (_isLoggedIn && _token != null) {
+        headers['Authorization'] = 'Bearer $_token';
+      }
+
+      debugPrint('[弹弹play服务] 通过 bgmid 获取番剧详情: $bgmtvSubjectId');
+
+      final response = await http.get(
+        Uri.parse('${await getApiBaseUrl()}$apiPath'),
+        headers: headers,
+      );
+
+      if (response.statusCode == 200) {
+        final data = json.decode(response.body);
+        if (data['success'] == true && data['bangumi'] != null) {
+          return data;
+        }
+      }
+
+      debugPrint('[弹弹play服务] bgmid 匹配失败: HTTP ${response.statusCode}');
+      return null;
+    } catch (e) {
+      debugPrint('[弹弹play服务] 通过 bgmid 获取番剧详情出错: $e');
+      return null;
+    }
+  }
+
   // 获取用户对特定剧集的观看状态
   static Future<Map<int, bool>> getEpisodesWatchStatus(
     List<int> episodeIds,

--- a/lib/themes/cupertino/pages/settings/pages/webdav_quick_settings_page.dart
+++ b/lib/themes/cupertino/pages/settings/pages/webdav_quick_settings_page.dart
@@ -20,20 +20,26 @@ class CupertinoWebDAVQuickSettingsPage extends StatefulWidget {
 class _CupertinoWebDAVQuickSettingsPageState
     extends State<CupertinoWebDAVQuickSettingsPage> {
   late final TextEditingController _directoryController;
+  late final TextEditingController _patternController;
 
   @override
   void initState() {
     super.initState();
     _directoryController = TextEditingController();
+    _patternController = TextEditingController();
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      Provider.of<WebDAVQuickAccessProvider>(context, listen: false)
-          .loadSettings();
+      final provider =
+          Provider.of<WebDAVQuickAccessProvider>(context, listen: false);
+      provider.loadSettings().then((_) {
+        _patternController.text = provider.bgmIdMatchPattern;
+      });
     });
   }
 
   @override
   void dispose() {
     _directoryController.dispose();
+    _patternController.dispose();
     super.dispose();
   }
 
@@ -82,6 +88,8 @@ class _CupertinoWebDAVQuickSettingsPageState
                   _buildPathBreadcrumbCard(context, provider),
                   const SizedBox(height: 24),
                   _buildAutoEnterSeasonCard(context, provider),
+                  const SizedBox(height: 24),
+                  _buildBgmIdQuickMatchCard(context, provider),
                   const SizedBox(height: 24),
                   _buildResetCard(context, provider),
                 ],
@@ -625,6 +633,74 @@ class _CupertinoWebDAVQuickSettingsPageState
           fontSize: 13,
         ),
       ),
+    );
+  }
+
+  Widget _buildBgmIdQuickMatchCard(BuildContext context, WebDAVQuickAccessProvider provider) {
+    final Color tileColor = resolveSettingsTileBackground(context);
+    final Color sectionColor = resolveSettingsSectionBackground(context);
+    final Color iconColor = resolveSettingsIconColor(context);
+    final Color textColor = resolveSettingsPrimaryTextColor(context);
+    final Color secondaryColor = resolveSettingsSecondaryTextColor(context);
+
+    return CupertinoSettingsGroupCard(
+      margin: EdgeInsets.zero,
+      backgroundColor: sectionColor,
+      children: [
+        CupertinoSettingsTile(
+          leading: Icon(CupertinoIcons.bolt_fill, color: iconColor),
+          title: const Text('bgmid 快速匹配'),
+          subtitle: const Text('解析 URL 中的 bgmid 跳过哈希计算'),
+          backgroundColor: tileColor,
+          trailing: CupertinoSwitch(
+            value: provider.bgmIdQuickMatch,
+            activeColor: CupertinoColors.activeBlue,
+            onChanged: (value) {
+              provider.setBgmIdQuickMatch(value);
+            },
+          ),
+        ),
+        if (provider.bgmIdQuickMatch)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 12),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '匹配规则（正则表达式）',
+                  style: TextStyle(color: textColor, fontSize: 13),
+                ),
+                SizedBox(height: 4),
+                Text(
+                  '从完整 URL 中匹配数字，默认匹配 "bgmid=数字"',
+                  style: TextStyle(color: secondaryColor, fontSize: 11),
+                ),
+                SizedBox(height: 8),
+                CupertinoTextField(
+                  controller: _patternController,
+                  placeholder: 'bgmid=(\\d+)',
+                  style: TextStyle(color: textColor, fontSize: 13),
+                  decoration: BoxDecoration(
+                    color: tileColor,
+                    borderRadius: BorderRadius.circular(8),
+                    border: Border.all(color: secondaryColor.withOpacity(0.3)),
+                  ),
+                  padding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                  onSubmitted: (value) {
+                    if (value.isNotEmpty) {
+                      provider.setBgmIdMatchPattern(value);
+                    }
+                  },
+                ),
+                SizedBox(height: 4),
+                Text(
+                  '示例: bgm[=-](\\d+) 可匹配 bgmid=123 或 bgm-123',
+                  style: TextStyle(color: secondaryColor.withOpacity(0.7), fontSize: 10),
+                ),
+              ],
+            ),
+          ),
+      ],
     );
   }
 

--- a/lib/themes/nipaplay/pages/settings/webdav_quick_settings_page.dart
+++ b/lib/themes/nipaplay/pages/settings/webdav_quick_settings_page.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:nipaplay/providers/webdav_quick_access_provider.dart';
 import 'package:nipaplay/services/webdav_service.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_snackbar.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/fluent_settings_switch.dart';
 import 'package:kmbal_ionicons/kmbal_ionicons.dart';
 import 'package:nipaplay/utils/app_accent_color.dart';
 
@@ -16,13 +17,25 @@ class WebDAVQuickSettingsPage extends StatefulWidget {
 }
 
 class _WebDAVQuickSettingsPageState extends State<WebDAVQuickSettingsPage> {
+  late TextEditingController _patternController;
+
   @override
   void initState() {
     super.initState();
+    _patternController = TextEditingController();
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      Provider.of<WebDAVQuickAccessProvider>(context, listen: false)
-          .loadSettings();
+      final provider =
+          Provider.of<WebDAVQuickAccessProvider>(context, listen: false);
+      provider.loadSettings().then((_) {
+        _patternController.text = provider.bgmIdMatchPattern;
+      });
     });
+  }
+
+  @override
+  void dispose() {
+    _patternController.dispose();
+    super.dispose();
   }
 
   @override
@@ -57,22 +70,29 @@ class _WebDAVQuickSettingsPageState extends State<WebDAVQuickSettingsPage> {
               // 开关：显示 WebDAV Tab
               _buildSettingsCard(
                 cardColor: cardColor,
-                child: SwitchListTile(
+                child: ListTile(
+                  leading: Icon(Ionicons.cloud_outline, color: textColor.withOpacity(0.7)),
                   title: Text(
                     '显示 WebDAV Tab',
-                    style: TextStyle(color: textColor),
+                    style: TextStyle(
+                      color: textColor,
+                      fontWeight: FontWeight.bold,
+                    ),
                   ),
                   subtitle: Text(
                     '在底部导航栏显示 WebDAV 快捷入口',
                     style: TextStyle(
                       color: secondaryTextColor,
-                      fontSize: 12,
                     ),
                   ),
-                  value: provider.showWebDAVTab,
-                  activeColor: accentColor,
-                  onChanged: (value) {
-                    provider.setShowWebDAVTab(value);
+                  trailing: FluentSettingsSwitch(
+                    value: provider.showWebDAVTab,
+                    onChanged: (value) {
+                      provider.setShowWebDAVTab(value);
+                    },
+                  ),
+                  onTap: () {
+                    provider.setShowWebDAVTab(!provider.showWebDAVTab);
                   },
                 ),
               ),
@@ -315,22 +335,29 @@ class _WebDAVQuickSettingsPageState extends State<WebDAVQuickSettingsPage> {
                 // 路径面包屑导航开关
                 _buildSettingsCard(
                   cardColor: cardColor,
-                  child: SwitchListTile(
+                  child: ListTile(
+                    leading: Icon(Ionicons.folder_outline, color: textColor.withOpacity(0.7)),
                     title: Text(
                       '显示路径导航',
-                      style: TextStyle(color: textColor),
+                      style: TextStyle(
+                        color: textColor,
+                        fontWeight: FontWeight.bold,
+                      ),
                     ),
                     subtitle: Text(
                       '在顶部显示可点击的路径面包屑导航',
                       style: TextStyle(
                         color: secondaryTextColor,
-                        fontSize: 12,
                       ),
                     ),
-                    value: provider.showPathBreadcrumb,
-                    activeColor: accentColor,
-                    onChanged: (value) {
-                      provider.setShowPathBreadcrumb(value);
+                    trailing: FluentSettingsSwitch(
+                      value: provider.showPathBreadcrumb,
+                      onChanged: (value) {
+                        provider.setShowPathBreadcrumb(value);
+                      },
+                    ),
+                    onTap: () {
+                      provider.setShowPathBreadcrumb(!provider.showPathBreadcrumb);
                     },
                   ),
                 ),
@@ -343,22 +370,29 @@ class _WebDAVQuickSettingsPageState extends State<WebDAVQuickSettingsPage> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      SwitchListTile(
+                      ListTile(
+                        leading: Icon(Ionicons.folder_open_outline, color: textColor.withOpacity(0.7)),
                         title: Text(
                           '自动进入 Season 文件夹',
-                          style: TextStyle(color: textColor),
+                          style: TextStyle(
+                            color: textColor,
+                            fontWeight: FontWeight.bold,
+                          ),
                         ),
                         subtitle: Text(
                           '打开文件夹时自动进入匹配的子文件夹',
                           style: TextStyle(
                             color: secondaryTextColor,
-                            fontSize: 12,
                           ),
                         ),
-                        value: provider.autoEnterSeasonFolder,
-                        activeColor: accentColor,
-                        onChanged: (value) {
-                          provider.setAutoEnterSeasonFolder(value);
+                        trailing: FluentSettingsSwitch(
+                          value: provider.autoEnterSeasonFolder,
+                          onChanged: (value) {
+                            provider.setAutoEnterSeasonFolder(value);
+                          },
+                        ),
+                        onTap: () {
+                          provider.setAutoEnterSeasonFolder(!provider.autoEnterSeasonFolder);
                         },
                       ),
                       if (provider.autoEnterSeasonFolder) ...[
@@ -460,7 +494,104 @@ class _WebDAVQuickSettingsPageState extends State<WebDAVQuickSettingsPage> {
                 ),
               ],
 
-              // 没有服务器连接时的提示
+            SizedBox(height: 16),
+
+            // bgmid 快速匹配开关
+            _buildSettingsCard(
+              cardColor: cardColor,
+              child: Column(
+                children: [
+                  ListTile(
+                    leading: Icon(Ionicons.flash_outline, color: textColor.withOpacity(0.7)),
+                    title: Text(
+                      'bgmid 快速匹配',
+                      style: TextStyle(
+                        color: textColor,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    subtitle: Text(
+                      '解析 URL 中的 bgmid 跳过哈希计算',
+                      style: TextStyle(
+                        color: secondaryTextColor,
+                      ),
+                    ),
+                    trailing: FluentSettingsSwitch(
+                      value: provider.bgmIdQuickMatch,
+                      onChanged: (value) {
+                        provider.setBgmIdQuickMatch(value);
+                      },
+                    ),
+                    onTap: () {
+                      provider.setBgmIdQuickMatch(!provider.bgmIdQuickMatch);
+                    },
+                  ),
+                  if (provider.bgmIdQuickMatch) ...[
+                    Divider(height: 1, color: secondaryTextColor.withOpacity(0.2)),
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(16, 8, 16, 12),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            '匹配规则（正则表达式）',
+                            style: TextStyle(
+                              color: textColor,
+                              fontSize: 13,
+                            ),
+                          ),
+                          SizedBox(height: 4),
+                          Text(
+                            '从完整 URL 中匹配数字，默认匹配 "bgmid=数字"',
+                            style: TextStyle(
+                              color: secondaryTextColor,
+                              fontSize: 11,
+                            ),
+                          ),
+                          SizedBox(height: 8),
+                          TextField(
+                            controller: _patternController,
+                            style: TextStyle(color: textColor, fontSize: 13),
+                            decoration: InputDecoration(
+                              hintText: 'bgmid=(\\d+)',
+                              hintStyle: TextStyle(color: secondaryTextColor.withOpacity(0.5)),
+                              contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                              border: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(8),
+                              ),
+                              enabledBorder: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(8),
+                                borderSide: BorderSide(color: secondaryTextColor.withOpacity(0.3)),
+                              ),
+                              focusedBorder: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(8),
+                                borderSide: BorderSide(color: accentColor),
+                              ),
+                              isDense: true,
+                            ),
+                            onSubmitted: (value) {
+                              if (value.isNotEmpty) {
+                                provider.setBgmIdMatchPattern(value);
+                              }
+                            },
+                          ),
+                          SizedBox(height: 4),
+                          Text(
+                            '示例: bgm[=-](\\d+) 可匹配 bgmid=123 或 bgm-123',
+                            style: TextStyle(
+                              color: secondaryTextColor.withOpacity(0.7),
+                              fontSize: 10,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+
+            // 没有服务器连接时的提示
               if (provider.showWebDAVTab && connections.isEmpty)
                 _buildSettingsCard(
                   cardColor: cardColor,


### PR DESCRIPTION
## 功能说明

WebDAV 播放时，从完整 URL 中匹配用户自定义正则规则提取 bgmid，通过 `/api/v2/bangumi/bgmtv/{bgmtvSubjectId}` 接口直接获取番剧信息和 episodeId，跳过原有流程中下载视频前 16MB 数据计算 MD5 哈希的步骤，降低匹配时间。匹配失败时自动回退原有流程。

## 功能特性

- **自定义正则规则**：用户可在设置中配置匹配规则，默认 `bgmid=(\d+)`，支持多种格式如 `bgm[=-](\d+)` 同时匹配 `bgmid=123` 和 `bgm-123`
- **全 URL 匹配**：从完整 WebDAV URL 中匹配，文件夹名称中的 bgmid 也生效
- **集数识别**：支持 `S01E12`、`第12集`、`EP12`、`[12]`、`-12-` 等格式
- **健壮性保障**：正则无效/无捕获组/匹配失败均静默回退原有哈希流程
- **影响范围**：仅 WebDAV 播放场景生效，其他播放入口不受影响

## 修改文件

| 文件 | 变更 |
|-----|------|
| `lib/providers/webdav_quick_access_provider.dart` | 新增 `bgmIdQuickMatch` 开关 + `bgmIdMatchPattern` 正则配置 |
| `lib/services/dandanplay_service_io.dart` | 新增 `getBangumiByBgmId()` API 调用 |
| `lib/pages/webdav_browser_page.dart` | 匹配逻辑：用户正则 + 完整 URL + 集数提取 |
| 两套主题 `webdav_quick_settings_page.dart` | 设置 UI：开关 + 正则输入框（桌面端使用 FluentUI 风格） |

## 设置位置

设置 > 实验室 > WebDAV快捷设置