### PR TITLE
feat(WebDAV): 添加文件搜索功能，优化bgmid匹配正则 [实验室]

### DIFF
--- a/lib/pages/webdav_browser_page.dart
+++ b/lib/pages/webdav_browser_page.dart
@@ -43,10 +43,32 @@ class _WebDAVBrowserPageState extends State<WebDAVBrowserPage> {
   // 是否正在初始化
   bool _isInitializing = true;
 
+  // 搜索相关状态
+  bool _isSearchMode = false;
+  bool _isSearching = false;
+  bool _stopSearchRequested = false;
+  String _searchKeyword = '';
+  List<WebDAVSearchResult> _searchResults = [];
+  int _searchedCount = 0;
+  int _foundCount = 0;
+  final TextEditingController _searchController = TextEditingController();
+
+  // UI 更新节流
+  DateTime? _lastUIUpdate;
+  static const int _uiUpdateThrottleMs = 100;
+  bool _maxResultsReached = false;
+
   @override
   void initState() {
     super.initState();
     _initializePage();
+  }
+
+  @override
+  void dispose() {
+    _stopSearchRequested = true;
+    _searchController.dispose();
+    super.dispose();
   }
 
   Future<void> _initializePage() async {
@@ -193,7 +215,9 @@ class _WebDAVBrowserPageState extends State<WebDAVBrowserPage> {
         final bgmidMatch = regex.firstMatch(videoUrl);
 
         if (bgmidMatch != null && bgmidMatch.groupCount >= 1) {
-          final bgmid = int.tryParse(bgmidMatch.group(1)!);
+          // 取最后一个捕获组的数字（兼容不同正则格式）
+          final lastGroup = bgmidMatch.group(bgmidMatch.groupCount);
+          final bgmid = int.tryParse(lastGroup ?? '');
 
           if (bgmid != null) {
             final result = await DandanplayService.getBangumiByBgmId(bgmid);
@@ -433,34 +457,41 @@ class _WebDAVBrowserPageState extends State<WebDAVBrowserPage> {
               secondaryTextColor: secondaryTextColor,
               accentColor: accentColor,
             ),
-            // 文件列表
+            // 文件列表或搜索结果
             Expanded(
-              child: _isLoading
-                  ? Center(
-                      child: CircularProgressIndicator(
-                          color: AppAccentColors.current),
+              child: _isSearchMode
+                  ? _buildSearchResults(
+                      cardColor: cardColor,
+                      textColor: textColor,
+                      secondaryTextColor: secondaryTextColor,
+                      accentColor: accentColor,
                     )
-                  : _currentFiles.isEmpty
+                  : _isLoading
                       ? Center(
-                          child: Text(
-                            '当前目录为空',
-                            style: TextStyle(color: secondaryTextColor),
-                          ),
+                          child: CircularProgressIndicator(
+                              color: AppAccentColors.current),
                         )
-                      : ListView.builder(
-                          padding: const EdgeInsets.all(16),
-                          itemCount: _currentFiles.length,
-                          itemBuilder: (context, index) {
-                            final file = _currentFiles[index];
-                            return _buildFileItem(
-                              file: file,
-                              cardColor: cardColor,
-                              textColor: textColor,
-                              secondaryTextColor: secondaryTextColor,
-                              accentColor: accentColor,
-                            );
-                          },
-                        ),
+                      : _currentFiles.isEmpty
+                          ? Center(
+                              child: Text(
+                                '当前目录为空',
+                                style: TextStyle(color: secondaryTextColor),
+                              ),
+                            )
+                          : ListView.builder(
+                              padding: const EdgeInsets.all(16),
+                              itemCount: _currentFiles.length,
+                              itemBuilder: (context, index) {
+                                final file = _currentFiles[index];
+                                return _buildFileItem(
+                                  file: file,
+                                  cardColor: cardColor,
+                                  textColor: textColor,
+                                  secondaryTextColor: secondaryTextColor,
+                                  accentColor: accentColor,
+                                );
+                              },
+                            ),
             ),
           ],
         ),
@@ -545,8 +576,41 @@ class _WebDAVBrowserPageState extends State<WebDAVBrowserPage> {
                   ),
                 ),
               ),
+              // 搜索按钮（根据设置显示）
+              if (Provider.of<WebDAVQuickAccessProvider>(context, listen: true)
+                  .enableSearch)
+                IconButton(
+                  icon: Icon(
+                    _isSearchMode ? Icons.close : Icons.search,
+                    color: _isSearchMode ? accentColor : textColor,
+                  ),
+                  onPressed: () {
+                    setState(() {
+                      if (_isSearchMode) {
+                        // 退出搜索模式
+                        _isSearchMode = false;
+                        _stopSearchRequested = true;
+                        _searchResults = [];
+                        _searchController.clear();
+                        _searchKeyword = '';
+                      } else {
+                        // 进入搜索模式
+                        _isSearchMode = true;
+                      }
+                    });
+                  },
+                ),
             ],
           ),
+          // 搜索输入框（搜索模式下显示）
+          if (_isSearchMode) ...[
+            SizedBox(height: 12),
+            _buildSearchInput(
+              textColor: textColor,
+              secondaryTextColor: secondaryTextColor,
+              accentColor: accentColor,
+            ),
+          ],
           // 路径面包屑导航（根据设置显示）
           if (Provider.of<WebDAVQuickAccessProvider>(context)
               .showPathBreadcrumb) ...[
@@ -833,6 +897,488 @@ class _WebDAVBrowserPageState extends State<WebDAVBrowserPage> {
         ),
       ),
     );
+  }
+
+  // ==================== 搜索功能相关方法 ====================
+
+  Widget _buildSearchInput({
+    required Color textColor,
+    required Color secondaryTextColor,
+    required Color accentColor,
+  }) {
+    final provider = Provider.of<WebDAVQuickAccessProvider>(context, listen: true);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // 搜索输入框
+        Row(
+          children: [
+            Expanded(
+              child: TextField(
+                controller: _searchController,
+                style: TextStyle(color: textColor),
+                decoration: InputDecoration(
+                  hintText: '搜索文件...',
+                  hintStyle: TextStyle(color: secondaryTextColor),
+                  prefixIcon: Icon(Icons.search, color: secondaryTextColor),
+                  filled: true,
+                  fillColor: Colors.transparent,
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(8),
+                    borderSide: BorderSide(color: secondaryTextColor.withOpacity(0.3)),
+                  ),
+                  enabledBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(8),
+                    borderSide: BorderSide(color: secondaryTextColor.withOpacity(0.3)),
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(8),
+                    borderSide: BorderSide(color: accentColor),
+                  ),
+                  contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                  suffixIcon: _searchController.text.isNotEmpty
+                      ? IconButton(
+                          icon: Icon(Icons.clear, color: secondaryTextColor),
+                          onPressed: () {
+                            _searchController.clear();
+                            setState(() {
+                              _searchKeyword = '';
+                              _searchResults = [];
+                            });
+                          },
+                        )
+                      : null,
+                ),
+                onChanged: (value) {
+                  setState(() {
+                    _searchKeyword = value;
+                  });
+                },
+                onSubmitted: (value) {
+                  if (value.isNotEmpty) {
+                    _startSearch();
+                  }
+                },
+              ),
+            ),
+            SizedBox(width: 8),
+            // 搜索按钮
+            ElevatedButton(
+              onPressed: _isSearching || _searchController.text.isEmpty
+                  ? null
+                  : _startSearch,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: accentColor,
+                foregroundColor: Colors.white,
+                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8),
+                ),
+              ),
+              child: Text(_isSearching ? '搜索中' : '搜索'),
+            ),
+          ],
+        ),
+        SizedBox(height: 8),
+        // 当前设置摘要
+        Text(
+          '${provider.searchScope.displayName}(${provider.searchDepthLimit}层) | ${provider.searchTargets.map((t) => t.displayName).join(',')} | 间隔${provider.searchRequestInterval}ms',
+          style: TextStyle(
+            color: secondaryTextColor,
+            fontSize: 12,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSearchResults({
+    required Color cardColor,
+    required Color textColor,
+    required Color secondaryTextColor,
+    required Color accentColor,
+  }) {
+    // 搜索进度显示
+    if (_isSearching) {
+      return Column(
+        children: [
+          // 进度指示器
+          Container(
+            margin: const EdgeInsets.all(16),
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: cardColor,
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Column(
+              children: [
+                Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        '搜索中... 已扫描 $_searchedCount 个目录，找到 $_foundCount 个结果',
+                        style: TextStyle(color: textColor, fontSize: 14),
+                      ),
+                    ),
+                    ElevatedButton(
+                      onPressed: () {
+                        setState(() {
+                          _stopSearchRequested = true;
+                        });
+                      },
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: Colors.red.withOpacity(0.8),
+                        foregroundColor: Colors.white,
+                        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                      ),
+                      child: const Text('停止'),
+                    ),
+                  ],
+                ),
+                SizedBox(height: 8),
+                LinearProgressIndicator(
+                  backgroundColor: secondaryTextColor.withOpacity(0.2),
+                  valueColor: AlwaysStoppedAnimation<Color>(accentColor),
+                ),
+              ],
+            ),
+          ),
+          // 已找到的结果
+          Expanded(
+            child: _searchResults.isEmpty
+                ? Center(
+                    child: Text(
+                      '正在搜索...',
+                      style: TextStyle(color: secondaryTextColor),
+                    ),
+                  )
+                : ListView.builder(
+                    padding: const EdgeInsets.all(16),
+                    itemCount: _searchResults.length,
+                    itemBuilder: (context, index) {
+                      final result = _searchResults[index];
+                      return _buildSearchResultItem(
+                        result: result,
+                        cardColor: cardColor,
+                        textColor: textColor,
+                        secondaryTextColor: secondaryTextColor,
+                        accentColor: accentColor,
+                      );
+                    },
+                  ),
+          ),
+        ],
+      );
+    }
+
+    // 搜索完成后的结果列表
+    if (_searchResults.isEmpty) {
+      if (_searchKeyword.isEmpty) {
+        return Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(Icons.search, size: 64, color: secondaryTextColor),
+              SizedBox(height: 16),
+              Text(
+                '输入关键词搜索文件',
+                style: TextStyle(color: secondaryTextColor, fontSize: 16),
+              ),
+            ],
+          ),
+        );
+      }
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.search_off, size: 64, color: secondaryTextColor),
+            SizedBox(height: 16),
+            Text(
+              '未找到匹配的文件',
+              style: TextStyle(color: secondaryTextColor, fontSize: 16),
+            ),
+            SizedBox(height: 8),
+            Text(
+              '关键词: $_searchKeyword',
+              style: TextStyle(color: secondaryTextColor.withOpacity(0.7), fontSize: 14),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return Column(
+      children: [
+        // 结果统计
+        Container(
+          margin: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          decoration: BoxDecoration(
+            color: accentColor.withOpacity(0.1),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Row(
+            children: [
+              Icon(Icons.check_circle, color: accentColor, size: 20),
+              SizedBox(width: 8),
+              Text(
+                '找到 ${_searchResults.length} 个结果',
+                style: TextStyle(color: accentColor, fontWeight: FontWeight.w600),
+              ),
+            ],
+          ),
+        ),
+        // 结果列表
+        Expanded(
+          child: ListView.builder(
+            padding: const EdgeInsets.all(16),
+            itemCount: _searchResults.length,
+            itemBuilder: (context, index) {
+              final result = _searchResults[index];
+              return _buildSearchResultItem(
+                result: result,
+                cardColor: cardColor,
+                textColor: textColor,
+                secondaryTextColor: secondaryTextColor,
+                accentColor: accentColor,
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSearchResultItem({
+    required WebDAVSearchResult result,
+    required Color cardColor,
+    required Color textColor,
+    required Color secondaryTextColor,
+    required Color accentColor,
+  }) {
+    final isDirectory = result.file.isDirectory;
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 8),
+      color: cardColor,
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: BorderSide(color: secondaryTextColor.withOpacity(0.1)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // 文件名
+            Row(
+              children: [
+                Icon(
+                  isDirectory ? Icons.folder_outlined : Icons.video_file_outlined,
+                  color: isDirectory ? Colors.amber : accentColor,
+                  size: 24,
+                ),
+                SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    result.file.name,
+                    style: TextStyle(
+                      color: textColor,
+                      fontSize: 14,
+                      fontWeight: FontWeight.w500,
+                    ),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+            ),
+            SizedBox(height: 4),
+            // 路径
+            Text(
+              result.relativePath.isEmpty ? '/' : result.relativePath,
+              style: TextStyle(
+                color: secondaryTextColor,
+                fontSize: 12,
+              ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+            SizedBox(height: 8),
+            // 操作按钮
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                // 跳转到目录按钮
+                TextButton.icon(
+                  icon: Icon(Icons.folder_open, size: 18, color: secondaryTextColor),
+                  label: Text('跳转', style: TextStyle(color: secondaryTextColor)),
+                  onPressed: () {
+                    // 获取父目录路径
+                    final parentPath = isDirectory
+                        ? result.file.path
+                        : result.file.path.substring(0, result.file.path.lastIndexOf('/') + 1);
+                    _navigateToPathFromSearch(parentPath);
+                  },
+                ),
+                SizedBox(width: 8),
+                // 播放按钮（仅文件）
+                if (!isDirectory)
+                  ElevatedButton.icon(
+                    icon: Icon(Icons.play_arrow, size: 18),
+                    label: const Text('播放'),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: accentColor,
+                      foregroundColor: Colors.white,
+                      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                    ),
+                    onPressed: () => _playSearchResult(result),
+                  ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _startSearch() async {
+    if (_currentConnection == null || _searchController.text.isEmpty) return;
+    if (_isSearching) return; // 防止 onSubmitted 重复触发
+
+    final provider = Provider.of<WebDAVQuickAccessProvider>(context, listen: false);
+    final keyword = _searchController.text.trim();
+    final maxResults = provider.searchMaxResults;
+
+    setState(() {
+      _isSearching = true;
+      _stopSearchRequested = false;
+      _searchKeyword = keyword;
+      _searchResults = [];
+      _searchedCount = 0;
+      _foundCount = 0;
+      _maxResultsReached = false;
+      _lastUIUpdate = null;
+    });
+
+    try {
+      final searchTargets = provider.searchTargets.map((t) => t.value).toSet();
+
+      await WebDAVService.instance.searchFiles(
+        connection: _currentConnection!,
+        keyword: keyword,
+        startPath: _currentPath,
+        scope: provider.searchScope.value,
+        depthLimit: provider.searchDepthLimit,
+        searchTargets: searchTargets,
+        timeoutSeconds: provider.searchTimeout.seconds,
+        requestIntervalMs: provider.searchRequestInterval,
+        onProgress: (searched, found) {
+          if (mounted && !_stopSearchRequested && !_maxResultsReached) {
+            // 节流 UI 更新
+            final now = DateTime.now();
+            if (_lastUIUpdate == null ||
+                now.difference(_lastUIUpdate!).inMilliseconds >= _uiUpdateThrottleMs) {
+              _lastUIUpdate = now;
+              setState(() {
+                _searchedCount = searched;
+                _foundCount = found;
+              });
+            }
+          }
+        },
+        onResultFound: (result) {
+          if (mounted && !_stopSearchRequested && !_maxResultsReached) {
+            if (_searchResults.length < maxResults) {
+              _searchResults.add(result);
+              // 后检查：刚达到上限时立即标记停止，不依赖下一轮回调
+              if (_searchResults.length >= maxResults) {
+                _maxResultsReached = true;
+                setState(() {
+                  _isSearching = false;
+                });
+                return;
+              }
+              // 节流 UI 更新
+              final now = DateTime.now();
+              if (_lastUIUpdate == null ||
+                  now.difference(_lastUIUpdate!).inMilliseconds >= _uiUpdateThrottleMs) {
+                _lastUIUpdate = now;
+                setState(() {});
+              }
+            }
+          }
+        },
+        onStopRequested: () => _stopSearchRequested || _maxResultsReached,
+      );
+
+      if (mounted && !_maxResultsReached) {
+        setState(() {
+          _isSearching = false;
+        });
+      }
+
+      // 显示达到上限提示
+      if (mounted && _maxResultsReached) {
+        BlurSnackBar.show(context, '已达到最大结果数 ($maxResults)，搜索已停止');
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _isSearching = false;
+        });
+        BlurSnackBar.show(context, '搜索失败: $e');
+      }
+    }
+  }
+
+  void _navigateToPathFromSearch(String path) {
+    setState(() {
+      _isSearchMode = false;
+      _searchResults = [];
+      _searchController.clear();
+      _searchKeyword = '';
+      _currentPath = path;
+      _pathHistory.clear();
+    });
+    _loadDirectory();
+  }
+
+  void _playSearchResult(WebDAVSearchResult result) async {
+    if (_currentConnection == null) return;
+
+    final videoUrl = WebDAVService.instance.getFileUrl(
+      _currentConnection!,
+      result.file.path,
+    );
+
+    final historyItem = WatchHistoryItem(
+      animeName: result.file.name.replaceAll(RegExp(r'\.[^.]+$'), ''),
+      episodeTitle: result.file.name,
+      filePath: videoUrl,
+      watchProgress: 0,
+      lastPosition: 0,
+      duration: 0,
+      lastWatchTime: DateTime.now(),
+    );
+
+    final playableItem = PlayableItem(
+      videoPath: videoUrl,
+      title: result.file.name.replaceAll(RegExp(r'\.[^.]+$'), ''),
+      subtitle: result.file.name,
+      historyItem: historyItem,
+    );
+
+    PlaybackService().play(playableItem);
   }
 
   String _formatFileSize(int bytes) {

--- a/lib/providers/webdav_quick_access_provider.dart
+++ b/lib/providers/webdav_quick_access_provider.dart
@@ -1,7 +1,69 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:nipaplay/services/webdav_service.dart';
 import 'package:nipaplay/utils/globals.dart' as globals;
+
+/// WebDAV 搜索范围
+enum WebDAVSearchScope {
+  currentDirectory('current_directory', '仅当前目录', '只搜索当前显示的目录'),
+  currentWithDepth('current_with_depth', '当前目录 + 子目录', '向下遍历指定层级'),
+  global('global', '全局搜索', '从根目录开始搜索所有文件');
+
+  final String value;
+  final String displayName;
+  final String description;
+  const WebDAVSearchScope(this.value, this.displayName, this.description);
+
+  static WebDAVSearchScope fromValue(String? value) {
+    return values.firstWhere(
+      (e) => e.value == value,
+      orElse: () => WebDAVSearchScope.currentWithDepth,
+    );
+  }
+}
+
+/// WebDAV 搜索目标类型（支持多选）
+enum WebDAVSearchTarget {
+  folder('folder', '文件夹'),
+  video('video', '视频文件');
+
+  final String value;
+  final String displayName;
+  const WebDAVSearchTarget(this.value, this.displayName);
+
+  static WebDAVSearchTarget fromValue(String? value) {
+    return values.firstWhere(
+      (e) => e.value == value,
+      orElse: () => WebDAVSearchTarget.video,
+    );
+  }
+
+  /// 获取默认选中的搜索目标
+  static Set<WebDAVSearchTarget> get defaultTargets => {
+    WebDAVSearchTarget.folder,
+    WebDAVSearchTarget.video,
+  };
+}
+
+/// WebDAV 搜索超时选项
+enum WebDAVSearchTimeout {
+  seconds10(10, '10 秒'),
+  seconds30(30, '30 秒'),
+  seconds60(60, '60 秒'),
+  unlimited(0, '无限制');
+
+  final int seconds;
+  final String displayName;
+  const WebDAVSearchTimeout(this.seconds, this.displayName);
+
+  static WebDAVSearchTimeout fromSeconds(int? seconds) {
+    return values.firstWhere(
+      (e) => e.seconds == seconds,
+      orElse: () => WebDAVSearchTimeout.seconds30,
+    );
+  }
+}
 
 /// WebDAV 文件排序预设
 enum WebDAVSortPreset {
@@ -57,6 +119,15 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
   static const String _keyBgmIdMatchPattern = 'webdav_bgmid_match_pattern';
   static const String _legacyDefaultPageIndexKey = 'default_page_index';
 
+  // 搜索功能相关存储键名
+  static const String _keyEnableSearch = 'webdav_enable_search';
+  static const String _keySearchScope = 'webdav_search_scope';
+  static const String _keySearchDepthLimit = 'webdav_search_depth_limit';
+  static const String _keySearchTargets = 'webdav_search_targets';
+  static const String _keySearchTimeout = 'webdav_search_timeout';
+  static const String _keySearchRequestInterval = 'webdav_search_request_interval';
+  static const String _keySearchMaxResults = 'webdav_search_max_results';
+
   // Tab 名称常量
   static const String tabHome = 'home';
   static const String tabVideo = 'video';
@@ -85,8 +156,17 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
   String _seasonFolderPattern = 'Season*';
   bool _showPathBreadcrumb = true;
   bool _bgmIdQuickMatch = false; // 默认关闭，用户需明确启用
-  String _bgmIdMatchPattern = 'bgmid=(\\d+)'; // 默认正则规则
+  String _bgmIdMatchPattern = 'bgm(id)?[=-](\\d+)'; // 默认正则规则
   bool _isLoaded = false;
+
+  // 搜索功能相关状态
+  bool _enableSearch = true; // 搜索功能总开关，默认开启
+  WebDAVSearchScope _searchScope = WebDAVSearchScope.currentWithDepth;
+  int _searchDepthLimit = 3; // 层级限制（1-10）
+  Set<WebDAVSearchTarget> _searchTargets = WebDAVSearchTarget.defaultTargets;
+  WebDAVSearchTimeout _searchTimeout = WebDAVSearchTimeout.seconds30;
+  int _searchRequestInterval = 100; // 请求间隔（毫秒），默认100ms
+  int _searchMaxResults = 500; // 最大搜索结果数，默认500
 
   // Getters
   bool get showWebDAVTab => _showWebDAVTab;
@@ -100,6 +180,15 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
   bool get bgmIdQuickMatch => _bgmIdQuickMatch;
   String get bgmIdMatchPattern => _bgmIdMatchPattern;
   bool get isLoaded => _isLoaded;
+
+  // 搜索功能相关 Getters
+  bool get enableSearch => _enableSearch;
+  WebDAVSearchScope get searchScope => _searchScope;
+  int get searchDepthLimit => _searchDepthLimit;
+  Set<WebDAVSearchTarget> get searchTargets => _searchTargets;
+  WebDAVSearchTimeout get searchTimeout => _searchTimeout;
+  int get searchRequestInterval => _searchRequestInterval;
+  int get searchMaxResults => _searchMaxResults;
 
   /// 获取有效的默认 Tab（处理 WebDAV 关闭时的回落）
   String get effectiveDefaultHomeTab {
@@ -202,7 +291,24 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
       _showPathBreadcrumb = prefs.getBool(_keyShowPathBreadcrumb) ?? true;
       _bgmIdQuickMatch = prefs.getBool(_keyBgmIdQuickMatch) ?? false;
       _bgmIdMatchPattern =
-          prefs.getString(_keyBgmIdMatchPattern) ?? 'bgmid=(\\d+)';
+          prefs.getString(_keyBgmIdMatchPattern) ?? 'bgm(id)?[=-](\\d+)';
+
+      // 加载搜索功能相关设置
+      _enableSearch = prefs.getBool(_keyEnableSearch) ?? true;
+      _searchScope = WebDAVSearchScope.fromValue(prefs.getString(_keySearchScope));
+      _searchDepthLimit = prefs.getInt(_keySearchDepthLimit) ?? 3;
+      // 加载搜索目标（多选）
+      final storedTargets = prefs.getStringList(_keySearchTargets);
+      if (storedTargets != null && storedTargets.isNotEmpty) {
+        _searchTargets = storedTargets
+            .map((v) => WebDAVSearchTarget.fromValue(v))
+            .toSet();
+      } else {
+        _searchTargets = WebDAVSearchTarget.defaultTargets;
+      }
+      _searchTimeout = WebDAVSearchTimeout.fromSeconds(prefs.getInt(_keySearchTimeout));
+      _searchRequestInterval = prefs.getInt(_keySearchRequestInterval) ?? 100;
+      _searchMaxResults = prefs.getInt(_keySearchMaxResults) ?? 500;
 
       _isLoaded = true;
       notifyListeners();
@@ -406,6 +512,134 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
     }
   }
 
+  // ==================== 搜索功能相关 Setter ====================
+
+  /// 设置是否启用搜索功能
+  Future<void> setEnableSearch(bool value) async {
+    if (_enableSearch == value) return;
+
+    _enableSearch = value;
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool(_keyEnableSearch, value);
+      notifyListeners();
+    } catch (e) {
+      debugPrint('保存搜索功能开关设置失败: $e');
+    }
+  }
+
+  /// 设置搜索范围
+  Future<void> setSearchScope(WebDAVSearchScope scope) async {
+    if (_searchScope == scope) return;
+
+    _searchScope = scope;
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_keySearchScope, scope.value);
+      notifyListeners();
+    } catch (e) {
+      debugPrint('保存搜索范围设置失败: $e');
+    }
+  }
+
+  /// 设置搜索层级限制
+  Future<void> setSearchDepthLimit(int limit) async {
+    if (_searchDepthLimit == limit) return;
+
+    // 确保在有效范围内
+    limit = limit.clamp(1, 10);
+    _searchDepthLimit = limit;
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setInt(_keySearchDepthLimit, limit);
+      notifyListeners();
+    } catch (e) {
+      debugPrint('保存搜索层级限制设置失败: $e');
+    }
+  }
+
+  /// 设置搜索目标类型
+  Future<void> setSearchTargets(Set<WebDAVSearchTarget> targets) async {
+    if (_searchTargets == targets) return;
+
+    _searchTargets = targets;
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final targetValues = targets.map((t) => t.value).toList();
+      await prefs.setStringList(_keySearchTargets, targetValues);
+      notifyListeners();
+    } catch (e) {
+      debugPrint('保存搜索目标类型设置失败: $e');
+    }
+  }
+
+  /// 切换单个搜索目标类型
+  Future<void> toggleSearchTarget(WebDAVSearchTarget target) async {
+    final newTargets = Set<WebDAVSearchTarget>.from(_searchTargets);
+    if (newTargets.contains(target)) {
+      // 至少保留一个选项
+      if (newTargets.length > 1) {
+        newTargets.remove(target);
+      }
+    } else {
+      newTargets.add(target);
+    }
+    await setSearchTargets(newTargets);
+  }
+
+  /// 设置搜索超时时间
+  Future<void> setSearchTimeout(WebDAVSearchTimeout timeout) async {
+    if (_searchTimeout == timeout) return;
+
+    _searchTimeout = timeout;
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setInt(_keySearchTimeout, timeout.seconds);
+      notifyListeners();
+    } catch (e) {
+      debugPrint('保存搜索超时设置失败: $e');
+    }
+  }
+
+  /// 设置搜索请求间隔（毫秒）
+  Future<void> setSearchRequestInterval(int intervalMs) async {
+    if (_searchRequestInterval == intervalMs) return;
+
+    // 确保在有效范围内（0-5000ms）
+    intervalMs = intervalMs.clamp(0, 5000);
+    _searchRequestInterval = intervalMs;
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setInt(_keySearchRequestInterval, intervalMs);
+      notifyListeners();
+    } catch (e) {
+      debugPrint('保存搜索请求间隔设置失败: $e');
+    }
+  }
+
+  /// 设置搜索最大结果数
+  Future<void> setSearchMaxResults(int maxResults) async {
+    if (_searchMaxResults == maxResults) return;
+
+    // 确保在有效范围内（50-2000）
+    maxResults = maxResults.clamp(50, 2000);
+    _searchMaxResults = maxResults;
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setInt(_keySearchMaxResults, maxResults);
+      notifyListeners();
+    } catch (e) {
+      debugPrint('保存搜索最大结果数设置失败: $e');
+    }
+  }
+
   /// 检查文件夹名称是否匹配模式（支持通配符 * 和 ?）
   bool matchesSeasonPattern(String folderName) {
     if (_seasonFolderPattern.isEmpty) return false;
@@ -484,7 +718,16 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
     _seasonFolderPattern = 'Season*';
     _showPathBreadcrumb = true;
     _bgmIdQuickMatch = false;
-    _bgmIdMatchPattern = 'bgmid=(\\d+)';
+    _bgmIdMatchPattern = 'bgm(id)?[=-](\\d+)';
+
+    // 重置搜索功能相关设置
+    _enableSearch = true;
+    _searchScope = WebDAVSearchScope.currentWithDepth;
+    _searchDepthLimit = 3;
+    _searchTargets = WebDAVSearchTarget.defaultTargets;
+    _searchTimeout = WebDAVSearchTimeout.seconds30;
+    _searchRequestInterval = 100;
+    _searchMaxResults = 500;
 
     try {
       final prefs = await SharedPreferences.getInstance();
@@ -498,6 +741,14 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
       await prefs.remove(_keyShowPathBreadcrumb);
       await prefs.remove(_keyBgmIdQuickMatch);
       await prefs.remove(_keyBgmIdMatchPattern);
+      // 清除搜索功能相关设置
+      await prefs.remove(_keyEnableSearch);
+      await prefs.remove(_keySearchScope);
+      await prefs.remove(_keySearchDepthLimit);
+      await prefs.remove(_keySearchTargets);
+      await prefs.remove(_keySearchTimeout);
+      await prefs.remove(_keySearchRequestInterval);
+      await prefs.remove(_keySearchMaxResults);
       notifyListeners();
     } catch (e) {
       debugPrint('重置 WebDAV 快捷设置失败: $e');

--- a/lib/services/webdav_service.dart
+++ b/lib/services/webdav_service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/io_client.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -73,6 +74,21 @@ class WebDAVFile {
     required this.isDirectory,
     this.size,
     this.lastModified,
+  });
+}
+
+/// WebDAV 搜索结果
+class WebDAVSearchResult {
+  final WebDAVFile file;
+  final String fullPath;
+  final String relativePath;
+  final WebDAVConnection connection;
+
+  const WebDAVSearchResult({
+    required this.file,
+    required this.fullPath,
+    required this.relativePath,
+    required this.connection,
   });
 }
 
@@ -1466,6 +1482,255 @@ class WebDAVService {
     } catch (_) {
       return trimmed;
     }
+  }
+
+  // ==================== 搜索功能 ====================
+
+  /// 搜索文件（递归遍历方式）
+  ///
+  /// 参数:
+  /// - connection: WebDAV 连接
+  /// - keyword: 搜索关键词
+  /// - startPath: 搜索起点路径
+  /// - scope: 搜索范围
+  /// - depthLimit: 层级限制（对 currentWithDepth 和 global 都有效）
+  /// - searchTargets: 搜索目标类型（文件夹、视频文件）
+  /// - timeoutSeconds: 超时时间（秒，0 表示无限制）
+  /// - requestIntervalMs: 请求间隔（毫秒），防止请求过快被服务器限制
+  /// - onProgress: 进度回调（已搜索数量，已找到数量）
+  /// - onResultFound: 实时结果回调，每找到一个结果立即通知
+  /// - onStopRequested: 停止信号 getter，返回 true 时停止搜索
+  ///
+  /// 返回: 搜索结果列表
+  Future<List<WebDAVSearchResult>> searchFiles({
+    required WebDAVConnection connection,
+    required String keyword,
+    required String startPath,
+    required String scope,
+    int depthLimit = 3,
+    Set<String>? searchTargets,
+    int timeoutSeconds = 30,
+    int requestIntervalMs = 100,
+    void Function(int searched, int found)? onProgress,
+    void Function(WebDAVSearchResult result)? onResultFound,
+    bool Function()? onStopRequested,
+  }) async {
+    final targets = searchTargets ?? const {'folder', 'video'};
+    final normalizedConnection = _normalizeConnection(connection);
+    final normalizedKeyword = keyword.trim().toLowerCase();
+
+    if (normalizedKeyword.isEmpty) {
+      return [];
+    }
+
+    final results = <WebDAVSearchResult>[];
+    final startTime = DateTime.now();
+    int searchedCount = 0;
+    int foundCount = 0;
+
+    // 根据搜索范围确定起点
+    String actualStartPath;
+    switch (scope) {
+      case 'current_directory':
+        actualStartPath = startPath;
+        depthLimit = 0; // 仅当前目录
+        break;
+      case 'current_with_depth':
+        actualStartPath = startPath;
+        break;
+      case 'global':
+        actualStartPath = '/';
+        break;
+      default:
+        actualStartPath = startPath;
+    }
+
+    // 递归遍历搜索
+    await _recursiveSearch(
+      connection: normalizedConnection,
+      keyword: normalizedKeyword,
+      currentPath: actualStartPath,
+      startPath: actualStartPath,
+      currentDepth: 0,
+      depthLimit: depthLimit,
+      searchTargets: targets,
+      results: results,
+      startTime: startTime,
+      timeoutSeconds: timeoutSeconds,
+      requestIntervalMs: requestIntervalMs,
+      onProgress: onProgress,
+      onResultFound: onResultFound,
+      onStopRequested: onStopRequested,
+      searchedCount: () => searchedCount,
+      foundCount: () => foundCount,
+      updateSearchedCount: (count) { searchedCount = count; },
+      updateFoundCount: (count) { foundCount = count; },
+    );
+
+    return results;
+  }
+
+  /// 递归搜索
+  Future<void> _recursiveSearch({
+    required WebDAVConnection connection,
+    required String keyword,
+    required String currentPath,
+    required String startPath,
+    required int currentDepth,
+    required int depthLimit,
+    required Set<String> searchTargets,
+    required List<WebDAVSearchResult> results,
+    required DateTime startTime,
+    required int timeoutSeconds,
+    required int requestIntervalMs,
+    required void Function(int, int)? onProgress,
+    required void Function(WebDAVSearchResult)? onResultFound,
+    required bool Function()? onStopRequested,
+    required int Function() searchedCount,
+    required int Function() foundCount,
+    required void Function(int) updateSearchedCount,
+    required void Function(int) updateFoundCount,
+  }) async {
+    // 检查停止条件
+    if (onStopRequested != null && onStopRequested()) {
+      return;
+    }
+
+    // 检查超时
+    if (timeoutSeconds > 0) {
+      final elapsed = DateTime.now().difference(startTime).inSeconds;
+      if (elapsed >= timeoutSeconds) {
+        return;
+      }
+    }
+
+    // 检查层级限制
+    if (currentDepth > depthLimit) {
+      return;
+    }
+
+    // 添加请求间隔延迟（非首次请求）
+    if (currentDepth > 0 && requestIntervalMs > 0) {
+      await Future.delayed(Duration(milliseconds: requestIntervalMs));
+    }
+
+    try {
+      final files = await listDirectoryAll(connection, currentPath);
+      // listDirectoryAll 是网络调用，返回后立即检查停止信号
+      if (onStopRequested != null && onStopRequested()) {
+        return;
+      }
+      updateSearchedCount(searchedCount() + files.length);
+
+      for (final file in files) {
+        // 检查停止信号
+        if (onStopRequested != null && onStopRequested()) {
+          return;
+        }
+
+        // 检查超时
+        if (timeoutSeconds > 0) {
+          final elapsed = DateTime.now().difference(startTime).inSeconds;
+          if (elapsed >= timeoutSeconds) {
+            return;
+          }
+        }
+
+        // 匹配搜索目标和关键词
+        if (_matchesSearchTarget(file, searchTargets) &&
+            file.name.toLowerCase().contains(keyword)) {
+          final result = WebDAVSearchResult(
+            file: file,
+            fullPath: file.path,
+            relativePath: _getRelativePath(file.path, startPath),
+            connection: connection,
+          );
+          results.add(result);
+          updateFoundCount(foundCount() + 1);
+          // 实时通知找到的结果
+          onResultFound?.call(result);
+          onProgress?.call(searchedCount(), foundCount());
+          // 结果通知后立即检查停止信号，UI 回调可能已设置 _maxResultsReached
+          if (onStopRequested != null && onStopRequested()) {
+            return;
+          }
+        }
+
+        // 如果是目录，递归搜索
+        if (file.isDirectory) {
+          await _recursiveSearch(
+            connection: connection,
+            keyword: keyword,
+            currentPath: file.path,
+            startPath: startPath,
+            currentDepth: currentDepth + 1,
+            depthLimit: depthLimit,
+            searchTargets: searchTargets,
+            results: results,
+            startTime: startTime,
+            timeoutSeconds: timeoutSeconds,
+            requestIntervalMs: requestIntervalMs,
+            onProgress: onProgress,
+            onResultFound: onResultFound,
+            onStopRequested: onStopRequested,
+            searchedCount: searchedCount,
+            foundCount: foundCount,
+            updateSearchedCount: updateSearchedCount,
+            updateFoundCount: updateFoundCount,
+          );
+        }
+      }
+
+      onProgress?.call(searchedCount(), foundCount());
+    } catch (e) {
+      debugPrint('[WebDAV] 搜索目录失败: $currentPath - $e');
+    }
+  }
+
+  /// 检查文件是否匹配搜索目标
+  bool _matchesSearchTarget(WebDAVFile file, Set<String> targets) {
+    if (targets.contains('all')) return true;
+
+    if (file.isDirectory) {
+      return targets.contains('folder');
+    }
+
+    final extension = _getFileExtension(file.name);
+    if (targets.contains('video') && _isVideoExtension(extension)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /// 获取文件扩展名
+  String _getFileExtension(String filename) {
+    final lower = filename.toLowerCase();
+    final dotIndex = lower.lastIndexOf('.');
+    if (dotIndex == -1 || dotIndex == lower.length - 1) {
+      return '';
+    }
+    return lower.substring(dotIndex + 1);
+  }
+
+  /// 检查是否为视频扩展名
+  bool _isVideoExtension(String extension) {
+    const videoExtensions = {
+      'mp4', 'mkv', 'avi', 'mov', 'wmv', 'flv', 'webm', 'm4v',
+      'mpg', 'mpeg', 'rm', 'rmvb', 'ts', 'mts', 'm2ts',
+    };
+    return videoExtensions.contains(extension);
+  }
+
+  /// 获取相对路径
+  String _getRelativePath(String fullPath, String basePath) {
+    final normalizedBase = _ensureTrailingSlash(
+      _collapseSlashes(basePath.isEmpty ? '/' : basePath),
+    );
+    if (fullPath.startsWith(normalizedBase)) {
+      return fullPath.substring(normalizedBase.length);
+    }
+    return fullPath;
   }
 }
 

--- a/lib/themes/cupertino/pages/settings/pages/webdav_quick_settings_page.dart
+++ b/lib/themes/cupertino/pages/settings/pages/webdav_quick_settings_page.dart
@@ -91,6 +91,8 @@ class _CupertinoWebDAVQuickSettingsPageState
                   const SizedBox(height: 24),
                   _buildBgmIdQuickMatchCard(context, provider),
                   const SizedBox(height: 24),
+                  _buildSearchConfigCard(context, provider),
+                  const SizedBox(height: 24),
                   _buildResetCard(context, provider),
                 ],
               ),
@@ -650,7 +652,7 @@ class _CupertinoWebDAVQuickSettingsPageState
         CupertinoSettingsTile(
           leading: Icon(CupertinoIcons.bolt_fill, color: iconColor),
           title: const Text('bgmid 快速匹配'),
-          subtitle: const Text('解析 URL 中的 bgmid 跳过哈希计算'),
+          subtitle: const Text('从 URL 中提取 bgmid，直接获取番剧信息'),
           backgroundColor: tileColor,
           trailing: CupertinoSwitch(
             value: provider.bgmIdQuickMatch,
@@ -672,13 +674,13 @@ class _CupertinoWebDAVQuickSettingsPageState
                 ),
                 SizedBox(height: 4),
                 Text(
-                  '从完整 URL 中匹配数字，默认匹配 "bgmid=数字"',
+                  '从完整 URL 中匹配 bgmid 数字，支持 bgmid=123 或 bgm-123 格式',
                   style: TextStyle(color: secondaryColor, fontSize: 11),
                 ),
                 SizedBox(height: 8),
                 CupertinoTextField(
                   controller: _patternController,
-                  placeholder: 'bgmid=(\\d+)',
+                  placeholder: 'bgm(id)?[=-](\\d+)',
                   style: TextStyle(color: textColor, fontSize: 13),
                   decoration: BoxDecoration(
                     color: tileColor,
@@ -694,13 +696,370 @@ class _CupertinoWebDAVQuickSettingsPageState
                 ),
                 SizedBox(height: 4),
                 Text(
-                  '示例: bgm[=-](\\d+) 可匹配 bgmid=123 或 bgm-123',
+                  '最后一个捕获组应为数字，如 bgmid=(\\d+) 或 bgm-(\\d+)',
                   style: TextStyle(color: secondaryColor.withOpacity(0.7), fontSize: 10),
                 ),
               ],
             ),
           ),
       ],
+    );
+  }
+
+  Widget _buildSearchConfigCard(BuildContext context, WebDAVQuickAccessProvider provider) {
+    final Color tileColor = resolveSettingsTileBackground(context);
+    final Color sectionColor = resolveSettingsSectionBackground(context);
+    final Color iconColor = resolveSettingsIconColor(context);
+    final Color textColor = resolveSettingsPrimaryTextColor(context);
+    final Color secondaryColor = resolveSettingsSecondaryTextColor(context);
+    final textTheme = CupertinoTheme.of(context).textTheme.textStyle;
+
+    return CupertinoSettingsGroupCard(
+      margin: EdgeInsets.zero,
+      backgroundColor: sectionColor,
+      children: [
+        CupertinoSettingsTile(
+          leading: Icon(CupertinoIcons.search, color: iconColor),
+          title: const Text('文件搜索'),
+          subtitle: const Text('在 WebDAV 页面显示搜索按钮'),
+          backgroundColor: tileColor,
+          trailing: CupertinoSwitch(
+            value: provider.enableSearch,
+            activeColor: CupertinoColors.activeBlue,
+            onChanged: (value) {
+              provider.setEnableSearch(value);
+            },
+          ),
+        ),
+        if (provider.enableSearch) ...[
+          // 搜索配置详细内容
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // 搜索范围
+                _buildCupertinoSectionTitle('搜索范围', textColor, iconColor),
+                SizedBox(height: 8),
+                ...WebDAVSearchScope.values.map((scope) =>
+                  _buildCupertinoRadioOption<WebDAVSearchScope>(
+                    context,
+                    scope.displayName,
+                    scope.description,
+                    scope,
+                    provider.searchScope,
+                    (value) => provider.setSearchScope(value),
+                    textColor,
+                    secondaryColor,
+                  ),
+                ),
+
+                // 层级限制（当前目录+子目录或全局搜索时显示）
+                if (provider.searchScope == WebDAVSearchScope.currentWithDepth ||
+                    provider.searchScope == WebDAVSearchScope.global) ...[
+                  SizedBox(height: 16),
+                  Row(
+                    children: [
+                      Icon(CupertinoIcons.layers_alt, size: 16, color: iconColor),
+                      SizedBox(width: 8),
+                      Text(
+                        '层级限制',
+                        style: textTheme.copyWith(fontSize: 13, color: secondaryColor),
+                      ),
+                      Spacer(),
+                      Container(
+                        padding: EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+                        decoration: BoxDecoration(
+                          color: CupertinoColors.activeBlue.withOpacity(0.1),
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        child: Text(
+                          '${provider.searchDepthLimit} 层',
+                          style: TextStyle(
+                            color: CupertinoColors.activeBlue,
+                            fontSize: 13,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  SizedBox(height: 8),
+                  // 层级选择器
+                  Wrap(
+                    spacing: 8,
+                    children: List.generate(10, (index) {
+                      final depth = index + 1;
+                      final isSelected = provider.searchDepthLimit == depth;
+                      return CupertinoButton(
+                        padding: EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                        minSize: 0,
+                        color: isSelected
+                            ? CupertinoColors.activeBlue.withOpacity(0.1)
+                            : CupertinoDynamicColor.resolve(
+                                CupertinoColors.tertiarySystemFill,
+                                context,
+                              ),
+                        borderRadius: BorderRadius.circular(16),
+                        onPressed: () {
+                          provider.setSearchDepthLimit(depth);
+                        },
+                        child: Text(
+                          '$depth',
+                          style: TextStyle(
+                            color: isSelected
+                                ? CupertinoColors.activeBlue
+                                : textColor,
+                            fontSize: 13,
+                          ),
+                        ),
+                      );
+                    }),
+                  ),
+                ],
+
+                SizedBox(height: 16),
+
+                // 搜索目标（多选）
+                _buildCupertinoSectionTitle('搜索目标（可多选）', textColor, iconColor),
+                SizedBox(height: 8),
+                Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: WebDAVSearchTarget.values.map((target) {
+                    final isSelected = provider.searchTargets.contains(target);
+                    return CupertinoButton(
+                      padding: EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                      minSize: 0,
+                      color: isSelected
+                          ? CupertinoColors.activeBlue.withOpacity(0.1)
+                          : CupertinoDynamicColor.resolve(
+                              CupertinoColors.tertiarySystemFill,
+                              context,
+                            ),
+                      borderRadius: BorderRadius.circular(16),
+                      onPressed: () {
+                        provider.toggleSearchTarget(target);
+                      },
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          if (isSelected)
+                            Icon(
+                              CupertinoIcons.check_mark,
+                              size: 14,
+                              color: CupertinoColors.activeBlue,
+                            ),
+                          if (isSelected) SizedBox(width: 4),
+                          Text(
+                            target.displayName,
+                            style: TextStyle(
+                              color: isSelected
+                                  ? CupertinoColors.activeBlue
+                                  : textColor,
+                              fontSize: 13,
+                            ),
+                          ),
+                        ],
+                      ),
+                    );
+                  }).toList(),
+                ),
+
+                SizedBox(height: 16),
+
+                // 搜索超时
+                _buildCupertinoSectionTitle('搜索超时', textColor, iconColor),
+                SizedBox(height: 8),
+                ...WebDAVSearchTimeout.values.map((timeout) =>
+                  _buildCupertinoRadioOption<WebDAVSearchTimeout>(
+                    context,
+                    timeout.displayName,
+                    null,
+                    timeout,
+                    provider.searchTimeout,
+                    (value) => provider.setSearchTimeout(value),
+                    textColor,
+                    secondaryColor,
+                  ),
+                ),
+
+                SizedBox(height: 16),
+
+                // 请求间隔
+                Row(
+                  children: [
+                    Icon(CupertinoIcons.time, size: 16, color: iconColor),
+                    SizedBox(width: 8),
+                    Text(
+                      '请求间隔',
+                      style: textTheme.copyWith(fontSize: 13, color: secondaryColor),
+                    ),
+                    Spacer(),
+                    Container(
+                      padding: EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+                      decoration: BoxDecoration(
+                        color: CupertinoColors.activeBlue.withOpacity(0.1),
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: Text(
+                        '${provider.searchRequestInterval} ms',
+                        style: TextStyle(
+                          color: CupertinoColors.activeBlue,
+                          fontSize: 13,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+                SizedBox(height: 4),
+                Text(
+                  '防止请求过快被服务器限制，0 表示无延迟',
+                  style: TextStyle(color: secondaryColor.withOpacity(0.7), fontSize: 11),
+                ),
+                SizedBox(height: 8),
+                // 间隔选择器
+                CupertinoSlidingSegmentedControl<int>(
+                  groupValue: _clampRequestInterval(provider.searchRequestInterval),
+                  children: const {
+                    0: Text('0'),
+                    50: Text('50'),
+                    100: Text('100'),
+                    200: Text('200'),
+                    500: Text('500'),
+                  },
+                  onValueChanged: (value) {
+                    if (value != null) {
+                      provider.setSearchRequestInterval(value);
+                    }
+                  },
+                ),
+
+                SizedBox(height: 16),
+
+                // 最大结果数
+                Row(
+                  children: [
+                    Icon(CupertinoIcons.number, size: 16, color: iconColor),
+                    SizedBox(width: 8),
+                    Text(
+                      '最大结果数',
+                      style: textTheme.copyWith(fontSize: 13, color: secondaryColor),
+                    ),
+                    Spacer(),
+                    Container(
+                      padding: EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+                      decoration: BoxDecoration(
+                        color: CupertinoColors.activeBlue.withOpacity(0.1),
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: Text(
+                        '${provider.searchMaxResults}',
+                        style: TextStyle(
+                          color: CupertinoColors.activeBlue,
+                          fontSize: 13,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+                SizedBox(height: 4),
+                Text(
+                  '搜索结果达到上限时自动停止',
+                  style: TextStyle(color: secondaryColor.withOpacity(0.7), fontSize: 11),
+                ),
+                SizedBox(height: 8),
+                // 最大结果数滑块
+                CupertinoSlider(
+                  value: provider.searchMaxResults.toDouble(),
+                  min: 50,
+                  max: 2000,
+                  divisions: 39,
+                  onChanged: (value) {
+                    provider.setSearchMaxResults(value.round());
+                  },
+                ),
+              ],
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildCupertinoSectionTitle(String title, Color textColor, Color iconColor) {
+    return Row(
+      children: [
+        Icon(CupertinoIcons.chevron_right, size: 14, color: iconColor),
+        SizedBox(width: 4),
+        Text(
+          title,
+          style: TextStyle(
+            color: textColor,
+            fontSize: 14,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCupertinoRadioOption<T>(
+    BuildContext context,
+    String title,
+    String? subtitle,
+    T value,
+    T groupValue,
+    ValueChanged<T> onChanged,
+    Color textColor,
+    Color secondaryColor,
+  ) {
+    final isSelected = value == groupValue;
+    return GestureDetector(
+      onTap: () => onChanged(value),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        child: Row(
+          children: [
+            Icon(
+              isSelected
+                  ? CupertinoIcons.check_mark_circled
+                  : CupertinoIcons.circle,
+              size: 20,
+              color: isSelected
+                  ? CupertinoColors.activeBlue
+                  : secondaryColor.withOpacity(0.5),
+            ),
+            SizedBox(width: 8),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: TextStyle(
+                      color: textColor,
+                      fontSize: 14,
+                    ),
+                  ),
+                  if (subtitle != null) ...[
+                    SizedBox(height: 2),
+                    Text(
+                      subtitle,
+                      style: TextStyle(
+                        color: secondaryColor,
+                        fontSize: 11,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 
@@ -739,5 +1098,10 @@ class _CupertinoWebDAVQuickSettingsPageState
         ),
       ],
     );
+  }
+
+  int _clampRequestInterval(int value) {
+    const validValues = [0, 50, 100, 200, 500];
+    return validValues.reduce((a, b) => (value - a).abs() < (value - b).abs() ? a : b);
   }
 }

--- a/lib/themes/nipaplay/pages/settings/webdav_quick_settings_page.dart
+++ b/lib/themes/nipaplay/pages/settings/webdav_quick_settings_page.dart
@@ -511,7 +511,7 @@ class _WebDAVQuickSettingsPageState extends State<WebDAVQuickSettingsPage> {
                       ),
                     ),
                     subtitle: Text(
-                      '解析 URL 中的 bgmid 跳过哈希计算',
+                      '从 URL 中提取 bgmid，直接获取番剧信息',
                       style: TextStyle(
                         color: secondaryTextColor,
                       ),
@@ -542,7 +542,7 @@ class _WebDAVQuickSettingsPageState extends State<WebDAVQuickSettingsPage> {
                           ),
                           SizedBox(height: 4),
                           Text(
-                            '从完整 URL 中匹配数字，默认匹配 "bgmid=数字"',
+                            '从完整 URL 中匹配 bgmid 数字，支持 bgmid=123 或 bgm-123 格式',
                             style: TextStyle(
                               color: secondaryTextColor,
                               fontSize: 11,
@@ -553,7 +553,7 @@ class _WebDAVQuickSettingsPageState extends State<WebDAVQuickSettingsPage> {
                             controller: _patternController,
                             style: TextStyle(color: textColor, fontSize: 13),
                             decoration: InputDecoration(
-                              hintText: 'bgmid=(\\d+)',
+                              hintText: 'bgm(id)?[=-](\\d+)',
                               hintStyle: TextStyle(color: secondaryTextColor.withOpacity(0.5)),
                               contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
                               border: OutlineInputBorder(
@@ -577,11 +577,287 @@ class _WebDAVQuickSettingsPageState extends State<WebDAVQuickSettingsPage> {
                           ),
                           SizedBox(height: 4),
                           Text(
-                            '示例: bgm[=-](\\d+) 可匹配 bgmid=123 或 bgm-123',
+                            '最后一个捕获组应为数字，如 bgmid=(\\d+) 或 bgm-(\\d+)',
                             style: TextStyle(
                               color: secondaryTextColor.withOpacity(0.7),
                               fontSize: 10,
                             ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+
+            SizedBox(height: 16),
+
+            // 搜索功能配置
+            _buildSettingsCard(
+              cardColor: cardColor,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // 搜索功能总开关
+                  ListTile(
+                    leading: Icon(Ionicons.search_outline, color: textColor.withOpacity(0.7)),
+                    title: Text(
+                      '文件搜索',
+                      style: TextStyle(
+                        color: textColor,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    subtitle: Text(
+                      '在 WebDAV 页面显示搜索按钮',
+                      style: TextStyle(
+                        color: secondaryTextColor,
+                      ),
+                    ),
+                    trailing: FluentSettingsSwitch(
+                      value: provider.enableSearch,
+                      onChanged: (value) {
+                        provider.setEnableSearch(value);
+                      },
+                    ),
+                    onTap: () {
+                      provider.setEnableSearch(!provider.enableSearch);
+                    },
+                  ),
+
+                  // 搜索详细配置（仅在开启搜索时显示）
+                  if (provider.enableSearch) ...[
+                    Divider(height: 1, color: secondaryTextColor.withOpacity(0.2)),
+                    Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          // 搜索范围
+                          _buildSearchSectionTitle('搜索范围', textColor),
+                          SizedBox(height: 8),
+                          ...WebDAVSearchScope.values.map((scope) =>
+                            RadioListTile<WebDAVSearchScope>(
+                              title: Text(
+                                scope.displayName,
+                                style: TextStyle(color: textColor, fontSize: 14),
+                              ),
+                              subtitle: Text(
+                                scope.description,
+                                style: TextStyle(color: secondaryTextColor, fontSize: 11),
+                              ),
+                              value: scope,
+                              groupValue: provider.searchScope,
+                              activeColor: accentColor,
+                              contentPadding: EdgeInsets.zero,
+                              visualDensity: VisualDensity.compact,
+                              onChanged: (value) {
+                                if (value != null) {
+                                  provider.setSearchScope(value);
+                                }
+                              },
+                            ),
+                          ),
+
+                          // 层级限制（当前目录+子目录或全局搜索时显示）
+                          if (provider.searchScope == WebDAVSearchScope.currentWithDepth ||
+                              provider.searchScope == WebDAVSearchScope.global) ...[
+                            SizedBox(height: 16),
+                            Row(
+                              children: [
+                                Text(
+                                  '层级限制',
+                                  style: TextStyle(
+                                    color: textColor,
+                                    fontSize: 14,
+                                    fontWeight: FontWeight.w500,
+                                  ),
+                                ),
+                                Spacer(),
+                                Container(
+                                  padding: EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+                                  decoration: BoxDecoration(
+                                    color: accentColor.withOpacity(0.1),
+                                    borderRadius: BorderRadius.circular(12),
+                                  ),
+                                  child: Text(
+                                    '${provider.searchDepthLimit} 层',
+                                    style: TextStyle(
+                                      color: accentColor,
+                                      fontSize: 13,
+                                      fontWeight: FontWeight.w600,
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            ),
+                            SizedBox(height: 8),
+                            Slider(
+                              value: provider.searchDepthLimit.toDouble(),
+                              min: 1,
+                              max: 10,
+                              divisions: 9,
+                              activeColor: accentColor,
+                              onChanged: (value) {
+                                provider.setSearchDepthLimit(value.round());
+                              },
+                            ),
+                          ],
+
+                          SizedBox(height: 16),
+
+                          // 搜索目标（多选）
+                          _buildSearchSectionTitle('搜索目标（可多选）', textColor),
+                          SizedBox(height: 8),
+                          Wrap(
+                            spacing: 8,
+                            runSpacing: 8,
+                            children: WebDAVSearchTarget.values.map((target) {
+                              final isSelected = provider.searchTargets.contains(target);
+                              return FilterChip(
+                                label: Text(target.displayName),
+                                selected: isSelected,
+                                selectedColor: accentColor.withOpacity(0.2),
+                                checkmarkColor: accentColor,
+                                labelStyle: TextStyle(
+                                  color: isSelected ? accentColor : textColor,
+                                  fontSize: 13,
+                                ),
+                                side: BorderSide(
+                                  color: isSelected ? accentColor : secondaryTextColor.withOpacity(0.3),
+                                ),
+                                onSelected: (selected) {
+                                  provider.toggleSearchTarget(target);
+                                },
+                              );
+                            }).toList(),
+                          ),
+
+                          SizedBox(height: 16),
+
+                          // 搜索超时
+                          _buildSearchSectionTitle('搜索超时', textColor),
+                          SizedBox(height: 8),
+                          ...WebDAVSearchTimeout.values.map((timeout) =>
+                            RadioListTile<WebDAVSearchTimeout>(
+                              title: Text(
+                                timeout.displayName,
+                                style: TextStyle(color: textColor, fontSize: 14),
+                              ),
+                              value: timeout,
+                              groupValue: provider.searchTimeout,
+                              activeColor: accentColor,
+                              contentPadding: EdgeInsets.zero,
+                              visualDensity: VisualDensity.compact,
+                              onChanged: (value) {
+                                if (value != null) {
+                                  provider.setSearchTimeout(value);
+                                }
+                              },
+                            ),
+                          ),
+
+                          SizedBox(height: 16),
+
+                          // 请求间隔
+                          Row(
+                            children: [
+                              Text(
+                                '请求间隔',
+                                style: TextStyle(
+                                  color: textColor,
+                                  fontSize: 14,
+                                  fontWeight: FontWeight.w500,
+                                ),
+                              ),
+                              Spacer(),
+                              Container(
+                                padding: EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+                                decoration: BoxDecoration(
+                                  color: accentColor.withOpacity(0.1),
+                                  borderRadius: BorderRadius.circular(12),
+                                ),
+                                child: Text(
+                                  '${provider.searchRequestInterval} ms',
+                                  style: TextStyle(
+                                    color: accentColor,
+                                    fontSize: 13,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                          SizedBox(height: 4),
+                          Text(
+                            '防止请求过快被服务器限制，0 表示无延迟',
+                            style: TextStyle(
+                              color: secondaryTextColor,
+                              fontSize: 11,
+                            ),
+                          ),
+                          SizedBox(height: 8),
+                          Slider(
+                            value: provider.searchRequestInterval.toDouble(),
+                            min: 0,
+                            max: 1000,
+                            divisions: 20,
+                            activeColor: accentColor,
+                            onChanged: (value) {
+                              provider.setSearchRequestInterval(value.round());
+                            },
+                          ),
+
+                          SizedBox(height: 16),
+
+                          // 最大结果数
+                          Row(
+                            children: [
+                              Text(
+                                '最大结果数',
+                                style: TextStyle(
+                                  color: textColor,
+                                  fontSize: 14,
+                                  fontWeight: FontWeight.w500,
+                                ),
+                              ),
+                              Spacer(),
+                              Container(
+                                padding: EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+                                decoration: BoxDecoration(
+                                  color: accentColor.withOpacity(0.1),
+                                  borderRadius: BorderRadius.circular(12),
+                                ),
+                                child: Text(
+                                  '${provider.searchMaxResults}',
+                                  style: TextStyle(
+                                    color: accentColor,
+                                    fontSize: 13,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                          SizedBox(height: 4),
+                          Text(
+                            '搜索结果达到上限时自动停止',
+                            style: TextStyle(
+                              color: secondaryTextColor,
+                              fontSize: 11,
+                            ),
+                          ),
+                          SizedBox(height: 8),
+                          Slider(
+                            value: provider.searchMaxResults.toDouble(),
+                            min: 50,
+                            max: 2000,
+                            divisions: 39,
+                            activeColor: accentColor,
+                            onChanged: (value) {
+                              provider.setSearchMaxResults(value.round());
+                            },
                           ),
                         ],
                       ),
@@ -683,6 +959,17 @@ class _WebDAVQuickSettingsPageState extends State<WebDAVQuickSettingsPage> {
       onPressed: () {
         provider.setSeasonFolderPattern(pattern);
       },
+    );
+  }
+
+  Widget _buildSearchSectionTitle(String title, Color textColor) {
+    return Text(
+      title,
+      style: TextStyle(
+        color: textColor,
+        fontSize: 14,
+        fontWeight: FontWeight.w500,
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary

- 在 WebDAV 浏览页面新增文件搜索功能，支持递归遍历、实时结果显示、多种搜索配置
- 优化 bgmid 匹配默认正则，兼容更多 URL 格式

## Related Issue

- Closes #（无关联 Issue）

## What Changed

### 文件搜索功能
- **搜索实现** (`lib/services/webdav_service.dart`)：基于 PROPFIND 的递归遍历搜索，搜索结果数据模型
- **搜索配置持久化** (`lib/providers/webdav_quick_access_provider.dart`)：7 个搜索配置项（范围/层级/目标/超时/间隔/最大结果数/开关），通过 SharedPreferences 持久化
- **搜索 UI** (`lib/pages/webdav_browser_page.dart`)：搜索输入框、实时进度、结果列表、跳转/播放操作，UI 节流 100ms
- **设置页面** (`lib/themes/*/webdav_quick_settings_page.dart`)：搜索配置卡片，NipaPlay 与 Cupertino 两套主题同步

### bgmid 正则优化
- 默认正则 `bgmid=(\d+)` → `bgm(id)?[=-](\d+)`，兼容 `bgmid=12345` 和 `bgm-12345`
- 取最后一个捕获组作为匹配数字
- 相关设置页文档说明修正

## 验证方式

- [x] `flutter analyze` 无新增 error
- [x] 手动测试：搜索关键词 → 实时结果展示 → 停止搜索 → 跳转目录 → 播放视频
- [x] 手动测试：调整搜索配置（范围/层级/间隔/最大结果数）→ 验证行为变化
- [x] 手动测试：播放含 `bgmid=123` 和 `bgm-123` 格式的 URL → 验证快速匹配