### PR TITLE
Hide downloader on iPad

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -17,6 +17,26 @@ import Photos
     }
 
     if let controller = window?.rootViewController as? FlutterViewController {
+      let deviceProfileChannel = FlutterMethodChannel(
+        name: "nipaplay/device_profile",
+        binaryMessenger: controller.binaryMessenger
+      )
+
+      deviceProfileChannel.setMethodCallHandler { call, result in
+        guard call.method == "getStartupDeviceProfile" else {
+          result(FlutterMethodNotImplemented)
+          return
+        }
+
+        let bounds = UIScreen.main.bounds
+        result([
+          "isIPad": UIDevice.current.userInterfaceIdiom == .pad,
+          "screenWidthDp": Double(bounds.width),
+          "screenHeightDp": Double(bounds.height),
+          "smallestScreenWidthDp": Double(min(bounds.width, bounds.height)),
+        ])
+      }
+
       let channel = FlutterMethodChannel(
         name: "nipaplay/system_share",
         binaryMessenger: controller.binaryMessenger

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1110,7 +1110,7 @@ class MainPageState extends State<MainPage>
   ];
   List<Widget> _pages = [];
   bool _showWebDAVTab = false;
-  bool _showDownloaderTab = true;
+  bool _showDownloaderTab = globals.isDownloaderSupportedPlatform;
   WebDAVQuickAccessProvider? _webdavQuickAccessProvider;
 
   // 用于热键管理
@@ -1122,6 +1122,10 @@ class MainPageState extends State<MainPage>
   static MainPageState? of(BuildContext context) {
     return context.findAncestorStateOfType<MainPageState>();
   }
+
+  bool get _canShowDownloaderTab =>
+      globals.isDownloaderSupportedPlatform &&
+      (_downloaderSettingsProvider?.enabled ?? true);
 
   // TabChangeNotifier监听 - Temporarily remove or comment out for Scheme 1
   TabChangeNotifier? _tabChangeNotifier;
@@ -1225,7 +1229,7 @@ class MainPageState extends State<MainPage>
       while (!_downloaderSettingsProvider!.isLoaded) {
         await Future<void>.delayed(const Duration(milliseconds: 16));
       }
-      _showDownloaderTab = _downloaderSettingsProvider!.enabled;
+      _showDownloaderTab = _canShowDownloaderTab;
       _downloaderSettingsProvider!.addListener(_onDownloaderSettingsChanged);
     } catch (e) {
       debugPrint('加载下载器设置失败: $e');
@@ -1273,7 +1277,7 @@ class MainPageState extends State<MainPage>
   }
 
   void _onDownloaderSettingsChanged() {
-    final showDownloaderTab = _downloaderSettingsProvider?.enabled ?? true;
+    final showDownloaderTab = _canShowDownloaderTab;
     final currentIndex = globalTabController?.index;
     final previousShowDownloaderTab = _showDownloaderTab;
     final currentNeedsRebuild = showDownloaderTab != _showDownloaderTab;

--- a/lib/providers/webdav_quick_access_provider.dart
+++ b/lib/providers/webdav_quick_access_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:nipaplay/services/webdav_service.dart';
+import 'package:nipaplay/utils/globals.dart' as globals;
 
 /// WebDAV 文件排序预设
 enum WebDAVSortPreset {
@@ -106,6 +107,11 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
       return tabHome;
     }
 
+    if (_defaultHomeTab == tabTorrent &&
+        !globals.isDownloaderSupportedPlatform) {
+      return tabHome;
+    }
+
     if (_isCupertinoOnlyTab(_defaultHomeTab) ||
         !_allSupportedTabs.contains(_defaultHomeTab)) {
       return tabHome;
@@ -116,17 +122,15 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
 
   /// Material 主题可用的默认主页选项
   List<String> get materialAvailableTabs {
-    if (_showWebDAVTab) {
-      return [
-        tabHome,
-        tabVideo,
-        tabWebDAV,
-        tabMediaLibrary,
-        tabTorrent,
-        tabAccount,
-      ];
-    }
-    return [tabHome, tabVideo, tabMediaLibrary, tabTorrent, tabAccount];
+    final tabs = <String>[
+      tabHome,
+      tabVideo,
+      if (_showWebDAVTab) tabWebDAV,
+      tabMediaLibrary,
+      if (globals.isDownloaderSupportedPlatform) tabTorrent,
+      tabAccount,
+    ];
+    return tabs;
   }
 
   /// Cupertino 主题可用的默认主页选项
@@ -225,6 +229,9 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
   /// 设置默认主页 Tab
   Future<void> setDefaultHomeTab(String tabName) async {
     if (!_allSupportedTabs.contains(tabName)) {
+      return;
+    }
+    if (tabName == tabTorrent && !globals.isDownloaderSupportedPlatform) {
       return;
     }
     if (_defaultHomeTab == tabName) return;

--- a/lib/themes/nipaplay/pages/settings/general_page.dart
+++ b/lib/themes/nipaplay/pages/settings/general_page.dart
@@ -68,9 +68,12 @@ class _GeneralPageState extends State<GeneralPage> {
           title: "视频播放", value: 1, isSelected: _defaultPageIndex == 1),
       DropdownMenuItemData(
           title: "媒体库", value: 2, isSelected: _defaultPageIndex == 2),
-      DropdownMenuItemData(
-          title: "下载器", value: 3, isSelected: _defaultPageIndex == 3),
     ];
+
+    if (globals.isDownloaderSupportedPlatform) {
+      items.add(DropdownMenuItemData(
+          title: "下载器", value: 3, isSelected: _defaultPageIndex == 3));
+    }
 
     items.add(DropdownMenuItemData(
         title: "个人中心", value: 4, isSelected: _defaultPageIndex == 4));
@@ -127,6 +130,8 @@ class _GeneralPageState extends State<GeneralPage> {
 
     if (resolvedIndex < 0) {
       resolvedIndex = 0;
+    } else if (!globals.isDownloaderSupportedPlatform && resolvedIndex == 3) {
+      resolvedIndex = 0;
     } else if (resolvedIndex > 4) {
       resolvedIndex = 4;
     }
@@ -144,6 +149,7 @@ class _GeneralPageState extends State<GeneralPage> {
   }
 
   Future<void> _saveDefaultPagePreference(int index) async {
+    if (!globals.isDownloaderSupportedPlatform && index == 3) return;
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(defaultPageIndexKey, index);
     await prefs.setString(_defaultHomeTabKey, _defaultHomeTabName(index));

--- a/lib/themes/nipaplay/pages/settings/settings_entries.dart
+++ b/lib/themes/nipaplay/pages/settings/settings_entries.dart
@@ -168,7 +168,7 @@ List<NipaplaySettingEntry> buildNipaplaySettingEntries(BuildContext context) {
     ]);
   }
 
-  entries.addAll([
+  entries.add(
     NipaplaySettingEntry(
       id: NipaplaySettingEntryIds.remoteMediaLibrary,
       title: l10n.remoteMediaLibrary,
@@ -176,13 +176,21 @@ List<NipaplaySettingEntry> buildNipaplaySettingEntries(BuildContext context) {
       pageTitle: l10n.remoteMediaLibrary,
       page: const RemoteMediaLibraryPage(),
     ),
-    const NipaplaySettingEntry(
-      id: NipaplaySettingEntryIds.downloader,
-      title: '下载器',
-      icon: Ionicons.cloud_download_outline,
-      pageTitle: '下载器',
-      page: DownloaderSettingsPage(),
-    ),
+  );
+
+  if (globals.isDownloaderSupportedPlatform) {
+    entries.add(
+      const NipaplaySettingEntry(
+        id: NipaplaySettingEntryIds.downloader,
+        title: '下载器',
+        icon: Ionicons.cloud_download_outline,
+        pageTitle: '下载器',
+        page: DownloaderSettingsPage(),
+      ),
+    );
+  }
+
+  entries.addAll([
     NipaplaySettingEntry(
       id: NipaplaySettingEntryIds.developerOptions,
       title: l10n.developerOptions,

--- a/lib/themes/nipaplay/widgets/custom_scaffold.dart
+++ b/lib/themes/nipaplay/widgets/custom_scaffold.dart
@@ -114,7 +114,9 @@ class _CustomScaffoldState extends State<CustomScaffold> {
       );
     }
 
-    final bool isDesktopOrTablet = globals.isDesktopOrTablet;
+    final bool isDesktop = globals.isDesktop;
+    final bool isTablet = globals.isTablet;
+    final bool isDesktopOrTablet = isDesktop || isTablet;
     final bool useLargeScreenLayout = widget.useLargeScreenLayout &&
         widget.pageIsHome &&
         isDesktopOrTablet &&
@@ -186,9 +188,11 @@ class _CustomScaffoldState extends State<CustomScaffold> {
           ? AppBar(
               toolbarHeight: !widget.pageIsHome && !isDesktopOrTablet
                   ? 100
-                  : isDesktopOrTablet
+                  : isDesktop
                       ? 20
-                      : 60,
+                      : isTablet
+                          ? 30
+                          : 60,
               leading: widget.pageIsHome
                   ? null
                   : IconButton(

--- a/lib/utils/globals.dart
+++ b/lib/utils/globals.dart
@@ -24,6 +24,7 @@ const MethodChannel _deviceProfileChannel =
 bool _startupDeviceProfileInitialized = false;
 bool _startupTabletLike = false;
 bool _startupAndroidTv = false;
+bool _startupIPad = false;
 
 class _DisplayMetrics {
   const _DisplayMetrics({
@@ -73,12 +74,15 @@ Future<void> initializeStartupDeviceProfile() async {
   var startupMetrics = metrics;
   var isAndroidTv = false;
 
-  if (!kIsWeb && Platform.isAndroid) {
+  var isIPad = false;
+
+  if (!kIsWeb && (Platform.isAndroid || Platform.isIOS)) {
     try {
       final profile = await _deviceProfileChannel
           .invokeMapMethod<String, dynamic>('getStartupDeviceProfile');
       if (profile != null) {
         isAndroidTv = profile['isAndroidTv'] == true;
+        isIPad = profile['isIPad'] == true;
         final screenWidthDp = (profile['screenWidthDp'] as num?)?.toDouble();
         final screenHeightDp = (profile['screenHeightDp'] as num?)?.toDouble();
         final smallestWidthDp =
@@ -104,6 +108,7 @@ Future<void> initializeStartupDeviceProfile() async {
     isAndroidTv: isAndroidTv,
     metrics: startupMetrics,
   );
+  _startupIPad = isIPad || (!kIsWeb && Platform.isIOS && _startupTabletLike);
   _startupDeviceProfileInitialized = true;
 }
 
@@ -142,6 +147,17 @@ bool get isTablet {
 
 bool get isTabletLikeMobile => isMobilePlatform && isTablet;
 bool get isAndroidTv => _startupAndroidTv;
+
+bool get isIPad {
+  if (kIsWeb) {
+    return defaultTargetPlatform == TargetPlatform.iOS && isTablet;
+  }
+  if (!Platform.isIOS) return false;
+  if (_startupDeviceProfileInitialized) return _startupIPad;
+  return isTablet;
+}
+
+bool get isDownloaderSupportedPlatform => !isIPad;
 
 bool get isTouch {
   //移动平台


### PR DESCRIPTION
## Summary
- add an iPad device-profile signal on iOS and a shared downloader platform gate
- hide the downloader tab on iPad regardless of the downloader setting
- remove downloader choices from settings/default-home UI on unsupported platforms

## Tests
- flutter test test/webdav_quick_access_provider_test.dart
- git diff --check

Note: flutter analyze on the touched files still reports existing repository warnings/infos unrelated to this change.