### PR TITLE
feat: add watched indicator for episodes from remote media library

### DIFF
--- a/lib/models/emby_model.dart
+++ b/lib/models/emby_model.dart
@@ -241,6 +241,7 @@ class EmbyEpisodeInfo {
   final DateTime dateAdded;
   final String? premiereDate;
   final int? runTimeTicks;
+  final EmbyUserData? userData;
   
   EmbyEpisodeInfo({
     required this.id,
@@ -256,6 +257,7 @@ class EmbyEpisodeInfo {
     required this.dateAdded,
     this.premiereDate,
     this.runTimeTicks,
+    this.userData,
   });
   
   factory EmbyEpisodeInfo.fromJson(Map<String, dynamic> json) {
@@ -273,6 +275,7 @@ class EmbyEpisodeInfo {
       dateAdded: DateTime.parse(json['DateCreated'] ?? DateTime.now().toIso8601String()),
       premiereDate: json['PremiereDate'],
       runTimeTicks: json['RunTimeTicks'],
+      userData: json['UserData'] != null ? EmbyUserData.fromJson(json['UserData']) : null,
     );
   }
   

--- a/lib/models/jellyfin_model.dart
+++ b/lib/models/jellyfin_model.dart
@@ -267,6 +267,7 @@ class JellyfinEpisodeInfo {
   final DateTime dateAdded;
   final String? premiereDate;
   final int? runTimeTicks;
+  final JellyfinUserData? userData;
   
   JellyfinEpisodeInfo({
     required this.id,
@@ -282,6 +283,7 @@ class JellyfinEpisodeInfo {
     required this.dateAdded,
     this.premiereDate,
     this.runTimeTicks,
+    this.userData,
   });
   
   factory JellyfinEpisodeInfo.fromJson(Map<String, dynamic> json) {
@@ -299,6 +301,7 @@ class JellyfinEpisodeInfo {
       dateAdded: DateTime.parse(json['DateCreated'] ?? DateTime.now().toIso8601String()),
       premiereDate: json['PremiereDate'],
       runTimeTicks: json['RunTimeTicks'],
+      userData: json['UserData'] != null ? JellyfinUserData.fromJson(json['UserData']) : null,
     );
   }
   

--- a/lib/models/shared_remote_library.dart
+++ b/lib/models/shared_remote_library.dart
@@ -133,6 +133,7 @@ class SharedRemoteEpisode {
     this.fileSize,
     this.lastWatchTime,
     this.videoHash,
+    this.watched,
   });
 
   final String shareId;
@@ -148,6 +149,7 @@ class SharedRemoteEpisode {
   final int? fileSize;
   final DateTime? lastWatchTime;
   final String? videoHash;
+  final bool? watched;
 
   factory SharedRemoteEpisode.fromJson(Map<String, dynamic> json) {
     final rawStreamPath = json['streamPath'] as String?;
@@ -172,6 +174,7 @@ class SharedRemoteEpisode {
           ? DateTime.tryParse(json['lastWatchTime'] as String)
           : null,
       videoHash: json['videoHash'] as String?,
+      watched: json['watched'] as bool?,
     );
   }
 }

--- a/lib/pages/media_server_detail_page.dart
+++ b/lib/pages/media_server_detail_page.dart
@@ -1238,15 +1238,29 @@ class _MediaServerDetailPageState extends State<MediaServerDetailPage>
                     ),
                 ],
               ),
-              trailing: AnimatedScale(
-                scale: isEpisodeHovered ? 1.1 : 1.0,
-                duration: const Duration(milliseconds: 180),
-                curve: Curves.easeOutCubic,
-                child: Icon(
-                  Ionicons.play_circle_outline,
-                  color: playIconColor,
-                  size: 22,
-                ),
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if (episode.userData?.played == true)
+                    Padding(
+                      padding: const EdgeInsets.only(right: 8.0),
+                      child: Icon(
+                        Ionicons.checkmark_circle,
+                        color: accentColor.withOpacity(0.7),
+                        size: 18,
+                      ),
+                    ),
+                  AnimatedScale(
+                    scale: isEpisodeHovered ? 1.1 : 1.0,
+                    duration: const Duration(milliseconds: 180),
+                    curve: Curves.easeOutCubic,
+                    child: Icon(
+                      Ionicons.play_circle_outline,
+                      color: playIconColor,
+                      size: 22,
+                    ),
+                  ),
+                ],
               ),
               onTap: () async {
                 if (_isDetailAutoMatching) {

--- a/lib/services/emby_service.dart
+++ b/lib/services/emby_service.dart
@@ -855,7 +855,7 @@ class EmbyService extends MediaServerServiceBase
     }
 
     final response = await _makeAuthenticatedRequest(
-        '/emby/Shows/$seriesId/Episodes?userId=$_userId&seasonId=$seasonId');
+        '/emby/Shows/$seriesId/Episodes?userId=$_userId&seasonId=$seasonId&Fields=Overview,UserData');
 
     if (response.statusCode == 200) {
       final data = json.decode(response.body);

--- a/lib/services/emby_service.dart
+++ b/lib/services/emby_service.dart
@@ -855,7 +855,7 @@ class EmbyService extends MediaServerServiceBase
     }
 
     final response = await _makeAuthenticatedRequest(
-        '/emby/Shows/$seriesId/Episodes?userId=$_userId&seasonId=$seasonId&Fields=Overview,UserData');
+        '/emby/Shows/$seriesId/Episodes?userId=$_userId&seasonId=$seasonId&Fields=Overview,UserData&EnableUserData=true');
 
     if (response.statusCode == 200) {
       final data = json.decode(response.body);

--- a/lib/services/jellyfin_service.dart
+++ b/lib/services/jellyfin_service.dart
@@ -772,7 +772,7 @@ class JellyfinService extends MediaServerServiceBase
     }
 
     final response = await _makeAuthenticatedRequest(
-        '/Shows/$seriesId/Episodes?userId=$_userId&seasonId=$seasonId');
+        '/Shows/$seriesId/Episodes?userId=$_userId&seasonId=$seasonId&fields=Overview,UserData');
 
     if (response.statusCode == 200) {
       final data = json.decode(response.body);

--- a/lib/services/jellyfin_service.dart
+++ b/lib/services/jellyfin_service.dart
@@ -772,7 +772,7 @@ class JellyfinService extends MediaServerServiceBase
     }
 
     final response = await _makeAuthenticatedRequest(
-        '/Shows/$seriesId/Episodes?userId=$_userId&seasonId=$seasonId&fields=Overview,UserData');
+        '/Shows/$seriesId/Episodes?userId=$_userId&seasonId=$seasonId&fields=Overview,UserData&enableUserData=true');
 
     if (response.statusCode == 200) {
       final data = json.decode(response.body);

--- a/lib/services/jellyfin_service.dart
+++ b/lib/services/jellyfin_service.dart
@@ -772,7 +772,7 @@ class JellyfinService extends MediaServerServiceBase
     }
 
     final response = await _makeAuthenticatedRequest(
-        '/Shows/$seriesId/Episodes?userId=$_userId&seasonId=$seasonId&fields=Overview,UserData&enableUserData=true');
+        '/Shows/$seriesId/Episodes?userId=$_userId&seasonId=$seasonId&Fields=Overview,UserData&EnableUserData=true');
 
     if (response.statusCode == 200) {
       final data = json.decode(response.body);
@@ -917,7 +917,7 @@ class JellyfinService extends MediaServerServiceBase
     try {
       // 使用adjacentTo参数获取相邻剧集，限制3个结果（上一集、当前集、下一集）
       final response = await _makeAuthenticatedRequest(
-          '/Items?adjacentTo=$currentEpisodeId&limit=3&fields=Overview,MediaSources');
+          '/Items?adjacentTo=$currentEpisodeId&limit=3&Fields=Overview,MediaSources');
 
       if (response.statusCode == 200) {
         final data = json.decode(response.body);

--- a/lib/themes/cupertino/pages/cupertino_media_server_detail_page.dart
+++ b/lib/themes/cupertino/pages/cupertino_media_server_detail_page.dart
@@ -600,6 +600,7 @@ class _CupertinoMediaServerDetailPageState
           duration: episode.runTimeTicks != null
               ? (episode.runTimeTicks / 10000000).round()
               : null,
+          watched: episode.userData?.played == true,
         ),
       );
     }
@@ -1619,6 +1620,15 @@ class _CupertinoMediaServerDetailPageState
               ),
             ),
             const SizedBox(width: 12),
+            if (episode.userData?.played == true)
+              Padding(
+                padding: const EdgeInsets.only(right: 8.0),
+                child: Icon(
+                  CupertinoIcons.checkmark_circle_fill,
+                  color: CupertinoColors.activeGreen.withOpacity(0.7),
+                  size: 18,
+                ),
+              ),
             Icon(
               CupertinoIcons.play_circle,
               color: iconColor,

--- a/lib/themes/cupertino/pages/cupertino_media_server_detail_page.dart
+++ b/lib/themes/cupertino/pages/cupertino_media_server_detail_page.dart
@@ -600,7 +600,7 @@ class _CupertinoMediaServerDetailPageState
           duration: episode.runTimeTicks != null
               ? (episode.runTimeTicks / 10000000).round()
               : null,
-          watched: episode.userData?.played == true,
+          watched: episode.userData?.played,
         ),
       );
     }
@@ -1547,6 +1547,11 @@ class _CupertinoMediaServerDetailPageState
                 .replaceAll('<br />', ' ')
             : null;
 
+    // 支持 SharedRemoteEpisode.watched 和 raw episode userData?.played 两种类型
+    final bool isEpisodeWatched = episode is SharedRemoteEpisode
+        ? episode.watched == true
+        : episode.userData?.played == true;
+
     return GestureDetector(
       onTap: () => _playEpisode(episode),
       child: Container(
@@ -1620,7 +1625,7 @@ class _CupertinoMediaServerDetailPageState
               ),
             ),
             const SizedBox(width: 12),
-            if (episode.userData?.played == true)
+            if (isEpisodeWatched)
               Padding(
                 padding: const EdgeInsets.only(right: 8.0),
                 child: Icon(

--- a/lib/themes/cupertino/widgets/cupertino_shared_anime_detail_page.dart
+++ b/lib/themes/cupertino/widgets/cupertino_shared_anime_detail_page.dart
@@ -1987,6 +1987,7 @@ class _CupertinoSharedAnimeDetailPageState
       context,
     );
     final episodeImage = _resolveEpisodeImage(episode);
+    final isWatched = episode.watched == true;
 
     return GestureDetector(
       onTap: hasSharedFile ? () => _playEpisode(episode) : null,
@@ -2023,6 +2024,16 @@ class _CupertinoSharedAnimeDetailPageState
                     if (!hasSharedFile)
                       Container(
                         color: CupertinoColors.black.withOpacity(0.2),
+                      ),
+                    if (isWatched)
+                      Positioned(
+                        top: 8,
+                        left: 8,
+                        child: Icon(
+                          CupertinoIcons.checkmark_circle_fill,
+                          size: 22,
+                          color: CupertinoColors.activeGreen.withOpacity(0.85),
+                        ),
                       ),
                     if (hasSharedFile)
                       Positioned(
@@ -3623,6 +3634,7 @@ class _CupertinoSharedAnimeDetailPageState
     final hasSharedFile = episode.fileExists;
     final isEnabled = hasSharedFile;
     final episodeImage = _resolveEpisodeImage(episode);
+    final isWatched = episode.watched == true;
 
     final Widget leadingWidget = episodeImage != null
         ? ClipRRect(
@@ -3751,6 +3763,15 @@ class _CupertinoSharedAnimeDetailPageState
             Row(
               mainAxisSize: MainAxisSize.min,
               children: [
+                if (isWatched)
+                  Padding(
+                    padding: const EdgeInsets.only(right: 8),
+                    child: Icon(
+                      CupertinoIcons.checkmark_circle_fill,
+                      size: 18,
+                      color: CupertinoColors.activeGreen.withOpacity(0.75),
+                    ),
+                  ),
                 if (hasSharedFile)
                   Container(
                     padding:


### PR DESCRIPTION
## Summary

Adds watched indicator (green checkmark) for episodes in the media server detail page, based on Emby/Jellyfin watch status.

## What Changed

### Data Models
- Added  field to  and 
- Added  field to 

### API
- Added  to Emby  request
- Added  to Jellyfin  request

### UI
- Material theme: green checkmark icon next to play button for watched episodes
- Cupertino theme: green filled checkmark icon for watched episodes

## Closes
Closes #221