### PR TITLE
fix: use platform-agnostic dandanplay_service import in WebDAVBrowserPage

### DIFF
--- a/lib/pages/webdav_browser_page.dart
+++ b/lib/pages/webdav_browser_page.dart
@@ -8,7 +8,7 @@ import 'package:nipaplay/themes/nipaplay/widgets/webdav_connection_dialog.dart';
 import 'package:nipaplay/models/watch_history_model.dart';
 import 'package:nipaplay/models/playable_item.dart';
 import 'package:nipaplay/services/playback_service.dart';
-import 'package:nipaplay/services/dandanplay_service_io.dart';
+import 'package:nipaplay/services/dandanplay_service.dart';
 import 'package:nipaplay/utils/webdav_file_sorter.dart';
 import 'package:kmbal_ionicons/kmbal_ionicons.dart';
 import 'package:nipaplay/utils/app_accent_color.dart';


### PR DESCRIPTION
## 修复内容

将 `webdav_browser_page.dart` 中的 `dandanplay_service_io.dart` 导入改为 `dandanplay_service.dart`（条件导出封装），避免 web 编译时 `dart:io` 编译失败。

## 背景

PR #491 引入了 WebDAV bgmid 快速匹配功能，但使用了 `_io.dart` 直接导入。项目已有条件导出封装 `dandanplay_service.dart`（native 用 `_io.dart`，web 用 `_stub.dart`），应该使用它来保持跨平台兼容性。

Codex review 指出了这个问题。

Refs: #491