### PR TITLE
Fix mobile remote access, danmaku shadow, and playlist sorting

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
     xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <!-- 基本存储权限 - 对于Android 9及以下 -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29" />

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -203,7 +203,7 @@
 	<key>NSDocumentsFolderUsageDescription</key>
 	<string>NipaPlay 需要访问文稿目录以管理您的文件。</string>
 	<key>NSLocalNetworkUsageDescription</key>
-	<string>需要访问本地网络以获取新番更新和弹幕信息</string>
+	<string>NipaPlay 需要访问本地网络以发现局域网设备、启用远程访问并共享本机媒体库。</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>NipaPlay需要访问您的相册以上传和选择视频文件。</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>

--- a/lib/services/auto_next_episode_service.dart
+++ b/lib/services/auto_next_episode_service.dart
@@ -7,6 +7,7 @@ import 'package:nipaplay/utils/video_player_state.dart';
 import 'package:provider/provider.dart';
 import 'package:nipaplay/providers/settings_provider.dart';
 import 'package:nipaplay/services/external_player_service.dart';
+import 'package:nipaplay/utils/webdav_file_sorter.dart';
 
 class AutoNextEpisodeService {
   static AutoNextEpisodeService? _instance;
@@ -23,14 +24,8 @@ class AutoNextEpisodeService {
   int _countdownDurationSeconds = defaultCountdownSeconds;
   bool _isCountingDown = false;
   String? _nextEpisodePath;
-  BuildContext? _context;
   bool _isCancelled = false;
   bool _autoPlayEnabled = true;
-  
-  // 设置上下文
-  void setContext(BuildContext context) {
-    _context = context;
-  }
   
   // 开始自动播放下一话的倒计时
   void startAutoNextEpisode(BuildContext context, String currentVideoPath) {
@@ -38,7 +33,7 @@ class AutoNextEpisodeService {
       debugPrint('[AutoNext] 自动连播已禁用，跳过startAutoNextEpisode调用');
       return;
     }
-    debugPrint('[AutoNext] startAutoNextEpisode called, _isCountingDown=$_isCountingDown, context=${context != null}, mounted=${(context is Element) ? (context).mounted : 'unknown'}');
+    debugPrint('[AutoNext] startAutoNextEpisode called, _isCountingDown=$_isCountingDown, mounted=${(context is Element) ? (context).mounted : 'unknown'}');
     if (_isCountingDown) {
       debugPrint('[AutoNext] _isCountingDown为true，直接return，不触发自动连播');
       return;
@@ -123,8 +118,11 @@ class AutoNextEpisodeService {
           .where((file) => videoExtensions.any((ext) => file.path.toLowerCase().endsWith(ext)))
           .toList();
 
-      // 按文件名排序
-      videoFiles.sort((a, b) => a.path.toLowerCase().compareTo(b.path.toLowerCase()));
+      // 按文件名自然排序，避免 1、15、2 这类字典序连播顺序。
+      videoFiles.sort((a, b) => WebDAVFileSorter.naturalCompare(
+            a.uri.pathSegments.isNotEmpty ? a.uri.pathSegments.last : a.path,
+            b.uri.pathSegments.isNotEmpty ? b.uri.pathSegments.last : b.path,
+          ));
       
       // 找到当前文件的索引
       final currentIndex = videoFiles.indexWhere((file) => file.path == currentVideoPath);

--- a/lib/services/episode_navigation_service.dart
+++ b/lib/services/episode_navigation_service.dart
@@ -14,6 +14,7 @@ import 'package:nipaplay/services/emby_episode_mapping_service.dart';
 import 'package:nipaplay/services/dandanplay_service.dart';
 import 'package:nipaplay/services/smb_proxy_service.dart';
 import 'package:nipaplay/services/smb_service.dart';
+import 'package:nipaplay/utils/webdav_file_sorter.dart';
 /// 剧集导航结果
 class EpisodeNavigationResult {
 
@@ -426,7 +427,7 @@ class EpisodeNavigationService {
       if (aTime != bTime) {
         return aTime.compareTo(bTime);
       }
-      return a.name.compareTo(b.name);
+      return WebDAVFileSorter.naturalCompare(a.name, b.name);
     });
     return sorted;
   }
@@ -916,8 +917,11 @@ class EpisodeNavigationService {
         return EpisodeNavigationResult.failure('目录中没有其他视频文件');
       }
 
-      // 按文件名排序
-      videoFiles.sort((a, b) => path.basename(a.path).compareTo(path.basename(b.path)));
+      // 按文件名自然排序，保持 1、2、10 这样的播放顺序。
+      videoFiles.sort((a, b) => WebDAVFileSorter.naturalCompare(
+            path.basename(a.path),
+            path.basename(b.path),
+          ));
 
       // 找到当前文件的位置
       final currentIndex = videoFiles.indexWhere((file) => file.path == currentFilePath);
@@ -969,8 +973,11 @@ class EpisodeNavigationService {
         return EpisodeNavigationResult.failure('目录中没有其他视频文件');
       }
 
-      // 按文件名排序
-      videoFiles.sort((a, b) => path.basename(a.path).compareTo(path.basename(b.path)));
+      // 按文件名自然排序，保持 1、2、10 这样的播放顺序。
+      videoFiles.sort((a, b) => WebDAVFileSorter.naturalCompare(
+            path.basename(a.path),
+            path.basename(b.path),
+          ));
 
       // 找到当前文件的位置
       final currentIndex = videoFiles.indexWhere((file) => file.path == currentFilePath);
@@ -1115,7 +1122,7 @@ class EpisodeNavigationService {
         return EpisodeNavigationResult.failure('目录中没有其他视频文件');
       }
 
-      videoFiles.sort((a, b) => a.name.compareTo(b.name));
+      videoFiles.sort((a, b) => WebDAVFileSorter.naturalCompare(a.name, b.name));
 
       final currentIndex = videoFiles.indexWhere(
         (e) => _normalizeSmbPath(e.path) == parsed.smbPath,
@@ -1172,7 +1179,7 @@ class EpisodeNavigationService {
         return EpisodeNavigationResult.failure('目录中没有其他视频文件');
       }
 
-      videoFiles.sort((a, b) => a.name.compareTo(b.name));
+      videoFiles.sort((a, b) => WebDAVFileSorter.naturalCompare(a.name, b.name));
 
       final currentIndex = videoFiles.indexWhere(
         (e) => _normalizeSmbPath(e.path) == parsed.smbPath,

--- a/lib/services/web_server_service.dart
+++ b/lib/services/web_server_service.dart
@@ -410,13 +410,34 @@ class WebServerService {
       await saveSettings();
     }
   }
+
+  int _accessUrlSortWeight(String url) {
+    final uri = Uri.tryParse(url);
+    final host = uri?.host.toLowerCase() ?? '';
+    if (host == 'localhost' || host == '127.0.0.1' || host == '::1') {
+      return 2;
+    }
+    final address = InternetAddress.tryParse(host);
+    if (address != null && address.type == InternetAddressType.IPv4) {
+      final bytes = address.rawAddress;
+      if (bytes.length == 4) {
+        final first = bytes[0];
+        final second = bytes[1];
+        if (first == 10 ||
+            (first == 172 && second >= 16 && second <= 31) ||
+            (first == 192 && second == 168) ||
+            (first == 169 && second == 254)) {
+          return 0;
+        }
+      }
+    }
+    return 1;
+  }
   
   Future<List<String>> getAccessUrls() async {
     if (!_isRunning || _server == null) return [];
 
     final urls = <String>[];
-    urls.add('http://localhost:${_server!.port}');
-    urls.add('http://127.0.0.1:${_server!.port}');
 
     try {
       for (var interface in await NetworkInterface.list()) {
@@ -429,6 +450,14 @@ class WebServerService {
     } catch (e) {
       print('Error getting network interfaces: $e');
     }
+    urls.add('http://localhost:${_server!.port}');
+    urls.add('http://127.0.0.1:${_server!.port}');
+    urls.sort((a, b) {
+      final weightCompare =
+          _accessUrlSortWeight(a).compareTo(_accessUrlSortWeight(b));
+      if (weightCompare != 0) return weightCompare;
+      return a.compareTo(b);
+    });
     return urls;
   }
 

--- a/lib/themes/cupertino/widgets/player_menu/cupertino_playlist_pane.dart
+++ b/lib/themes/cupertino/widgets/player_menu/cupertino_playlist_pane.dart
@@ -20,6 +20,7 @@ import 'package:nipaplay/services/webdav_service.dart';
 import 'package:nipaplay/providers/shared_remote_library_provider.dart';
 import 'package:nipaplay/utils/media_source_utils.dart';
 import 'package:nipaplay/utils/shared_remote_history_helper.dart';
+import 'package:nipaplay/utils/webdav_file_sorter.dart';
 import 'package:provider/provider.dart';
 
 class CupertinoPlaylistPane extends StatefulWidget {
@@ -239,7 +240,10 @@ class _CupertinoPlaylistPaneState extends State<CupertinoPlaylistPane> {
           ),
         )
         .toList()
-      ..sort((a, b) => a.path.compareTo(b.path));
+      ..sort((a, b) => WebDAVFileSorter.naturalCompare(
+            p.basename(a.path),
+            p.basename(b.path),
+          ));
 
     if (files.isEmpty) {
       throw Exception('当前目录没有其他视频文件');
@@ -267,7 +271,7 @@ class _CupertinoPlaylistPaneState extends State<CupertinoPlaylistPane> {
         .where((entry) =>
             !entry.isDirectory && provider.isRemoteFilePlayable(entry))
         .toList()
-      ..sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+      ..sort((a, b) => WebDAVFileSorter.naturalCompare(a.name, b.name));
 
     _episodes = playableEntries.map((entry) {
       final streamUrl =
@@ -311,7 +315,7 @@ class _CupertinoPlaylistPaneState extends State<CupertinoPlaylistPane> {
         final aId = a.episodeId ?? 0;
         final bId = b.episodeId ?? 0;
         if (aId != bId) return aId.compareTo(bId);
-        return a.title.toLowerCase().compareTo(b.title.toLowerCase());
+        return WebDAVFileSorter.naturalCompare(a.title, b.title);
       });
 
     _episodes = sorted
@@ -372,7 +376,7 @@ class _CupertinoPlaylistPaneState extends State<CupertinoPlaylistPane> {
             !entry.isDirectory &&
             WebDAVService.instance.isVideoFile(entry.name))
         .toList()
-      ..sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+      ..sort((a, b) => WebDAVFileSorter.naturalCompare(a.name, b.name));
 
     _episodes = videoEntries.map((entry) {
       final fileUrl = WebDAVService.instance.getFileUrl(
@@ -416,7 +420,7 @@ class _CupertinoPlaylistPaneState extends State<CupertinoPlaylistPane> {
         .where((entry) =>
             !entry.isDirectory && SMBService.instance.isVideoFile(entry.name))
         .toList()
-      ..sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+      ..sort((a, b) => WebDAVFileSorter.naturalCompare(a.name, b.name));
 
     _episodes = videoEntries.map((entry) {
       final url =

--- a/lib/themes/nipaplay/pages/settings/settings_entries.dart
+++ b/lib/themes/nipaplay/pages/settings/settings_entries.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:kmbal_ionicons/kmbal_ionicons.dart';
 import 'package:nipaplay/l10n/l10n.dart';
@@ -150,7 +151,7 @@ List<NipaplaySettingEntry> buildNipaplaySettingEntries(BuildContext context) {
   );
 
   if (!globals.isPhone) {
-    entries.addAll([
+    entries.add(
       NipaplaySettingEntry(
         id: NipaplaySettingEntryIds.shortcuts,
         title: l10n.shortcuts,
@@ -158,6 +159,11 @@ List<NipaplaySettingEntry> buildNipaplaySettingEntries(BuildContext context) {
         pageTitle: l10n.shortcutsSettings,
         page: const ShortcutsSettingsPage(),
       ),
+    );
+  }
+
+  if (!kIsWeb) {
+    entries.add(
       NipaplaySettingEntry(
         id: NipaplaySettingEntryIds.remoteAccess,
         title: l10n.remoteAccess,
@@ -165,7 +171,7 @@ List<NipaplaySettingEntry> buildNipaplaySettingEntries(BuildContext context) {
         pageTitle: l10n.remoteAccess,
         page: const RemoteAccessPage(),
       ),
-    ]);
+    );
   }
 
   entries.add(

--- a/lib/themes/nipaplay/widgets/modern_video_controls.dart
+++ b/lib/themes/nipaplay/widgets/modern_video_controls.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show ImageFilter;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:nipaplay/utils/app_accent_color.dart';
@@ -754,14 +756,68 @@ class _DanmakuToggleIcon extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (visible) {
-      return SvgPicture.asset(
-        'assets/danmaku-fill.svg',
-        width: size,
-        height: size,
-      );
+    final offSvgString = visible ? null : _danmakuOffSvgString();
+
+    Widget buildSvg({ColorFilter? colorFilter}) {
+      return visible
+          ? SvgPicture.asset(
+              'assets/danmaku-fill.svg',
+              width: size,
+              height: size,
+              colorFilter: colorFilter,
+            )
+          : SvgPicture.string(
+              offSvgString!,
+              width: size,
+              height: size,
+              colorFilter: colorFilter,
+            );
     }
 
+    return SizedBox(
+      width: size,
+      height: size,
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          _buildSvgShadow(
+            buildSvg,
+            const Offset(0, 1.5),
+            2.5,
+            const Color.fromARGB(64, 0, 0, 0),
+          ),
+          _buildSvgShadow(
+            buildSvg,
+            const Offset(0, 3),
+            5,
+            const Color.fromARGB(48, 0, 0, 0),
+          ),
+          Positioned.fill(child: buildSvg()),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSvgShadow(
+    Widget Function({ColorFilter? colorFilter}) buildSvg,
+    Offset offset,
+    double blurSigma,
+    Color color,
+  ) {
+    return Positioned.fill(
+      child: Transform.translate(
+        offset: offset,
+        child: ImageFiltered(
+          imageFilter: ImageFilter.blur(sigmaX: blurSigma, sigmaY: blurSigma),
+          child: buildSvg(
+            colorFilter: ColorFilter.mode(color, BlendMode.srcIn),
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _danmakuOffSvgString() {
     final accentColor = AppAccentColors.current;
     final r = (accentColor.r * 255.0)
         .round()
@@ -781,15 +837,7 @@ class _DanmakuToggleIcon extends StatelessWidget {
         .toRadixString(16)
         .padLeft(2, '0')
         .toUpperCase();
-    final accentColorStr = '#$r$g$b';
-    final svgString =
-        _danmakuOffFillSvg.replaceAll('{{ACCENT_COLOR}}', accentColorStr);
-
-    return SvgPicture.string(
-      svgString,
-      width: size,
-      height: size,
-    );
+    return _danmakuOffFillSvg.replaceAll('{{ACCENT_COLOR}}', '#$r$g$b');
   }
 
   static const String _danmakuOffFillSvg =

--- a/lib/themes/nipaplay/widgets/playlist_menu.dart
+++ b/lib/themes/nipaplay/widgets/playlist_menu.dart
@@ -22,6 +22,7 @@ import 'package:nipaplay/providers/shared_remote_library_provider.dart';
 import 'package:nipaplay/utils/message_helper.dart';
 import 'package:nipaplay/utils/media_source_utils.dart';
 import 'package:nipaplay/utils/shared_remote_history_helper.dart';
+import 'package:nipaplay/utils/webdav_file_sorter.dart';
 
 class PlaylistMenu extends StatefulWidget {
   final VoidCallback onClose;
@@ -156,9 +157,11 @@ class _PlaylistMenuState extends State<PlaylistMenu> {
                   .any((ext) => file.path.toLowerCase().endsWith(ext)))
               .toList();
 
-          // 按文件名排序
-          videoFiles.sort(
-              (a, b) => a.path.toLowerCase().compareTo(b.path.toLowerCase()));
+          // 按文件名自然排序，避免 1、15、2 这类字典序播放顺序。
+          videoFiles.sort((a, b) => WebDAVFileSorter.naturalCompare(
+                p.basename(a.path),
+                p.basename(b.path),
+              ));
 
           _fileSystemEpisodes = videoFiles.map((file) => file.path).toList();
           _hasFileSystemData = _fileSystemEpisodes.isNotEmpty;
@@ -332,7 +335,7 @@ class _PlaylistMenuState extends State<PlaylistMenu> {
           .toList();
 
       playableEntries
-          .sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+          .sort((a, b) => WebDAVFileSorter.naturalCompare(a.name, b.name));
 
       _fileSystemEpisodes = playableEntries.map((entry) {
         final streamUrl =
@@ -402,7 +405,7 @@ class _PlaylistMenuState extends State<PlaylistMenu> {
           if (aEpisodeId != bEpisodeId) {
             return aEpisodeId.compareTo(bEpisodeId);
           }
-          return a.title.toLowerCase().compareTo(b.title.toLowerCase());
+          return WebDAVFileSorter.naturalCompare(a.title, b.title);
         });
 
       final animeName = (_currentAnimeTitle?.trim().isNotEmpty ?? false)
@@ -458,7 +461,8 @@ class _PlaylistMenuState extends State<PlaylistMenu> {
 
       final connectionUri = Uri.parse(resolved.connection.url);
       final basePath = connectionUri.path.isEmpty ? '/' : connectionUri.path;
-      final normalizedBasePath = basePath.endsWith('/') ? basePath : '$basePath/';
+      final normalizedBasePath =
+          basePath.endsWith('/') ? basePath : '$basePath/';
       final filePath = resolved.relativePath.startsWith('/')
           ? resolved.relativePath
           : '/${resolved.relativePath}';
@@ -490,7 +494,7 @@ class _PlaylistMenuState extends State<PlaylistMenu> {
               !entry.isDirectory &&
               WebDAVService.instance.isVideoFile(entry.name))
           .toList()
-        ..sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+        ..sort((a, b) => WebDAVFileSorter.naturalCompare(a.name, b.name));
 
       _fileSystemEpisodes = videoEntries.map((entry) {
         final fileUrl = WebDAVService.instance.getFileUrl(
@@ -547,7 +551,7 @@ class _PlaylistMenuState extends State<PlaylistMenu> {
           .where((entry) =>
               !entry.isDirectory && SMBService.instance.isVideoFile(entry.name))
           .toList()
-        ..sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+        ..sort((a, b) => WebDAVFileSorter.naturalCompare(a.name, b.name));
 
       _fileSystemEpisodes = videoEntries.map((entry) {
         final url =


### PR DESCRIPTION
## Summary
- expose remote access settings on mobile native platforms, including iOS, and update mobile network permissions/descriptions
- sort playlist and episode navigation entries with natural filename ordering
- add a matching lightweight shadow for the danmaku toggle SVG icon

## Issues
- Fixes #500
- Fixes #489
- Fixes #481

## Validation
- flutter analyze --no-fatal-infos lib/themes/nipaplay/widgets/playlist_menu.dart lib/themes/cupertino/widgets/player_menu/cupertino_playlist_pane.dart lib/services/episode_navigation_service.dart lib/services/auto_next_episode_service.dart lib/themes/nipaplay/widgets/modern_video_controls.dart lib/themes/nipaplay/pages/settings/settings_entries.dart lib/services/web_server_service.dart
- flutter test test/webdav_file_sorter_test.dart
- plutil -lint ios/Runner/Info.plist
- git diff --check