### PR TITLE
Promote Rust file scanning

### DIFF
--- a/lib/constants/settings_keys.dart
+++ b/lib/constants/settings_keys.dart
@@ -24,8 +24,6 @@ class SettingsKeys {
   static const String labsEnableLargeScreenMode =
       'labs_enable_large_screen_mode';
 
-  static const String labsEnableRustFileScan = 'labs_enable_rust_file_scan';
-
   static const String torrentDownloadDirectory = 'torrent_download_directory';
 
   static const String downloaderEnabled = 'downloader_enabled';

--- a/lib/providers/labs_settings_provider.dart
+++ b/lib/providers/labs_settings_provider.dart
@@ -8,20 +8,14 @@ class LabsSettingsProvider extends ChangeNotifier {
   }
 
   bool _enableLargeScreenMode = false;
-  bool _enableRustFileScan = false;
   bool _isLoaded = false;
 
   bool get enableLargeScreenMode => _enableLargeScreenMode;
-  bool get enableRustFileScan => _enableRustFileScan;
   bool get isLoaded => _isLoaded;
 
   Future<void> _loadSettings() async {
     _enableLargeScreenMode = await SettingsStorage.loadBool(
       SettingsKeys.labsEnableLargeScreenMode,
-      defaultValue: false,
-    );
-    _enableRustFileScan = await SettingsStorage.loadBool(
-      SettingsKeys.labsEnableRustFileScan,
       defaultValue: false,
     );
     _isLoaded = true;
@@ -34,16 +28,6 @@ class LabsSettingsProvider extends ChangeNotifier {
     notifyListeners();
     await SettingsStorage.saveBool(
       SettingsKeys.labsEnableLargeScreenMode,
-      enabled,
-    );
-  }
-
-  Future<void> setEnableRustFileScan(bool enabled) async {
-    if (_enableRustFileScan == enabled) return;
-    _enableRustFileScan = enabled;
-    notifyListeners();
-    await SettingsStorage.saveBool(
-      SettingsKeys.labsEnableRustFileScan,
       enabled,
     );
   }

--- a/lib/services/rust_file_scan_service.dart
+++ b/lib/services/rust_file_scan_service.dart
@@ -10,7 +10,6 @@ class RustFileScanResult {
     required this.newFiles,
     required this.modifiedFiles,
     required this.deletedFiles,
-    required this.folderHash,
     required this.currentHashes,
   });
 
@@ -20,28 +19,19 @@ class RustFileScanResult {
   final List<String> newFiles;
   final List<String> modifiedFiles;
   final List<String> deletedFiles;
-  final String folderHash;
   final Map<String, String> currentHashes;
 }
 
 class RustFileScanService {
   const RustFileScanService._();
 
-  static Future<bool> isAvailable() async {
-    if (kIsWeb) return false;
-    try {
-      await ensureRustInitialized();
-      return rust.isRustFileScanAvailable();
-    } catch (error) {
-      debugPrint('RustFileScanService: Rust scan unavailable: $error');
-      return false;
-    }
-  }
-
   static Future<RustFileScanResult> calculateDiff({
     required String folderPath,
     required Map<String, String> cachedHashes,
   }) async {
+    if (kIsWeb) {
+      throw UnsupportedError('Rust file scan is not available on Web.');
+    }
     await ensureRustInitialized();
     final diff = await rust.diffVideoFiles(
       folderPath: folderPath,
@@ -62,7 +52,6 @@ class RustFileScanService {
       newFiles: List<String>.from(diff.newFiles),
       modifiedFiles: List<String>.from(diff.modifiedFiles),
       deletedFiles: List<String>.from(diff.deletedFiles),
-      folderHash: diff.folderHash,
       currentHashes: {
         for (final entry in diff.currentHashes) entry.relativePath: entry.hash,
       },

--- a/lib/services/scan_service.dart
+++ b/lib/services/scan_service.dart
@@ -2,15 +2,11 @@ import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'dart:io' if (dart.library.io) 'dart:io';
 import 'package:path/path.dart' as p;
-import 'package:nipaplay/constants/settings_keys.dart';
 import 'package:nipaplay/models/watch_history_model.dart';
 import 'package:nipaplay/services/concurrent_video_processor.dart';
 import 'package:nipaplay/services/rust_file_scan_service.dart';
 import 'package:nipaplay/utils/ios_container_path_fixer.dart';
-import 'package:nipaplay/utils/settings_storage.dart';
-import 'dart:async';
 import 'dart:convert';
-import 'package:crypto/crypto.dart';
 // Import Provider if ScanService needs to directly refresh other providers,
 // otherwise it will be refreshed by UI listening to this service.
 // import 'package:provider/provider.dart';
@@ -96,7 +92,6 @@ class _FolderFileDiff {
   final List<String> newFiles;
   final List<String> modifiedFiles;
   final List<String> deletedFiles;
-  final String? folderHash;
   final Map<String, String>? currentHashes;
 
   _FolderFileDiff({
@@ -106,7 +101,6 @@ class _FolderFileDiff {
     required this.newFiles,
     required this.modifiedFiles,
     required this.deletedFiles,
-    this.folderHash,
     this.currentHashes,
   });
 
@@ -120,7 +114,6 @@ class _FolderFileDiff {
 
 class ScanService with ChangeNotifier {
   static const String _scannedFoldersPrefsKey = 'nipaplay_scanned_folders';
-  static const String _folderHashCachePrefsKey = 'nipaplay_folder_hash_cache';
   static const String _subFolderHashCachePrefsKey =
       'nipaplay_subfolder_hash_cache';
   // _lastScannedDirectoryPickerPathKey will likely remain in UI as it's picker-specific
@@ -128,10 +121,7 @@ class ScanService with ChangeNotifier {
   List<String> _scannedFolders = [];
   List<String> get scannedFolders => List.unmodifiable(_scannedFolders);
 
-  // 文件夹hash缓存，用于判断文件夹是否有变化
-  Map<String, String> _folderHashCache = {};
-
-  // 子文件夹hash缓存，用于精确定位变化
+  // 文件hash缓存由 Rust 扫描结果维护，用于精确定位新增、修改、删除文件。
   Map<String, Map<String, String>> _subFolderHashCache = {};
 
   // 批量刷新阶段已经算出的 diff，避免正式扫描时重复遍历目录。
@@ -182,7 +172,6 @@ class ScanService with ChangeNotifier {
 
   ScanService() {
     _loadScannedFolders();
-    _loadFolderHashCache();
     _loadSubFolderHashCache();
     // 启动时自动检测变化
     _performStartupChangeDetection();
@@ -250,34 +239,6 @@ class ScanService with ChangeNotifier {
     }
   }
 
-  /// 加载文件夹hash缓存
-  Future<void> _loadFolderHashCache() async {
-    try {
-      final prefs = await SharedPreferences.getInstance();
-      final cacheJson = prefs.getString(_folderHashCachePrefsKey);
-      if (cacheJson != null) {
-        final Map<String, dynamic> cacheMap = json.decode(cacheJson);
-        _folderHashCache =
-            cacheMap.map((key, value) => MapEntry(key, value.toString()));
-      }
-    } catch (e) {
-      debugPrint("加载文件夹hash缓存失败: $e");
-      _folderHashCache = {};
-    }
-  }
-
-  /// 保存文件夹hash缓存
-  Future<void> _saveFolderHashCache() async {
-    try {
-      final prefs = await SharedPreferences.getInstance();
-      final cacheJson = json.encode(_folderHashCache);
-      await prefs.setString(_folderHashCachePrefsKey, cacheJson);
-      debugPrint("文件夹hash缓存已保存，包含 ${_folderHashCache.length} 个条目");
-    } catch (e) {
-      debugPrint("保存文件夹hash缓存失败: $e");
-    }
-  }
-
   /// 加载子文件夹hash缓存
   Future<void> _loadSubFolderHashCache() async {
     try {
@@ -311,16 +272,6 @@ class ScanService with ChangeNotifier {
     }
   }
 
-  Future<bool> _shouldUseRustFileScan() async {
-    if (kIsWeb) return false;
-    final enabled = await SettingsStorage.loadBool(
-      SettingsKeys.labsEnableRustFileScan,
-      defaultValue: false,
-    );
-    if (!enabled) return false;
-    return RustFileScanService.isAvailable();
-  }
-
   _FolderFileDiff _diffFromRustResult(RustFileScanResult result) {
     return _FolderFileDiff(
       currentCount: result.currentCount,
@@ -329,171 +280,50 @@ class ScanService with ChangeNotifier {
       newFiles: result.newFiles,
       modifiedFiles: result.modifiedFiles,
       deletedFiles: result.deletedFiles,
-      folderHash: result.folderHash,
       currentHashes: result.currentHashes,
     );
   }
 
-  Future<_FolderFileDiff?> _tryCalculateFolderFileDiffWithRust(
+  Future<_FolderFileDiff> _calculateFolderFileDiffWithRust(
     String folderPath,
   ) async {
-    if (!await _shouldUseRustFileScan()) return null;
-    try {
-      final result = await RustFileScanService.calculateDiff(
-        folderPath: folderPath,
-        cachedHashes: _subFolderHashCache[folderPath] ?? {},
-      );
-      debugPrint(
-        "Rust 文件扫描完成 $folderPath: ${result.currentCount} 个视频文件",
-      );
-      return _diffFromRustResult(result);
-    } catch (e) {
-      debugPrint("Rust 文件扫描失败，回退 Dart 扫描 $folderPath: $e");
-      return null;
-    }
+    final result = await RustFileScanService.calculateDiff(
+      folderPath: folderPath,
+      cachedHashes: _subFolderHashCache[folderPath] ?? {},
+    );
+    debugPrint(
+      "Rust 文件扫描完成 $folderPath: ${result.currentCount} 个视频文件",
+    );
+    return _diffFromRustResult(result);
   }
 
-  Future<String?> _tryCalculateFolderHashWithRust(String folderPath) async {
-    if (!await _shouldUseRustFileScan()) return null;
-    try {
-      final result = await RustFileScanService.calculateDiff(
-        folderPath: folderPath,
-        cachedHashes: _subFolderHashCache[folderPath] ?? {},
-      );
-      final diff = _diffFromRustResult(result);
-      _precomputedFolderDiffs[folderPath] = diff;
-      return result.folderHash;
-    } catch (e) {
-      debugPrint("Rust 文件夹 hash 计算失败，回退 Dart 扫描 $folderPath: $e");
-      return null;
-    }
-  }
-
-  Future<void> _storeDiffHashes(
+  Future<void> _storeFileHashes(
     String folderPath,
     _FolderFileDiff diff,
   ) async {
-    var changed = false;
-    if (diff.folderHash != null && diff.folderHash!.isNotEmpty) {
-      _folderHashCache[folderPath] = diff.folderHash!;
-      await _saveFolderHashCache();
-      changed = true;
-    }
-
     if (diff.currentHashes != null) {
       _subFolderHashCache[folderPath] = Map<String, String>.from(
         diff.currentHashes!,
       );
       await _saveSubFolderHashCache();
-      changed = true;
-    }
-
-    if (changed) {
       debugPrint("已使用扫描结果更新文件夹 $folderPath 的hash缓存");
     }
   }
 
-  /// 计算文件夹的hash值
-  /// 基于文件夹内所有视频文件的路径、大小和修改时间
-  Future<String> _calculateFolderHash(String folderPath) async {
-    if (kIsWeb) return ''; // Web平台无法访问本地文件系统
-    final rustHash = await _tryCalculateFolderHashWithRust(folderPath);
-    if (rustHash != null) {
-      return rustHash;
-    }
-
-    try {
-      final directory = Directory(folderPath);
-      if (!await directory.exists()) {
-        return '';
-      }
-
-      List<String> fileInfoList = [];
-
-      await for (var entity
-          in directory.list(recursive: true, followLinks: false)) {
-        if (entity is File) {
-          String extension = p.extension(entity.path).toLowerCase();
-          if (extension == '.mp4' || extension == '.mkv') {
-            try {
-              final stat = await entity.stat();
-              // 组合文件路径、大小和修改时间作为hash输入
-              final fileInfo =
-                  '${entity.path}|${stat.size}|${stat.modified.millisecondsSinceEpoch}';
-              fileInfoList.add(fileInfo);
-            } catch (e) {
-              // 如果无法获取文件信息，使用文件路径作为备用
-              fileInfoList.add(entity.path);
-            }
-          }
-        }
-      }
-
-      // 排序确保hash的一致性
-      fileInfoList.sort();
-
-      // 计算整个列表的hash
-      final combinedInfo = fileInfoList.join('\n');
-      final bytes = utf8.encode(combinedInfo);
-      final hash = sha256.convert(bytes).toString();
-
-      debugPrint(
-          "文件夹 $folderPath 的hash计算完成: $hash (包含 ${fileInfoList.length} 个视频文件)");
-      return hash;
-    } catch (e) {
-      debugPrint("计算文件夹hash失败 $folderPath: $e");
-      return '';
-    }
-  }
-
-  /// 检查文件夹是否有变化
-  Future<bool> _hasFolderChanged(String folderPath) async {
-    if (kIsWeb) return false; // 在Web上，假设没有变化
-    final currentHash = await _calculateFolderHash(folderPath);
-    final cachedHash = _folderHashCache[folderPath];
-
-    if (cachedHash == null) {
-      debugPrint("文件夹 $folderPath 没有缓存的hash，视为有变化");
-      return true;
-    }
-
-    final hasChanged = currentHash != cachedHash;
-    if (currentHash.length < 8 || cachedHash.length < 8) {
-      debugPrint(
-          "文件夹 $folderPath hash比较: ${hasChanged ? '有变化' : '无变化'} (当前: $currentHash, 缓存: $cachedHash)");
-      return hasChanged;
-    }
-    debugPrint(
-        "文件夹 $folderPath hash比较: ${hasChanged ? '有变化' : '无变化'} (当前: ${currentHash.substring(0, 8)}..., 缓存: ${cachedHash.substring(0, 8)}...)");
-    return hasChanged;
-  }
-
-  /// 更新文件夹hash缓存
-  Future<void> _updateFolderHash(
+  /// 更新文件hash缓存
+  Future<void> _updateFileHashes(
     String folderPath, {
     _FolderFileDiff? precomputedDiff,
   }) async {
     if (kIsWeb) return;
-    final diff = precomputedDiff ?? _precomputedFolderDiffs.remove(folderPath);
-    if (diff != null &&
-        (diff.folderHash != null || diff.currentHashes != null)) {
-      await _storeDiffHashes(folderPath, diff);
-      return;
+    try {
+      final diff = precomputedDiff ??
+          _precomputedFolderDiffs.remove(folderPath) ??
+          await _calculateFolderFileDiffWithRust(folderPath);
+      await _storeFileHashes(folderPath, diff);
+    } catch (e) {
+      debugPrint("更新文件夹hash缓存失败 $folderPath: $e");
     }
-
-    final currentHash = await _calculateFolderHash(folderPath);
-    if (currentHash.isNotEmpty) {
-      _folderHashCache[folderPath] = currentHash;
-      await _saveFolderHashCache();
-      debugPrint("已更新文件夹 $folderPath 的hash缓存");
-    }
-
-    // 同时更新子文件夹hash缓存
-    final subFolderHashes = await _calculateSubFolderHashes(folderPath);
-    _subFolderHashCache[folderPath] = subFolderHashes;
-    await _saveSubFolderHashCache();
-    debugPrint(
-        "已更新文件夹 $folderPath 的子文件夹hash缓存，包含 ${subFolderHashes.length} 个文件");
   }
 
   /// 清理不存在文件夹的hash缓存
@@ -501,7 +331,7 @@ class ScanService with ChangeNotifier {
     if (kIsWeb) return;
     final keysToRemove = <String>[];
 
-    for (final folderPath in _folderHashCache.keys) {
+    for (final folderPath in _subFolderHashCache.keys) {
       if (!_scannedFolders.contains(folderPath) ||
           !await Directory(folderPath).exists()) {
         keysToRemove.add(folderPath);
@@ -509,12 +339,10 @@ class ScanService with ChangeNotifier {
     }
 
     for (final key in keysToRemove) {
-      _folderHashCache.remove(key);
-      _subFolderHashCache.remove(key); // 同时清理子文件夹缓存
+      _subFolderHashCache.remove(key);
     }
 
     if (keysToRemove.isNotEmpty) {
-      await _saveFolderHashCache();
       await _saveSubFolderHashCache();
       debugPrint("已清理 ${keysToRemove.length} 个无效的文件夹hash缓存");
     }
@@ -522,9 +350,7 @@ class ScanService with ChangeNotifier {
 
   /// 清理所有文件夹hash缓存，强制下次扫描时重新检查所有文件夹
   Future<void> clearAllFolderHashCache() async {
-    _folderHashCache.clear();
     _subFolderHashCache.clear();
-    await _saveFolderHashCache();
     await _saveSubFolderHashCache();
     debugPrint("已清理所有文件夹hash缓存");
     _updateScanMessage("已清理智能扫描缓存，下次扫描将检查所有文件夹。");
@@ -588,54 +414,6 @@ class ScanService with ChangeNotifier {
     );
   }
 
-  /// 计算文件夹内所有子文件夹和视频文件的hash
-  Future<Map<String, String>> _calculateSubFolderHashes(
-      String folderPath) async {
-    if (kIsWeb) return {};
-    final rustDiff = await _tryCalculateFolderFileDiffWithRust(folderPath);
-    if (rustDiff?.currentHashes != null) {
-      return Map<String, String>.from(rustDiff!.currentHashes!);
-    }
-
-    final Map<String, String> subHashes = {};
-    final directory = Directory(folderPath);
-
-    if (!await directory.exists()) {
-      return subHashes;
-    }
-
-    try {
-      await for (var entity
-          in directory.list(recursive: true, followLinks: false)) {
-        if (entity is File) {
-          String extension = p.extension(entity.path).toLowerCase();
-          if (extension == '.mp4' || extension == '.mkv') {
-            try {
-              final stat = await entity.stat();
-              final relativePath = p.relative(entity.path, from: folderPath);
-              final fileInfo =
-                  '${stat.size}|${stat.modified.millisecondsSinceEpoch}';
-              final bytes = utf8.encode(fileInfo);
-              final hash = sha256
-                  .convert(bytes)
-                  .toString()
-                  .substring(0, 16); // 使用短hash节省空间
-              subHashes[relativePath] = hash;
-            } catch (e) {
-              // 如果无法获取文件信息，使用文件路径作为备用
-              final relativePath = p.relative(entity.path, from: folderPath);
-              subHashes[relativePath] = 'error';
-            }
-          }
-        }
-      }
-    } catch (e) {
-      debugPrint("计算子文件夹hash失败 $folderPath: $e");
-    }
-
-    return subHashes;
-  }
-
   /// 计算文件夹内视频文件的变化明细
   Future<_FolderFileDiff> _calculateFolderFileDiff(String folderPath) async {
     final precomputed = _precomputedFolderDiffs.remove(folderPath);
@@ -643,50 +421,7 @@ class ScanService with ChangeNotifier {
       return precomputed;
     }
 
-    final rustDiff = await _tryCalculateFolderFileDiffWithRust(folderPath);
-    if (rustDiff != null) {
-      return rustDiff;
-    }
-
-    final currentSubFolderHashes = await _calculateSubFolderHashes(folderPath);
-    final cachedSubFolderHashes = _subFolderHashCache[folderPath] ?? {};
-
-    final List<String> newFiles = [];
-    final List<String> modifiedFiles = [];
-    final List<String> deletedFiles = [];
-
-    for (final entry in currentSubFolderHashes.entries) {
-      final subPath = entry.key;
-      final currentHash = entry.value;
-      final cachedHash = cachedSubFolderHashes[subPath];
-
-      if (cachedHash == null) {
-        newFiles.add(subPath);
-      } else if (cachedHash != currentHash) {
-        modifiedFiles.add(subPath);
-      }
-    }
-
-    for (final cachedPath in cachedSubFolderHashes.keys) {
-      if (!currentSubFolderHashes.containsKey(cachedPath)) {
-        deletedFiles.add(cachedPath);
-      }
-    }
-
-    final List<String> currentFiles = currentSubFolderHashes.keys.toList()
-      ..sort();
-    newFiles.sort();
-    modifiedFiles.sort();
-    deletedFiles.sort();
-
-    return _FolderFileDiff(
-      currentCount: currentSubFolderHashes.length,
-      cachedCount: cachedSubFolderHashes.length,
-      currentFiles: currentFiles,
-      newFiles: newFiles,
-      modifiedFiles: modifiedFiles,
-      deletedFiles: deletedFiles,
-    );
+    return _calculateFolderFileDiffWithRust(folderPath);
   }
 
   /// 获取变化检测结果的摘要
@@ -808,13 +543,11 @@ class ScanService with ChangeNotifier {
     _updateScanState(
         scanning: true, progress: 0.0, message: "开始智能刷新所有媒体文件夹...");
 
-    // 先清理无效的hash缓存
     await _cleanupFolderHashCache();
 
-    List<String> allFoldersToScan = List.from(_scannedFolders);
-    List<String> foldersNeedingScan = [];
+    final allFoldersToScan = List<String>.from(_scannedFolders);
+    final foldersNeedingScan = <String>[];
 
-    // 第一阶段：检查哪些文件夹需要扫描
     _updateScanState(message: "正在检查文件夹变化...");
 
     for (int i = 0; i < allFoldersToScan.length; i++) {
@@ -826,17 +559,31 @@ class ScanService with ChangeNotifier {
 
       final folderPath = allFoldersToScan[i];
       _updateScanState(
-          progress: (i + 1) / allFoldersToScan.length * 0.3, // 前30%用于检查
+          progress: (i + 1) / allFoldersToScan.length * 0.3,
           message:
               "检查文件夹变化: ${p.basename(folderPath)} (${i + 1}/${allFoldersToScan.length})");
 
-      final hasChanged = await _hasFolderChanged(folderPath);
-      if (hasChanged) {
-        foldersNeedingScan.add(folderPath);
+      try {
+        final diff = await _calculateFolderFileDiffWithRust(folderPath);
+        _precomputedFolderDiffs[folderPath] = diff;
+        if (diff.hasChanges) {
+          foldersNeedingScan.add(folderPath);
+        }
+      } catch (e) {
+        _precomputedFolderDiffs.clear();
+        _updateScanState(
+          scanning: false,
+          message: "Rust 文件扫描失败: $e",
+          completed: true,
+        );
+        return;
       }
     }
 
     if (foldersNeedingScan.isEmpty) {
+      for (final diffEntry in _precomputedFolderDiffs.entries) {
+        await _storeFileHashes(diffEntry.key, diffEntry.value);
+      }
       _precomputedFolderDiffs.clear();
       _updateScanState(
           scanning: false,
@@ -846,21 +593,20 @@ class ScanService with ChangeNotifier {
       return;
     }
 
-    // 第二阶段：扫描有变化的文件夹
     _updateScanState(
         message: "发现 ${foldersNeedingScan.length} 个文件夹有变化，开始扫描...");
 
-    int foldersProcessedCount = 0;
+    var foldersProcessedCount = 0;
 
-    for (String folderPath in foldersNeedingScan) {
+    for (final folderPath in foldersNeedingScan) {
       if (!_isScanning) {
         _precomputedFolderDiffs.clear();
         _updateScanState(scanning: false, message: "刷新已取消。", completed: true);
         return;
       }
 
-      final overallProgress = 0.3 +
-          (foldersProcessedCount / foldersNeedingScan.length) * 0.7; // 后70%用于扫描
+      final overallProgress =
+          0.3 + (foldersProcessedCount / foldersNeedingScan.length) * 0.7;
       _updateScanState(
           progress: overallProgress,
           message:
@@ -874,10 +620,9 @@ class ScanService with ChangeNotifier {
     }
 
     if (_isScanning || foldersProcessedCount == foldersNeedingScan.length) {
-      // 批量扫描完成，设置标志
       _justFinishedScanning = true;
       final skippedCount = allFoldersToScan.length - foldersNeedingScan.length;
-      String completionMessage =
+      var completionMessage =
           "智能刷新完成：扫描了 ${foldersNeedingScan.length} 个有变化的文件夹";
       if (skippedCount > 0) {
         completionMessage += "，跳过了 $skippedCount 个无变化的文件夹";
@@ -936,7 +681,23 @@ class ScanService with ChangeNotifier {
 
     // 第一阶段：分析文件变化
     _updateScanState(message: "正在分析文件变化...");
-    final diff = await _calculateFolderFileDiff(directoryPath);
+    final _FolderFileDiff diff;
+    try {
+      diff = await _calculateFolderFileDiff(directoryPath);
+    } catch (e) {
+      final message = "Rust 文件扫描失败: $e";
+      debugPrint("$message ($directoryPath)");
+      if (!isPartOfBatch) {
+        _updateScanState(
+          scanning: false,
+          message: message,
+          completed: true,
+        );
+      } else {
+        _updateScanMessage("${p.basename(directoryPath)} $message");
+      }
+      return;
+    }
     if (diff.currentCount == 0 && diff.cachedCount == 0) {
       if (!isPartOfBatch) {
         _totalFilesFound = 0;
@@ -950,26 +711,18 @@ class ScanService with ChangeNotifier {
       } else {
         _updateScanMessage("在 ${p.basename(directoryPath)} 中无视频文件。");
       }
-      await _updateFolderHash(directoryPath, precomputedDiff: diff);
+      await _updateFileHashes(directoryPath, precomputedDiff: diff);
       return;
     }
 
     List<String> filesToProcess = List<String>.from(diff.filesToProcess)
       ..sort();
-    if (filesToProcess.isEmpty &&
-        diff.deletedFiles.isEmpty &&
-        diff.currentFiles.isNotEmpty) {
-      final hasChanged = await _hasFolderChanged(directoryPath);
-      if (hasChanged) {
-        filesToProcess = List<String>.from(diff.currentFiles);
-      }
-    }
     if (filesToProcess.isEmpty) {
       if (diff.deletedFiles.isNotEmpty) {
         final deletionMessage =
             "检测到 ${diff.deletedFiles.length} 个文件被删除，无需重新刮削。";
         if (!isPartOfBatch) {
-          await _updateFolderHash(directoryPath, precomputedDiff: diff);
+          await _updateFileHashes(directoryPath, precomputedDiff: diff);
           _updateScanState(
             scanning: false,
             progress: 1.0,
@@ -977,12 +730,12 @@ class ScanService with ChangeNotifier {
             completed: true,
           );
         } else {
-          await _updateFolderHash(directoryPath, precomputedDiff: diff);
+          await _updateFileHashes(directoryPath, precomputedDiff: diff);
           _updateScanMessage("${p.basename(directoryPath)} $deletionMessage");
         }
       } else {
         if (!isPartOfBatch) {
-          await _updateFolderHash(directoryPath, precomputedDiff: diff);
+          await _updateFileHashes(directoryPath, precomputedDiff: diff);
           _updateScanState(
             scanning: false,
             progress: 1.0,
@@ -990,7 +743,7 @@ class ScanService with ChangeNotifier {
             completed: true,
           );
         } else {
-          await _updateFolderHash(directoryPath, precomputedDiff: diff);
+          await _updateFileHashes(directoryPath, precomputedDiff: diff);
           _updateScanMessage("文件夹 ${p.basename(directoryPath)} 没有变化，已跳过。");
         }
       }
@@ -1062,7 +815,7 @@ class ScanService with ChangeNotifier {
       }
 
       _justFinishedScanning = true;
-      await _updateFolderHash(directoryPath, precomputedDiff: diff);
+      await _updateFileHashes(directoryPath, precomputedDiff: diff);
       _updateScanState(
           scanning: false,
           progress: 1.0,
@@ -1070,7 +823,7 @@ class ScanService with ChangeNotifier {
           completed: true);
     } else if (isPartOfBatch) {
       _totalFilesFound += videoFiles.length;
-      await _updateFolderHash(directoryPath, precomputedDiff: diff);
+      await _updateFileHashes(directoryPath, precomputedDiff: diff);
     }
   }
 
@@ -1139,17 +892,10 @@ class ScanService with ChangeNotifier {
       _scannedFolders = List.from(_scannedFolders)..remove(folderPath);
       await _saveScannedFolders();
 
-      // 同时移除对应的hash缓存
-      if (_folderHashCache.containsKey(folderPath)) {
-        _folderHashCache.remove(folderPath);
-        await _saveFolderHashCache();
-        debugPrint("已清理文件夹 $folderPath 的hash缓存");
-      }
-
       if (_subFolderHashCache.containsKey(folderPath)) {
         _subFolderHashCache.remove(folderPath);
         await _saveSubFolderHashCache();
-        debugPrint("已清理文件夹 $folderPath 的子文件夹hash缓存");
+        debugPrint("已清理文件夹 $folderPath 的文件hash缓存");
       }
 
       _updateScanMessage("已从扫描列表移除文件夹: $folderPath");

--- a/lib/services/scan_service.dart
+++ b/lib/services/scan_service.dart
@@ -570,13 +570,11 @@ class ScanService with ChangeNotifier {
           foldersNeedingScan.add(folderPath);
         }
       } catch (e) {
-        _precomputedFolderDiffs.clear();
-        _updateScanState(
-          scanning: false,
-          message: "Rust 文件扫描失败: $e",
-          completed: true,
-        );
-        return;
+        // Rust diff failed for this folder — fall back to a full scan
+        // instead of aborting the entire batch.
+        debugPrint(
+            'Rust 文件 diff 失败，回退到全量扫描: $folderPath — $e');
+        foldersNeedingScan.add(folderPath);
       }
     }
 

--- a/lib/src/rust/api/file_scan.dart
+++ b/lib/src/rust/api/file_scan.dart
@@ -6,118 +6,130 @@
 import '../frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
+// These functions are ignored because they are not marked as `pub`: `collect_video_files`, `ensure_existing_directory`, `is_video_file`, `make_scan_entry`, `path_to_dart_string`, `sha256_hex`
 
-            // These functions are ignored because they are not marked as `pub`: `calculate_folder_hash`, `collect_video_files`, `ensure_existing_directory`, `is_video_file`, `make_scan_entry`, `path_to_dart_string`, `sha256_hex`
+Future<RustFileScanSnapshot> scanVideoFiles({required String folderPath}) =>
+    RustLib.instance.api.crateApiFileScanScanVideoFiles(folderPath: folderPath);
 
+Future<RustFileScanDiff> diffVideoFiles(
+        {required String folderPath,
+        required List<RustFileHashEntry> cachedHashes}) =>
+    RustLib.instance.api.crateApiFileScanDiffVideoFiles(
+        folderPath: folderPath, cachedHashes: cachedHashes);
 
-            bool  isRustFileScanAvailable() => RustLib.instance.api.crateApiFileScanIsRustFileScanAvailable();
+class RustFileHashEntry {
+  final String relativePath;
+  final String hash;
 
-Future<RustFileScanSnapshot>  scanVideoFiles({required String folderPath }) => RustLib.instance.api.crateApiFileScanScanVideoFiles(folderPath: folderPath);
+  const RustFileHashEntry({
+    required this.relativePath,
+    required this.hash,
+  });
 
-Future<RustFileScanDiff>  diffVideoFiles({required String folderPath , required List<RustFileHashEntry> cachedHashes }) => RustLib.instance.api.crateApiFileScanDiffVideoFiles(folderPath: folderPath, cachedHashes: cachedHashes);
+  @override
+  int get hashCode => relativePath.hashCode ^ hash.hashCode;
 
-            class RustFileHashEntry  {
-                final String relativePath;
-final String hash;
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RustFileHashEntry &&
+          runtimeType == other.runtimeType &&
+          relativePath == other.relativePath &&
+          hash == other.hash;
+}
 
-                const RustFileHashEntry({required this.relativePath ,required this.hash ,});
+class RustFileScanDiff {
+  final int currentCount;
+  final int cachedCount;
+  final List<String> currentFiles;
+  final List<String> newFiles;
+  final List<String> modifiedFiles;
+  final List<String> deletedFiles;
+  final List<RustFileHashEntry> currentHashes;
 
-                
-                
+  const RustFileScanDiff({
+    required this.currentCount,
+    required this.cachedCount,
+    required this.currentFiles,
+    required this.newFiles,
+    required this.modifiedFiles,
+    required this.deletedFiles,
+    required this.currentHashes,
+  });
 
-                
-        @override
-        int get hashCode => relativePath.hashCode^hash.hashCode;
-        
+  @override
+  int get hashCode =>
+      currentCount.hashCode ^
+      cachedCount.hashCode ^
+      currentFiles.hashCode ^
+      newFiles.hashCode ^
+      modifiedFiles.hashCode ^
+      deletedFiles.hashCode ^
+      currentHashes.hashCode;
 
-                
-        @override
-        bool operator ==(Object other) =>
-            identical(this, other) ||
-            other is RustFileHashEntry &&
-                runtimeType == other.runtimeType
-                && relativePath == other.relativePath&& hash == other.hash;
-        
-            }
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RustFileScanDiff &&
+          runtimeType == other.runtimeType &&
+          currentCount == other.currentCount &&
+          cachedCount == other.cachedCount &&
+          currentFiles == other.currentFiles &&
+          newFiles == other.newFiles &&
+          modifiedFiles == other.modifiedFiles &&
+          deletedFiles == other.deletedFiles &&
+          currentHashes == other.currentHashes;
+}
 
-class RustFileScanDiff  {
-                final int currentCount;
-final int cachedCount;
-final List<String> currentFiles;
-final List<String> newFiles;
-final List<String> modifiedFiles;
-final List<String> deletedFiles;
-final String folderHash;
-final List<RustFileHashEntry> currentHashes;
+class RustFileScanEntry {
+  final String relativePath;
+  final String absolutePath;
+  final PlatformInt64 size;
+  final PlatformInt64 modifiedMillis;
+  final String fileHash;
 
-                const RustFileScanDiff({required this.currentCount ,required this.cachedCount ,required this.currentFiles ,required this.newFiles ,required this.modifiedFiles ,required this.deletedFiles ,required this.folderHash ,required this.currentHashes ,});
+  const RustFileScanEntry({
+    required this.relativePath,
+    required this.absolutePath,
+    required this.size,
+    required this.modifiedMillis,
+    required this.fileHash,
+  });
 
-                
-                
+  @override
+  int get hashCode =>
+      relativePath.hashCode ^
+      absolutePath.hashCode ^
+      size.hashCode ^
+      modifiedMillis.hashCode ^
+      fileHash.hashCode;
 
-                
-        @override
-        int get hashCode => currentCount.hashCode^cachedCount.hashCode^currentFiles.hashCode^newFiles.hashCode^modifiedFiles.hashCode^deletedFiles.hashCode^folderHash.hashCode^currentHashes.hashCode;
-        
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RustFileScanEntry &&
+          runtimeType == other.runtimeType &&
+          relativePath == other.relativePath &&
+          absolutePath == other.absolutePath &&
+          size == other.size &&
+          modifiedMillis == other.modifiedMillis &&
+          fileHash == other.fileHash;
+}
 
-                
-        @override
-        bool operator ==(Object other) =>
-            identical(this, other) ||
-            other is RustFileScanDiff &&
-                runtimeType == other.runtimeType
-                && currentCount == other.currentCount&& cachedCount == other.cachedCount&& currentFiles == other.currentFiles&& newFiles == other.newFiles&& modifiedFiles == other.modifiedFiles&& deletedFiles == other.deletedFiles&& folderHash == other.folderHash&& currentHashes == other.currentHashes;
-        
-            }
+class RustFileScanSnapshot {
+  final List<RustFileScanEntry> files;
 
-class RustFileScanEntry  {
-                final String relativePath;
-final String absolutePath;
-final PlatformInt64 size;
-final PlatformInt64 modifiedMillis;
-final String fileHash;
+  const RustFileScanSnapshot({
+    required this.files,
+  });
 
-                const RustFileScanEntry({required this.relativePath ,required this.absolutePath ,required this.size ,required this.modifiedMillis ,required this.fileHash ,});
+  @override
+  int get hashCode => files.hashCode;
 
-                
-                
-
-                
-        @override
-        int get hashCode => relativePath.hashCode^absolutePath.hashCode^size.hashCode^modifiedMillis.hashCode^fileHash.hashCode;
-        
-
-                
-        @override
-        bool operator ==(Object other) =>
-            identical(this, other) ||
-            other is RustFileScanEntry &&
-                runtimeType == other.runtimeType
-                && relativePath == other.relativePath&& absolutePath == other.absolutePath&& size == other.size&& modifiedMillis == other.modifiedMillis&& fileHash == other.fileHash;
-        
-            }
-
-class RustFileScanSnapshot  {
-                final String folderHash;
-final List<RustFileScanEntry> files;
-
-                const RustFileScanSnapshot({required this.folderHash ,required this.files ,});
-
-                
-                
-
-                
-        @override
-        int get hashCode => folderHash.hashCode^files.hashCode;
-        
-
-                
-        @override
-        bool operator ==(Object other) =>
-            identical(this, other) ||
-            other is RustFileScanSnapshot &&
-                runtimeType == other.runtimeType
-                && folderHash == other.folderHash&& files == other.files;
-        
-            }
-            
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RustFileScanSnapshot &&
+          runtimeType == other.runtimeType &&
+          files == other.files;
+}

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -72,7 +72,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -1390884270;
+  int get rustContentHash => 629279474;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -90,8 +90,6 @@ abstract class RustLibApi extends BaseApi {
   Future<void> crateApiSimpleInitApp();
 
   bool crateApiPerformanceIsPerformanceProbeAvailable();
-
-  bool crateApiFileScanIsRustFileScanAvailable();
 
   bool crateApiTorrentIsTorrentEngineAvailable();
 
@@ -212,34 +210,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  bool crateApiFileScanIsRustFileScanAvailable() {
-    return handler.executeSync(SyncTask(
-      callFfi: () {
-        final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 4)!;
-      },
-      codec: SseCodec(
-        decodeSuccessData: sse_decode_bool,
-        decodeErrorData: null,
-      ),
-      constMeta: kCrateApiFileScanIsRustFileScanAvailableConstMeta,
-      argValues: [],
-      apiImpl: this,
-    ));
-  }
-
-  TaskConstMeta get kCrateApiFileScanIsRustFileScanAvailableConstMeta =>
-      const TaskConstMeta(
-        debugName: "is_rust_file_scan_available",
-        argNames: [],
-      );
-
-  @override
   bool crateApiTorrentIsTorrentEngineAvailable() {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 5)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 4)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -263,7 +238,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 6, port: port_);
+            funcId: 5, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_rust_cpu_sample,
@@ -287,7 +262,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 7, port: port_);
+            funcId: 6, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_rust_gpu_sample,
@@ -311,7 +286,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 8, port: port_);
+            funcId: 7, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_f_64,
@@ -335,7 +310,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 9, port: port_);
+            funcId: 8, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_rust_performance_sample,
@@ -361,7 +336,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(folderPath, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 10, port: port_);
+            funcId: 9, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_rust_file_scan_snapshot,
@@ -391,7 +366,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_String(downloadDir, serializer);
         sse_encode_bool(createFolderForTask, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 11, port: port_);
+            funcId: 10, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -421,7 +396,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_String(downloadDir, serializer);
         sse_encode_bool(createFolderForTask, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 12, port: port_);
+            funcId: 11, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -446,7 +421,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_i_32(id, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 13, port: port_);
+            funcId: 12, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -471,7 +446,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_i_32(id, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 14, port: port_);
+            funcId: 13, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -497,7 +472,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(downloadDir, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 15, port: port_);
+            funcId: 14, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -522,7 +497,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(downloadDir, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 16, port: port_);
+            funcId: 15, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -546,7 +521,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_i_32(id, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 17, port: port_);
+            funcId: 16, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -571,7 +546,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_i_32(id, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 18, port: port_);
+            funcId: 17, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -690,8 +665,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   RustFileScanDiff dco_decode_rust_file_scan_diff(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 8)
-      throw Exception('unexpected arr length: expect 8 but see ${arr.length}');
+    if (arr.length != 7)
+      throw Exception('unexpected arr length: expect 7 but see ${arr.length}');
     return RustFileScanDiff(
       currentCount: dco_decode_i_32(arr[0]),
       cachedCount: dco_decode_i_32(arr[1]),
@@ -699,8 +674,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       newFiles: dco_decode_list_String(arr[3]),
       modifiedFiles: dco_decode_list_String(arr[4]),
       deletedFiles: dco_decode_list_String(arr[5]),
-      folderHash: dco_decode_String(arr[6]),
-      currentHashes: dco_decode_list_rust_file_hash_entry(arr[7]),
+      currentHashes: dco_decode_list_rust_file_hash_entry(arr[6]),
     );
   }
 
@@ -723,11 +697,10 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   RustFileScanSnapshot dco_decode_rust_file_scan_snapshot(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 2)
-      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    if (arr.length != 1)
+      throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return RustFileScanSnapshot(
-      folderHash: dco_decode_String(arr[0]),
-      files: dco_decode_list_rust_file_scan_entry(arr[1]),
+      files: dco_decode_list_rust_file_scan_entry(arr[0]),
     );
   }
 
@@ -906,7 +879,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_newFiles = sse_decode_list_String(deserializer);
     var var_modifiedFiles = sse_decode_list_String(deserializer);
     var var_deletedFiles = sse_decode_list_String(deserializer);
-    var var_folderHash = sse_decode_String(deserializer);
     var var_currentHashes = sse_decode_list_rust_file_hash_entry(deserializer);
     return RustFileScanDiff(
         currentCount: var_currentCount,
@@ -915,7 +887,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         newFiles: var_newFiles,
         modifiedFiles: var_modifiedFiles,
         deletedFiles: var_deletedFiles,
-        folderHash: var_folderHash,
         currentHashes: var_currentHashes);
   }
 
@@ -940,9 +911,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   RustFileScanSnapshot sse_decode_rust_file_scan_snapshot(
       SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_folderHash = sse_decode_String(deserializer);
     var var_files = sse_decode_list_rust_file_scan_entry(deserializer);
-    return RustFileScanSnapshot(folderHash: var_folderHash, files: var_files);
+    return RustFileScanSnapshot(files: var_files);
   }
 
   @protected
@@ -1103,7 +1073,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_list_String(self.newFiles, serializer);
     sse_encode_list_String(self.modifiedFiles, serializer);
     sse_encode_list_String(self.deletedFiles, serializer);
-    sse_encode_String(self.folderHash, serializer);
     sse_encode_list_rust_file_hash_entry(self.currentHashes, serializer);
   }
 
@@ -1122,7 +1091,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_rust_file_scan_snapshot(
       RustFileScanSnapshot self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_String(self.folderHash, serializer);
     sse_encode_list_rust_file_scan_entry(self.files, serializer);
   }
 

--- a/lib/themes/nipaplay/pages/settings/labs_page.dart
+++ b/lib/themes/nipaplay/pages/settings/labs_page.dart
@@ -29,19 +29,6 @@ class LabsPage extends StatelessWidget {
               color: colorScheme.onSurface.withValues(alpha: 0.12),
               height: 1,
             ),
-            SettingsItem.toggle(
-              title: 'Rust 文件扫描',
-              subtitle: '开启后使用 Rust 扫描本地媒体文件并计算变化，降低 UI 卡顿风险',
-              icon: Ionicons.flash_outline,
-              value: labsSettings.enableRustFileScan,
-              onChanged: (bool value) {
-                labsSettings.setEnableRustFileScan(value);
-              },
-            ),
-            Divider(
-              color: colorScheme.onSurface.withValues(alpha: 0.12),
-              height: 1,
-            ),
             SettingsItem.button(
               title: 'WebDAV 快捷设置',
               subtitle: '配置底部 WebDAV 快捷 Tab，快速访问 WebDAV 服务器',

--- a/rust/src/api/file_scan.rs
+++ b/rust/src/api/file_scan.rs
@@ -12,7 +12,6 @@ pub struct RustFileScanEntry {
 }
 
 pub struct RustFileScanSnapshot {
-    pub folder_hash: String,
     pub files: Vec<RustFileScanEntry>,
 }
 
@@ -23,18 +22,12 @@ pub struct RustFileScanDiff {
     pub new_files: Vec<String>,
     pub modified_files: Vec<String>,
     pub deleted_files: Vec<String>,
-    pub folder_hash: String,
     pub current_hashes: Vec<RustFileHashEntry>,
 }
 
 pub struct RustFileHashEntry {
     pub relative_path: String,
     pub hash: String,
-}
-
-#[flutter_rust_bridge::frb(sync)]
-pub fn is_rust_file_scan_available() -> bool {
-    true
 }
 
 pub fn scan_video_files(folder_path: String) -> Result<RustFileScanSnapshot, String> {
@@ -48,14 +41,13 @@ pub fn scan_video_files(folder_path: String) -> Result<RustFileScanSnapshot, Str
     collect_video_files(&root, &root, &mut files)?;
     files.sort_by(|a, b| a.relative_path.cmp(&b.relative_path));
 
-    let folder_hash = calculate_folder_hash(&files);
     println!(
         "[nipaplay_rust_scan] scan_video_files finish path={} files={} elapsed_ms={}",
         folder_path,
         files.len(),
         started_at.elapsed().as_millis()
     );
-    Ok(RustFileScanSnapshot { folder_hash, files })
+    Ok(RustFileScanSnapshot { files })
 }
 
 pub fn diff_video_files(
@@ -135,7 +127,6 @@ pub fn diff_video_files(
         new_files,
         modified_files,
         deleted_files,
-        folder_hash: snapshot.folder_hash,
         current_hashes,
     })
 }
@@ -231,20 +222,6 @@ fn is_video_file(path: &Path) -> bool {
             extension == "mp4" || extension == "mkv"
         })
         .unwrap_or(false)
-}
-
-fn calculate_folder_hash(files: &[RustFileScanEntry]) -> String {
-    let combined = files
-        .iter()
-        .map(|entry| {
-            format!(
-                "{}|{}|{}",
-                entry.absolute_path, entry.size, entry.modified_millis
-            )
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
-    sha256_hex(combined.as_bytes())
 }
 
 fn path_to_dart_string(path: &Path) -> String {

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1390884270;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 629279474;
 
 // Section: executor
 
@@ -142,36 +142,6 @@ fn wire__crate__api__performance__is_performance_probe_available_impl(
             transform_result_sse::<_, ()>((move || {
                 let output_ok =
                     Result::<_, ()>::Ok(crate::api::performance::is_performance_probe_available())?;
-                Ok(output_ok)
-            })())
-        },
-    )
-}
-fn wire__crate__api__file_scan__is_rust_file_scan_available_impl(
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "is_rust_file_scan_available",
-            port: None,
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            deserializer.end();
-            transform_result_sse::<_, ()>((move || {
-                let output_ok =
-                    Result::<_, ()>::Ok(crate::api::file_scan::is_rust_file_scan_available())?;
                 Ok(output_ok)
             })())
         },
@@ -793,7 +763,6 @@ impl SseDecode for crate::api::file_scan::RustFileScanDiff {
         let mut var_newFiles = <Vec<String>>::sse_decode(deserializer);
         let mut var_modifiedFiles = <Vec<String>>::sse_decode(deserializer);
         let mut var_deletedFiles = <Vec<String>>::sse_decode(deserializer);
-        let mut var_folderHash = <String>::sse_decode(deserializer);
         let mut var_currentHashes =
             <Vec<crate::api::file_scan::RustFileHashEntry>>::sse_decode(deserializer);
         return crate::api::file_scan::RustFileScanDiff {
@@ -803,7 +772,6 @@ impl SseDecode for crate::api::file_scan::RustFileScanDiff {
             new_files: var_newFiles,
             modified_files: var_modifiedFiles,
             deleted_files: var_deletedFiles,
-            folder_hash: var_folderHash,
             current_hashes: var_currentHashes,
         };
     }
@@ -830,13 +798,9 @@ impl SseDecode for crate::api::file_scan::RustFileScanEntry {
 impl SseDecode for crate::api::file_scan::RustFileScanSnapshot {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_folderHash = <String>::sse_decode(deserializer);
         let mut var_files =
             <Vec<crate::api::file_scan::RustFileScanEntry>>::sse_decode(deserializer);
-        return crate::api::file_scan::RustFileScanSnapshot {
-            folder_hash: var_folderHash,
-            files: var_files,
-        };
+        return crate::api::file_scan::RustFileScanSnapshot { files: var_files };
     }
 }
 
@@ -895,41 +859,41 @@ fn pde_ffi_dispatcher_primary_impl(
     match func_id {
         1 => wire__crate__api__file_scan__diff_video_files_impl(port, ptr, rust_vec_len, data_len),
         2 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
-        6 => wire__crate__api__performance__sample_cpu_counters_impl(
+        5 => wire__crate__api__performance__sample_cpu_counters_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        7 => wire__crate__api__performance__sample_gpu_percent_impl(
+        6 => wire__crate__api__performance__sample_gpu_percent_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        8 => wire__crate__api__performance__sample_memory_rss_mb_impl(
+        7 => wire__crate__api__performance__sample_memory_rss_mb_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        9 => wire__crate__api__performance__sample_performance_impl(
+        8 => wire__crate__api__performance__sample_performance_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        10 => wire__crate__api__file_scan__scan_video_files_impl(port, ptr, rust_vec_len, data_len),
-        11 => wire__crate__api__torrent__torrent_add_file_impl(port, ptr, rust_vec_len, data_len),
-        12 => wire__crate__api__torrent__torrent_add_magnet_impl(port, ptr, rust_vec_len, data_len),
-        13 => wire__crate__api__torrent__torrent_delete_impl(port, ptr, rust_vec_len, data_len),
-        14 => wire__crate__api__torrent__torrent_forget_impl(port, ptr, rust_vec_len, data_len),
-        15 => {
+        9 => wire__crate__api__file_scan__scan_video_files_impl(port, ptr, rust_vec_len, data_len),
+        10 => wire__crate__api__torrent__torrent_add_file_impl(port, ptr, rust_vec_len, data_len),
+        11 => wire__crate__api__torrent__torrent_add_magnet_impl(port, ptr, rust_vec_len, data_len),
+        12 => wire__crate__api__torrent__torrent_delete_impl(port, ptr, rust_vec_len, data_len),
+        13 => wire__crate__api__torrent__torrent_forget_impl(port, ptr, rust_vec_len, data_len),
+        14 => {
             wire__crate__api__torrent__torrent_init_session_impl(port, ptr, rust_vec_len, data_len)
         }
-        16 => wire__crate__api__torrent__torrent_list_impl(port, ptr, rust_vec_len, data_len),
-        17 => wire__crate__api__torrent__torrent_pause_impl(port, ptr, rust_vec_len, data_len),
-        18 => wire__crate__api__torrent__torrent_resume_impl(port, ptr, rust_vec_len, data_len),
+        15 => wire__crate__api__torrent__torrent_list_impl(port, ptr, rust_vec_len, data_len),
+        16 => wire__crate__api__torrent__torrent_pause_impl(port, ptr, rust_vec_len, data_len),
+        17 => wire__crate__api__torrent__torrent_resume_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -947,12 +911,7 @@ fn pde_ffi_dispatcher_sync_impl(
             rust_vec_len,
             data_len,
         ),
-        4 => wire__crate__api__file_scan__is_rust_file_scan_available_impl(
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        5 => {
+        4 => {
             wire__crate__api__torrent__is_torrent_engine_available_impl(ptr, rust_vec_len, data_len)
         }
         _ => unreachable!(),
@@ -1014,7 +973,6 @@ impl flutter_rust_bridge::IntoDart for crate::api::file_scan::RustFileScanDiff {
             self.new_files.into_into_dart().into_dart(),
             self.modified_files.into_into_dart().into_dart(),
             self.deleted_files.into_into_dart().into_dart(),
-            self.folder_hash.into_into_dart().into_dart(),
             self.current_hashes.into_into_dart().into_dart(),
         ]
         .into_dart()
@@ -1058,11 +1016,7 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::file_scan::RustFileScanEntry>
 // Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::file_scan::RustFileScanSnapshot {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        [
-            self.folder_hash.into_into_dart().into_dart(),
-            self.files.into_into_dart().into_dart(),
-        ]
-        .into_dart()
+        [self.files.into_into_dart().into_dart()].into_dart()
     }
 }
 impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
@@ -1244,7 +1198,6 @@ impl SseEncode for crate::api::file_scan::RustFileScanDiff {
         <Vec<String>>::sse_encode(self.new_files, serializer);
         <Vec<String>>::sse_encode(self.modified_files, serializer);
         <Vec<String>>::sse_encode(self.deleted_files, serializer);
-        <String>::sse_encode(self.folder_hash, serializer);
         <Vec<crate::api::file_scan::RustFileHashEntry>>::sse_encode(
             self.current_hashes,
             serializer,
@@ -1266,7 +1219,6 @@ impl SseEncode for crate::api::file_scan::RustFileScanEntry {
 impl SseEncode for crate::api::file_scan::RustFileScanSnapshot {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <String>::sse_encode(self.folder_hash, serializer);
         <Vec<crate::api::file_scan::RustFileScanEntry>>::sse_encode(self.files, serializer);
     }
 }


### PR DESCRIPTION
## Summary
- remove the Rust file scanning lab toggle and its persisted setting
- route local file scan diffing through Rust without Dart scanner fallback
- remove unused Rust scan availability/folder hash bridge API and regenerate FRB bindings

## Verification
- /Library/Afolder/FlutterProject/flutter/bin/dart analyze lib/services/scan_service.dart lib/services/rust_file_scan_service.dart lib/providers/labs_settings_provider.dart lib/constants/settings_keys.dart lib/themes/nipaplay/pages/settings/labs_page.dart lib/src/rust/api/file_scan.dart lib/src/rust/frb_generated.dart
- cargo test

Note: full-repo dart analyze still fails on existing packages/adaptive_platform_ui/example missing example dependencies/files, unrelated to this PR.