### PR TITLE
Fix #490: adapt dandanplay icon for light/dark mode

### DIFF
--- a/lib/themes/nipaplay/pages/settings/remote_media_library_page.dart
+++ b/lib/themes/nipaplay/pages/settings/remote_media_library_page.dart
@@ -980,11 +980,17 @@ class _RemoteMediaLibraryPageState extends State<RemoteMediaLibraryPage> {
       children: [
         Row(
           children: [
-            Image.asset(
-              'assets/dandanplay.png',
-              width: 32,
-              height: 32,
-              fit: BoxFit.contain,
+            ColorFiltered(
+              colorFilter: ColorFilter.mode(
+                colorScheme.onSurface,
+                BlendMode.srcIn,
+              ),
+              child: Image.asset(
+                'assets/dandanplay.png',
+                width: 32,
+                height: 32,
+                fit: BoxFit.contain,
+              ),
             ),
             SizedBox(width: 12),
             Text(


### PR DESCRIPTION
## Summary
- fix dandanplay icon visibility issue in media server settings
- apply theme-aware tint using colorScheme.onSurface so the icon is readable in both light and dark mode

## Testing
- flutter analyze lib/themes/nipaplay/pages/settings/remote_media_library_page.dart

Closes #490