### PR TITLE
fix: add missing getBangumiByBgmId stub for Web platform

### DIFF
--- a/lib/services/dandanplay_service_stub.dart
+++ b/lib/services/dandanplay_service_stub.dart
@@ -1301,6 +1301,12 @@ class DandanplayService {
     }
   }
 
+  /// 通过 Bangumi.tv subjectId 获取番剧详情（Web stub — 不支持）
+  static Future<Map<String, dynamic>?> getBangumiByBgmId(int bgmtvSubjectId) async {
+    debugPrint('[弹弹play服务-Web] getBangumiByBgmId not supported on web');
+    return null;
+  }
+
   static Future<Map<int, bool>> getEpisodesWatchStatus(
       List<int> episodeIds) async {
     try {


### PR DESCRIPTION
## 问题描述

PR #491 添加了  方法到 ，但遗漏了  中的 stub 实现，导致 Web 平台编译失败。

## 修复内容

在  中添加  的 stub 实现：

```dart
/// 通过 Bangumi.tv subjectId 获取番剧详情（Web stub — 不支持）
static Future<Map<String, dynamic>?> getBangumiByBgmId(int bgmtvSubjectId) async {
  debugPrint('[弹弹play服务-Web] getBangumiByBgmId not supported on web');
  return null;
}
```

返回  并输出调试日志，与文件中其他 Web 不支持的方法 stub 保持一致。

## 测试

- [x] Web 平台编译通过
- [x] 方法签名与  版本一致