### PR TITLE
Fix Cupertino settings bottom padding

### DIFF
--- a/lib/themes/cupertino/pages/cupertino_settings_page.dart
+++ b/lib/themes/cupertino/pages/cupertino_settings_page.dart
@@ -41,6 +41,8 @@ class _CupertinoSettingsPageState extends State<CupertinoSettingsPage> {
     final Color backgroundColor =
         CupertinoColors.systemGroupedBackground.resolveFrom(context);
     final double statusBarHeight = MediaQuery.of(context).padding.top;
+    final double bottomContentPadding =
+        MediaQuery.viewPaddingOf(context).bottom + 96;
     final double titleOpacity = (1.0 - (_scrollOffset / 10.0)).clamp(0.0, 1.0);
 
     return ColoredBox(
@@ -55,10 +57,10 @@ class _CupertinoSettingsPageState extends State<CupertinoSettingsPage> {
             slivers: [
               SliverPadding(
                 padding: EdgeInsets.only(top: statusBarHeight + 52),
-                sliver: SliverToBoxAdapter(
+                sliver: const SliverToBoxAdapter(
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: const [
+                    children: [
                       CupertinoSettingsGeneralSection(),
                       SizedBox(height: 24),
                       CupertinoSettingsLabsSection(),
@@ -68,7 +70,9 @@ class _CupertinoSettingsPageState extends State<CupertinoSettingsPage> {
                   ),
                 ),
               ),
-              const SliverPadding(padding: EdgeInsets.only(bottom: 32)),
+              SliverPadding(
+                padding: EdgeInsets.only(bottom: bottomContentPadding),
+              ),
             ],
           ),
           Positioned(


### PR DESCRIPTION
## Summary
- Add bottom safe-area-aware padding to the Cupertino settings page so the About section is not covered by the bottom tab bar.
- Keep the settings sections const where possible.

## Verification
- flutter analyze lib/themes/cupertino/pages/cupertino_settings_page.dart
- Launched on iPhone 17 Pro Max simulator and hot reloaded the settings page fix.