### PR TITLE
Improve torrent downloader workflow

### DIFF
--- a/lib/constants/settings_keys.dart
+++ b/lib/constants/settings_keys.dart
@@ -30,4 +30,10 @@ class SettingsKeys {
 
   static const String downloaderCreateFolderForTask =
       'downloader_create_folder_for_task';
+
+  static const String downloaderAutoScanCompletedTasks =
+      'downloader_auto_scan_completed_tasks';
+
+  static const String downloaderAutoScannedCompletedTaskKeys =
+      'downloader_auto_scanned_completed_task_keys';
 }

--- a/lib/models/torrent_task.dart
+++ b/lib/models/torrent_task.dart
@@ -1,5 +1,64 @@
 import 'dart:convert';
 
+import 'package:path/path.dart' as p;
+
+class TorrentTaskFile {
+  const TorrentTaskFile({
+    required this.index,
+    required this.name,
+    required this.components,
+    required this.length,
+    required this.included,
+  });
+
+  static const Set<String> videoExtensions = {
+    '.mp4',
+    '.m4v',
+    '.mkv',
+    '.mov',
+    '.avi',
+    '.flv',
+    '.ts',
+    '.mpeg',
+    '.mpg',
+    '.webm',
+  };
+
+  final int index;
+  final String name;
+  final List<String> components;
+  final int length;
+  final bool included;
+
+  String get displayName {
+    if (components.isNotEmpty) {
+      return components.join('/');
+    }
+    return name;
+  }
+
+  String get fileName {
+    final display = displayName;
+    return display.isEmpty ? name : p.basename(display);
+  }
+
+  bool get isVideo =>
+      videoExtensions.contains(p.extension(fileName).toLowerCase());
+
+  factory TorrentTaskFile.fromMap(int index, Map<String, dynamic> map) {
+    final rawComponents = map['components'];
+    return TorrentTaskFile(
+      index: index,
+      name: TorrentTask._asString(map['name'], fallback: '未命名文件'),
+      components: rawComponents is List
+          ? rawComponents.map((value) => value.toString()).toList()
+          : const <String>[],
+      length: TorrentTask._asInt(map['length']),
+      included: map['included'] != false,
+    );
+  }
+}
+
 class TorrentTask {
   const TorrentTask({
     required this.id,
@@ -14,6 +73,7 @@ class TorrentTask {
     required this.downloadSpeedBytesPerSecond,
     required this.uploadSpeedBytesPerSecond,
     required this.error,
+    this.files = const <TorrentTaskFile>[],
   });
 
   final int id;
@@ -28,6 +88,7 @@ class TorrentTask {
   final int downloadSpeedBytesPerSecond;
   final int uploadSpeedBytesPerSecond;
   final String? error;
+  final List<TorrentTaskFile> files;
 
   double get progress {
     if (totalBytes <= 0) return 0;
@@ -39,6 +100,8 @@ class TorrentTask {
   bool get isActive => state == 'live' || state == 'initializing';
 
   bool get hasError => state == 'error' || (error?.isNotEmpty ?? false);
+
+  String get autoScanKey => '$infoHash|$outputFolder';
 
   String get displayState {
     if (hasError) return '错误';
@@ -78,6 +141,27 @@ class TorrentTask {
       uploadSpeedBytesPerSecond:
           _speedBytes(live['upload_speed'] as Map<String, dynamic>?),
       error: stats['error']?.toString(),
+      files: _filesFromMap(map),
+    );
+  }
+
+  TorrentTask copyWith({
+    List<TorrentTaskFile>? files,
+  }) {
+    return TorrentTask(
+      id: id,
+      infoHash: infoHash,
+      name: name,
+      outputFolder: outputFolder,
+      state: state,
+      progressBytes: progressBytes,
+      uploadedBytes: uploadedBytes,
+      totalBytes: totalBytes,
+      finished: finished,
+      downloadSpeedBytesPerSecond: downloadSpeedBytesPerSecond,
+      uploadSpeedBytesPerSecond: uploadSpeedBytesPerSecond,
+      error: error,
+      files: files ?? this.files,
     );
   }
 
@@ -90,6 +174,25 @@ class TorrentTask {
         .whereType<Map<String, dynamic>>()
         .map(TorrentTask.fromMap)
         .toList();
+  }
+
+  static TorrentTask? detailsFromJson(String jsonText) {
+    final decoded = jsonDecode(jsonText);
+    if (decoded is! Map<String, dynamic>) return null;
+    return TorrentTask.fromMap(decoded);
+  }
+
+  static List<TorrentTaskFile> _filesFromMap(Map<String, dynamic> map) {
+    final rawFiles = map['files'];
+    if (rawFiles is! List) return const <TorrentTaskFile>[];
+    final files = <TorrentTaskFile>[];
+    for (var index = 0; index < rawFiles.length; index++) {
+      final rawFile = rawFiles[index];
+      if (rawFile is Map<String, dynamic>) {
+        files.add(TorrentTaskFile.fromMap(index, rawFile));
+      }
+    }
+    return files;
   }
 
   static int _speedBytes(Map<String, dynamic>? speed) {

--- a/lib/pages/torrent_download_page.dart
+++ b/lib/pages/torrent_download_page.dart
@@ -264,7 +264,7 @@ class _TorrentDownloadPageState extends State<TorrentDownloadPage>
     if (!mounted) return;
     final settings =
         Provider.of<DownloaderSettingsProvider>(context, listen: false);
-    if (!settings.autoScanCompletedTasks) return;
+    if (!settings.isLoaded || !settings.autoScanCompletedTasks) return;
 
     await _loadAutoScanRegistry();
     if (!mounted) return;

--- a/lib/pages/torrent_download_page.dart
+++ b/lib/pages/torrent_download_page.dart
@@ -4,8 +4,12 @@ import 'package:file_selector/file_selector.dart';
 import 'package:flutter/material.dart';
 import 'package:kmbal_ionicons/kmbal_ionicons.dart';
 import 'package:nipaplay/models/torrent_task.dart';
+import 'package:nipaplay/models/playable_item.dart';
+import 'package:nipaplay/providers/downloader_settings_provider.dart';
+import 'package:nipaplay/providers/service_provider.dart';
 import 'package:nipaplay/services/file_picker_service.dart';
 import 'package:nipaplay/services/folder_opener.dart';
+import 'package:nipaplay/services/playback_service.dart';
 import 'package:nipaplay/services/torrent_download_service.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_dialog.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_snackbar.dart';
@@ -13,6 +17,7 @@ import 'package:nipaplay/themes/nipaplay/widgets/hover_scale_text_button.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/library_management_layout.dart';
 import 'package:nipaplay/utils/app_accent_color.dart';
 import 'package:path/path.dart' as p;
+import 'package:provider/provider.dart';
 
 class TorrentDownloadPage extends StatefulWidget {
   const TorrentDownloadPage({super.key});
@@ -27,9 +32,13 @@ class _TorrentDownloadPageState extends State<TorrentDownloadPage>
   final TextEditingController _magnetController = TextEditingController();
   Timer? _refreshTimer;
   List<TorrentTask> _tasks = const <TorrentTask>[];
+  final Set<String> _autoScannedCompletedTaskKeys = <String>{};
+  final Set<String> _autoScanningTaskKeys = <String>{};
+  Future<void> _autoScanChain = Future<void>.value();
   String _downloadDirectory = '';
   bool _isLoading = true;
   bool _isBusy = false;
+  bool _autoScanRegistryLoaded = false;
 
   @override
   void initState() {
@@ -76,6 +85,7 @@ class _TorrentDownloadPageState extends State<TorrentDownloadPage>
         _tasks = tasks;
         _isLoading = false;
       });
+      unawaited(_handleAutoScanCompletedTasks(tasks, silent: true));
     } catch (e) {
       if (!mounted) return;
       setState(() {
@@ -93,6 +103,7 @@ class _TorrentDownloadPageState extends State<TorrentDownloadPage>
       setState(() {
         _tasks = tasks;
       });
+      unawaited(_handleAutoScanCompletedTasks(tasks, silent: silent));
     } catch (e) {
       if (!mounted || silent) return;
       BlurSnackBar.show(context, '刷新下载列表失败: $e');
@@ -237,6 +248,168 @@ class _TorrentDownloadPageState extends State<TorrentDownloadPage>
     }
   }
 
+  Future<void> _loadAutoScanRegistry() async {
+    if (_autoScanRegistryLoaded) return;
+    final keys = await _service.loadAutoScannedCompletedTaskKeys();
+    _autoScannedCompletedTaskKeys
+      ..clear()
+      ..addAll(keys);
+    _autoScanRegistryLoaded = true;
+  }
+
+  Future<void> _handleAutoScanCompletedTasks(
+    List<TorrentTask> tasks, {
+    required bool silent,
+  }) async {
+    if (!mounted) return;
+    final settings =
+        Provider.of<DownloaderSettingsProvider>(context, listen: false);
+    if (!settings.autoScanCompletedTasks) return;
+
+    await _loadAutoScanRegistry();
+    if (!mounted) return;
+
+    for (final task in tasks) {
+      if (!task.finished || task.outputFolder.trim().isEmpty) continue;
+      final key = task.autoScanKey;
+      if (_autoScannedCompletedTaskKeys.contains(key) ||
+          _autoScanningTaskKeys.contains(key)) {
+        continue;
+      }
+
+      _autoScanningTaskKeys.add(key);
+      _autoScanChain = _autoScanChain.then(
+        (_) => _autoScanCompletedTask(task, key, silent: silent),
+      );
+      unawaited(_autoScanChain);
+    }
+  }
+
+  Future<void> _autoScanCompletedTask(
+    TorrentTask task,
+    String key, {
+    required bool silent,
+  }) async {
+    try {
+      final scanService = ServiceProvider.scanService;
+      await scanService.addScannedFolder(task.outputFolder);
+      while (mounted && scanService.isScanning) {
+        await Future<void>.delayed(const Duration(seconds: 2));
+      }
+      if (!mounted) return;
+
+      await scanService.startDirectoryScan(
+        task.outputFolder,
+        skipPreviouslyMatchedUnwatched: true,
+      );
+      await ServiceProvider.watchHistoryProvider.refresh();
+      await _service.markAutoScannedCompletedTask(key);
+      _autoScannedCompletedTaskKeys.add(key);
+
+      if (!mounted || silent) return;
+      BlurSnackBar.show(context, '已自动扫描并加入媒体库: ${task.name}');
+    } catch (e) {
+      if (!mounted || silent) return;
+      BlurSnackBar.show(context, '自动扫描下载任务失败: $e');
+    } finally {
+      _autoScanningTaskKeys.remove(key);
+    }
+  }
+
+  Future<void> _playTask(TorrentTask task) async {
+    if (_isBusy) return;
+    setState(() {
+      _isBusy = true;
+    });
+
+    try {
+      final files = await _service.listPlayableFiles(task);
+      if (!mounted) return;
+      if (files.isEmpty) {
+        BlurSnackBar.show(context, '尚未获取到可播放的视频文件，请稍后再试');
+        return;
+      }
+
+      final selected = files.length == 1
+          ? files.first
+          : await _showPlayableFilesDialog(files);
+      if (selected == null || !mounted) return;
+
+      final source = await _service.getPlaybackSource(task, selected);
+      if (!mounted) return;
+      await PlaybackService().play(
+        PlayableItem(
+          videoPath: source.videoPath,
+          title: source.historyItem?.animeName ?? selected.fileName,
+          subtitle: source.historyItem?.episodeTitle ?? task.name,
+          historyItem: source.historyItem,
+          actualPlayUrl: source.actualPlayUrl,
+        ),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      BlurSnackBar.show(context, '播放下载任务失败: $e');
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isBusy = false;
+        });
+      }
+    }
+  }
+
+  Future<TorrentTaskFile?> _showPlayableFilesDialog(
+    List<TorrentTaskFile> files,
+  ) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return BlurDialog.show<TorrentTaskFile>(
+      context: context,
+      title: '选择要播放的文件',
+      contentWidget: ConstrainedBox(
+        constraints: const BoxConstraints(maxHeight: 360),
+        child: ListView.separated(
+          shrinkWrap: true,
+          itemCount: files.length,
+          separatorBuilder: (_, __) => Divider(
+            color: colorScheme.onSurface.withOpacity(0.08),
+            height: 1,
+          ),
+          itemBuilder: (dialogContext, index) {
+            final file = files[index];
+            return ListTile(
+              dense: true,
+              contentPadding: EdgeInsets.zero,
+              leading: Icon(
+                Ionicons.play_circle_outline,
+                color: AppAccentColors.current,
+              ),
+              title: Text(
+                file.displayName,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(color: colorScheme.onSurface),
+              ),
+              subtitle: Text(
+                _TorrentTaskCard.formatBytes(file.length),
+                style: TextStyle(color: colorScheme.onSurface.withOpacity(0.6)),
+              ),
+              onTap: () => Navigator.of(dialogContext).pop(file),
+            );
+          },
+        ),
+      ),
+      actions: [
+        HoverScaleTextButton(
+          child: Text(
+            '取消',
+            style: TextStyle(color: colorScheme.onSurface.withOpacity(0.7)),
+          ),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+      ],
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
@@ -321,6 +494,7 @@ class _TorrentDownloadPageState extends State<TorrentDownloadPage>
       padding: const EdgeInsets.all(16),
       itemBuilder: (context, task) => _TorrentTaskCard(
         task: task,
+        onPlay: () => _playTask(task),
         onToggle: () => _toggleTask(task),
         onOpenFolder: () => _openTaskFolder(task),
         onForget: () => _forgetTask(task),
@@ -562,6 +736,7 @@ class _MagnetInputState extends State<_MagnetInput> {
 class _TorrentTaskCard extends StatelessWidget {
   const _TorrentTaskCard({
     required this.task,
+    required this.onPlay,
     required this.onToggle,
     required this.onOpenFolder,
     required this.onForget,
@@ -569,6 +744,7 @@ class _TorrentTaskCard extends StatelessWidget {
   });
 
   final TorrentTask task;
+  final VoidCallback onPlay;
   final VoidCallback onToggle;
   final VoidCallback onOpenFolder;
   final VoidCallback onForget;
@@ -646,15 +822,15 @@ class _TorrentTaskCard extends StatelessWidget {
                 _MetricText(
                   label: '已下载',
                   value:
-                      '${_formatBytes(task.progressBytes)} / ${_formatBytes(task.totalBytes)}',
+                      '${formatBytes(task.progressBytes)} / ${formatBytes(task.totalBytes)}',
                 ),
                 _MetricText(
                   label: '下载',
-                  value: '${_formatBytes(task.downloadSpeedBytesPerSecond)}/s',
+                  value: '${formatBytes(task.downloadSpeedBytesPerSecond)}/s',
                 ),
                 _MetricText(
                   label: '上传',
-                  value: '${_formatBytes(task.uploadSpeedBytesPerSecond)}/s',
+                  value: '${formatBytes(task.uploadSpeedBytesPerSecond)}/s',
                 ),
               ],
             ),
@@ -668,8 +844,16 @@ class _TorrentTaskCard extends StatelessWidget {
               ),
             ],
             const SizedBox(height: 12),
-            Row(
+            Wrap(
+              spacing: 8,
+              runSpacing: 4,
               children: [
+                if (task.finished)
+                  _TorrentHoverAction(
+                    icon: Ionicons.play_circle_outline,
+                    label: '播放',
+                    onPressed: onPlay,
+                  ),
                 if (!task.finished) ...[
                   _TorrentHoverAction(
                     icon: task.isPaused
@@ -678,20 +862,17 @@ class _TorrentTaskCard extends StatelessWidget {
                     label: task.isPaused ? '继续' : '暂停',
                     onPressed: onToggle,
                   ),
-                  const SizedBox(width: 8),
                 ],
                 _TorrentHoverAction(
                   icon: Ionicons.folder_open_outline,
                   label: '打开文件夹',
                   onPressed: onOpenFolder,
                 ),
-                const SizedBox(width: 8),
                 _TorrentHoverAction(
                   icon: Ionicons.remove_circle_outline,
                   label: '移除',
                   onPressed: onForget,
                 ),
-                const SizedBox(width: 8),
                 _TorrentHoverAction(
                   icon: Ionicons.trash_outline,
                   label: '删文件',
@@ -709,7 +890,7 @@ class _TorrentTaskCard extends StatelessWidget {
     return '${(value * 100).clamp(0, 100).toStringAsFixed(1)}%';
   }
 
-  static String _formatBytes(int bytes) {
+  static String formatBytes(int bytes) {
     if (bytes <= 0) return '0 B';
     const units = ['B', 'KB', 'MB', 'GB', 'TB'];
     var value = bytes.toDouble();

--- a/lib/providers/downloader_settings_provider.dart
+++ b/lib/providers/downloader_settings_provider.dart
@@ -9,10 +9,12 @@ class DownloaderSettingsProvider extends ChangeNotifier {
 
   bool _enabled = true;
   bool _createFolderForTask = true;
+  bool _autoScanCompletedTasks = true;
   bool _isLoaded = false;
 
   bool get enabled => _enabled;
   bool get createFolderForTask => _createFolderForTask;
+  bool get autoScanCompletedTasks => _autoScanCompletedTasks;
   bool get isLoaded => _isLoaded;
 
   Future<void> _loadSettings() async {
@@ -22,6 +24,10 @@ class DownloaderSettingsProvider extends ChangeNotifier {
     );
     _createFolderForTask = await SettingsStorage.loadBool(
       SettingsKeys.downloaderCreateFolderForTask,
+      defaultValue: true,
+    );
+    _autoScanCompletedTasks = await SettingsStorage.loadBool(
+      SettingsKeys.downloaderAutoScanCompletedTasks,
       defaultValue: true,
     );
     _isLoaded = true;
@@ -41,6 +47,16 @@ class DownloaderSettingsProvider extends ChangeNotifier {
     notifyListeners();
     await SettingsStorage.saveBool(
       SettingsKeys.downloaderCreateFolderForTask,
+      enabled,
+    );
+  }
+
+  Future<void> setAutoScanCompletedTasks(bool enabled) async {
+    if (_autoScanCompletedTasks == enabled) return;
+    _autoScanCompletedTasks = enabled;
+    notifyListeners();
+    await SettingsStorage.saveBool(
+      SettingsKeys.downloaderAutoScanCompletedTasks,
       enabled,
     );
   }

--- a/lib/services/torrent_download_service.dart
+++ b/lib/services/torrent_download_service.dart
@@ -1,9 +1,15 @@
+import 'dart:io' as io;
+
+import 'package:flutter/foundation.dart';
 import 'package:nipaplay/constants/settings_keys.dart';
 import 'package:nipaplay/models/torrent_task.dart';
+import 'package:nipaplay/models/watch_history_model.dart';
+import 'package:nipaplay/services/security_bookmark_service.dart';
 import 'package:nipaplay/src/rust/api/torrent.dart' as rust_torrent;
 import 'package:nipaplay/src/rust/rust_init.dart';
 import 'package:nipaplay/utils/settings_storage.dart';
 import 'package:nipaplay/utils/storage_service.dart';
+import 'package:path/path.dart' as p;
 
 class TorrentDownloadService {
   TorrentDownloadService._();
@@ -18,7 +24,7 @@ class TorrentDownloadService {
       SettingsKeys.torrentDownloadDirectory,
     );
     if (saved.trim().isNotEmpty) {
-      return saved.trim();
+      return _resolveDownloadDirectoryAccess(saved.trim());
     }
     final defaultDir = await StorageService.getDownloadsDirectory();
     await SettingsStorage.saveString(
@@ -31,11 +37,12 @@ class TorrentDownloadService {
   Future<void> setDownloadDirectory(String directory) async {
     final trimmed = directory.trim();
     if (trimmed.isEmpty) return;
+    final resolved = await _resolveDownloadDirectoryAccess(trimmed);
     await SettingsStorage.saveString(
       SettingsKeys.torrentDownloadDirectory,
-      trimmed,
+      resolved,
     );
-    _sessionDownloadDir = trimmed;
+    _sessionDownloadDir = resolved;
   }
 
   Future<void> initialize() async {
@@ -49,26 +56,97 @@ class TorrentDownloadService {
     return TorrentTask.listFromJson(jsonText);
   }
 
+  Future<TorrentTask> getTaskDetails(TorrentTask task) async {
+    await ensureRustInitialized();
+    final jsonText = await rust_torrent.torrentDetails(id: task.id);
+    final details = TorrentTask.detailsFromJson(jsonText);
+    if (details == null) return task;
+    return task.copyWith(files: details.files);
+  }
+
+  Future<List<TorrentTaskFile>> listPlayableFiles(TorrentTask task) async {
+    final details = task.files.isNotEmpty ? task : await getTaskDetails(task);
+    return details.files
+        .where((file) => file.included && file.isVideo)
+        .toList(growable: false);
+  }
+
+  Future<String> getStreamUrl(TorrentTask task, TorrentTaskFile file) async {
+    await ensureRustInitialized();
+    return rust_torrent.torrentStreamUrl(
+      id: task.id,
+      fileId: file.index,
+      filename: file.fileName,
+    );
+  }
+
+  Future<TorrentPlaybackSource> getPlaybackSource(
+    TorrentTask task,
+    TorrentTaskFile file,
+  ) async {
+    if (task.finished) {
+      final localPath = await _findCompletedFilePath(task, file);
+      if (localPath == null) {
+        throw Exception('找不到已完成的视频文件: ${file.displayName}');
+      }
+      final historyItem = await _resolveCompletedFileHistory(localPath);
+      _log('play completed file from disk: "$localPath"');
+      return TorrentPlaybackSource(
+        videoPath: localPath,
+        historyItem: historyItem,
+      );
+    }
+
+    final streamUrl = await getStreamUrl(task, file);
+    _log('play unfinished file from stream: "$streamUrl"');
+    return TorrentPlaybackSource(
+      videoPath: streamUrl,
+      actualPlayUrl: streamUrl,
+    );
+  }
+
   Future<void> addMagnet(String magnetUri) async {
     final downloadDir = await getDownloadDirectory();
     final createFolder = await _createFolderForTask();
-    await _initSession(downloadDir);
-    await rust_torrent.torrentAddMagnet(
-      magnetUri: magnetUri,
-      downloadDir: downloadDir,
-      createFolderForTask: createFolder,
+    _log(
+      'addMagnet start: ${_summarizeMagnetForLog(magnetUri)}, '
+      'downloadDir="$downloadDir", createFolderForTask=$createFolder',
     );
+    try {
+      await _initSession(downloadDir);
+      await rust_torrent.torrentAddMagnet(
+        magnetUri: magnetUri,
+        downloadDir: downloadDir,
+        createFolderForTask: createFolder,
+      );
+      _log('addMagnet success: ${_summarizeMagnetForLog(magnetUri)}');
+    } catch (error, stackTrace) {
+      _log('addMagnet failed: $error');
+      _log('addMagnet stackTrace: $stackTrace');
+      rethrow;
+    }
   }
 
   Future<void> addTorrentFile(String torrentFilePath) async {
     final downloadDir = await getDownloadDirectory();
     final createFolder = await _createFolderForTask();
-    await _initSession(downloadDir);
-    await rust_torrent.torrentAddFile(
-      torrentFilePath: torrentFilePath,
-      downloadDir: downloadDir,
-      createFolderForTask: createFolder,
+    _log(
+      'addTorrentFile start: path="$torrentFilePath", '
+      'downloadDir="$downloadDir", createFolderForTask=$createFolder',
     );
+    try {
+      await _initSession(downloadDir);
+      await rust_torrent.torrentAddFile(
+        torrentFilePath: torrentFilePath,
+        downloadDir: downloadDir,
+        createFolderForTask: createFolder,
+      );
+      _log('addTorrentFile success: path="$torrentFilePath"');
+    } catch (error, stackTrace) {
+      _log('addTorrentFile failed: $error');
+      _log('addTorrentFile stackTrace: $stackTrace');
+      rethrow;
+    }
   }
 
   Future<void> pause(int id) async {
@@ -92,11 +170,19 @@ class TorrentDownloadService {
   }
 
   Future<void> _initSession(String downloadDir) async {
-    if (_sessionInitialized && _sessionDownloadDir == downloadDir) return;
+    if (_sessionInitialized && _sessionDownloadDir == downloadDir) {
+      _log('initSession skipped: already initialized for "$downloadDir"');
+      return;
+    }
+    _log(
+      'initSession start: downloadDir="$downloadDir", '
+      'previousDir="$_sessionDownloadDir", initialized=$_sessionInitialized',
+    );
     await ensureRustInitialized();
     await rust_torrent.torrentInitSession(downloadDir: downloadDir);
     _sessionInitialized = true;
     _sessionDownloadDir = downloadDir;
+    _log('initSession success: downloadDir="$downloadDir"');
   }
 
   Future<bool> _createFolderForTask() {
@@ -105,4 +191,190 @@ class TorrentDownloadService {
       defaultValue: true,
     );
   }
+
+  Future<String?> _findCompletedFilePath(
+    TorrentTask task,
+    TorrentTaskFile file,
+  ) async {
+    final outputFolder = task.outputFolder.trim();
+    if (outputFolder.isEmpty) return null;
+
+    final resolvedOutputFolder =
+        await _resolveDownloadDirectoryAccess(outputFolder);
+    final candidates = <String>{
+      p.normalize(p.join(resolvedOutputFolder, file.displayName)),
+      p.normalize(p.join(resolvedOutputFolder, file.fileName)),
+      p.normalize(p.join(resolvedOutputFolder, task.name)),
+    };
+
+    for (final candidate in candidates) {
+      if (await io.File(candidate).exists()) {
+        return candidate;
+      }
+    }
+
+    final found = await _findFileByNameAndSize(
+      resolvedOutputFolder,
+      file.fileName,
+      file.length,
+    );
+    if (found != null) return found;
+
+    _log(
+      'completed file not found: task="${task.name}", file="${file.displayName}", '
+      'outputFolder="$resolvedOutputFolder", candidates=$candidates',
+    );
+    return null;
+  }
+
+  Future<WatchHistoryItem> _resolveCompletedFileHistory(String filePath) async {
+    final existing = await WatchHistoryManager.getHistoryItem(filePath);
+    if (existing != null) {
+      _log(
+        'play completed file with existing history: '
+        '"${existing.animeName}" / "${existing.episodeTitle ?? ''}"',
+      );
+      return existing;
+    }
+
+    final fallback = WatchHistoryItem(
+      filePath: filePath,
+      animeName: p.basenameWithoutExtension(filePath),
+      episodeTitle: null,
+      watchProgress: 0,
+      lastPosition: 0,
+      duration: 0,
+      lastWatchTime: DateTime.now(),
+      isFromScan: false,
+    );
+    await WatchHistoryManager.addOrUpdateHistory(fallback);
+    _log(
+      'created fallback history before scraping completed file: "$filePath"',
+    );
+    return fallback;
+  }
+
+  Future<String?> _findFileByNameAndSize(
+    String folder,
+    String fileName,
+    int expectedLength,
+  ) async {
+    final directory = io.Directory(folder);
+    if (!await directory.exists()) return null;
+
+    await for (final entity in directory.list(
+      recursive: true,
+      followLinks: false,
+    )) {
+      if (entity is! io.File || p.basename(entity.path) != fileName) {
+        continue;
+      }
+      if (expectedLength <= 0 || await entity.length() == expectedLength) {
+        return entity.path;
+      }
+    }
+
+    return null;
+  }
+
+  Future<String> _resolveDownloadDirectoryAccess(String directory) async {
+    if (!io.Platform.isMacOS) return directory;
+
+    try {
+      final resolved = await SecurityBookmarkService.resolveBookmark(directory);
+      if (resolved != null && resolved.trim().isNotEmpty) {
+        if (resolved != directory) {
+          _log(
+            'download directory bookmark resolved: "$directory" -> "$resolved"',
+          );
+        } else {
+          _log('download directory bookmark restored: "$directory"');
+        }
+        return resolved;
+      }
+
+      _log(
+          'download directory has no bookmark, using path directly: "$directory"');
+    } catch (error) {
+      _log('download directory bookmark restore failed: "$directory", $error');
+    }
+
+    return directory;
+  }
+
+  Future<Set<String>> loadAutoScannedCompletedTaskKeys() async {
+    final keys = await SettingsStorage.loadStringList(
+      SettingsKeys.downloaderAutoScannedCompletedTaskKeys,
+    );
+    return keys.toSet();
+  }
+
+  Future<void> markAutoScannedCompletedTask(String key) async {
+    final trimmed = key.trim();
+    if (trimmed.isEmpty) return;
+    final keys = await loadAutoScannedCompletedTaskKeys();
+    keys.add(trimmed);
+    await SettingsStorage.saveStringList(
+      SettingsKeys.downloaderAutoScannedCompletedTaskKeys,
+      keys.toList(growable: false),
+    );
+  }
+
+  void _log(String message) {
+    debugPrint('[TorrentDownloadService] $message');
+  }
+
+  String _summarizeMagnetForLog(String magnetUri) {
+    final trimmed = magnetUri.trim();
+    final hasOuterWhitespace = trimmed.length != magnetUri.length;
+    final hasInnerWhitespace = trimmed.runes.any((rune) {
+      return String.fromCharCode(rune).trim().isEmpty;
+    });
+    final buffer = StringBuffer()
+      ..write('length=${trimmed.length}')
+      ..write(', startsWithMagnet=${trimmed.startsWith('magnet:')}')
+      ..write(
+        ', startsWithMagnetCi=${trimmed.toLowerCase().startsWith('magnet:')}',
+      )
+      ..write(', hasOuterWhitespace=$hasOuterWhitespace')
+      ..write(', hasInnerWhitespace=$hasInnerWhitespace');
+
+    try {
+      final uri = Uri.tryParse(trimmed);
+      if (uri == null) {
+        buffer.write(', uriParse=null');
+        return buffer.toString();
+      }
+
+      final xtValues = uri.queryParametersAll['xt'] ?? const <String>[];
+      final dn = uri.queryParameters['dn'];
+      final trackerCount = uri.queryParametersAll['tr']?.length ?? 0;
+      buffer
+        ..write(', scheme=${uri.scheme.isEmpty ? '<empty>' : uri.scheme}')
+        ..write(', xt=${xtValues.map(_truncateForLog).join('|')}')
+        ..write(', dn=${dn == null ? '<none>' : _truncateForLog(dn)}')
+        ..write(', trackerCount=$trackerCount');
+    } catch (error) {
+      buffer.write(', uriParseError=$error');
+    }
+
+    return buffer.toString();
+  }
+
+  String _truncateForLog(String value, {int maxLength = 96}) {
+    if (value.length <= maxLength) return value;
+    return '${value.substring(0, maxLength)}...';
+  }
+}
+
+class TorrentPlaybackSource {
+  const TorrentPlaybackSource({
+    required this.videoPath,
+    this.actualPlayUrl,
+    this.historyItem,
+  });
+
+  final String videoPath;
+  final String? actualPlayUrl;
+  final WatchHistoryItem? historyItem;
 }

--- a/lib/src/rust/api/torrent.dart
+++ b/lib/src/rust/api/torrent.dart
@@ -6,8 +6,9 @@
 import '../frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These functions are ignored because they are not marked as `pub`: `add_torrent_options`, `current_api`, `default_session_dir`, `file_stem_folder_name`, `magnet_folder_name`, `normalize_download_dir`, `normalize_torrent_id`, `response_to_json`, `sanitize_folder_name`, `torrent_runtime`
-// These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `TorrentRuntime`
+// These functions are ignored because they are not marked as `pub`: `add_torrent_options`, `current_api`, `default_session_dir`, `ensure_stream_server`, `file_stem_folder_name`, `file_stem_or_name`, `handle_stream_request`, `magnet_folder_name`, `normalize_download_dir`, `normalize_torrent_id`, `parse_http_request`, `parse_range`, `parse_stream_path`, `read_http_request`, `response_to_json`, `sanitize_folder_name`, `torrent_runtime`, `url_path_segment_encode`, `write_simple_response`
+// These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `HttpRange`, `TorrentRuntime`, `TorrentStreamServer`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`
 
 Future<void> torrentInitSession({required String downloadDir}) =>
     RustLib.instance.api
@@ -33,6 +34,14 @@ Future<String> torrentAddFile(
 
 Future<String> torrentList({required String downloadDir}) =>
     RustLib.instance.api.crateApiTorrentTorrentList(downloadDir: downloadDir);
+
+Future<String> torrentDetails({required int id}) =>
+    RustLib.instance.api.crateApiTorrentTorrentDetails(id: id);
+
+Future<String> torrentStreamUrl(
+        {required int id, required int fileId, required String filename}) =>
+    RustLib.instance.api.crateApiTorrentTorrentStreamUrl(
+        id: id, fileId: fileId, filename: filename);
 
 Future<void> torrentPause({required int id}) =>
     RustLib.instance.api.crateApiTorrentTorrentPause(id: id);

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -72,7 +72,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => 629279474;
+  int get rustContentHash => -1076023073;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -116,6 +116,8 @@ abstract class RustLibApi extends BaseApi {
 
   Future<void> crateApiTorrentTorrentDelete({required int id});
 
+  Future<String> crateApiTorrentTorrentDetails({required int id});
+
   Future<void> crateApiTorrentTorrentForget({required int id});
 
   Future<void> crateApiTorrentTorrentInitSession({required String downloadDir});
@@ -125,6 +127,9 @@ abstract class RustLibApi extends BaseApi {
   Future<void> crateApiTorrentTorrentPause({required int id});
 
   Future<void> crateApiTorrentTorrentResume({required int id});
+
+  Future<String> crateApiTorrentTorrentStreamUrl(
+      {required int id, required int fileId, required String filename});
 }
 
 class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
@@ -440,13 +445,38 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<void> crateApiTorrentTorrentForget({required int id}) {
+  Future<String> crateApiTorrentTorrentDetails({required int id}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_i_32(id, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
             funcId: 13, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_String,
+        decodeErrorData: sse_decode_String,
+      ),
+      constMeta: kCrateApiTorrentTorrentDetailsConstMeta,
+      argValues: [id],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiTorrentTorrentDetailsConstMeta =>
+      const TaskConstMeta(
+        debugName: "torrent_details",
+        argNames: ["id"],
+      );
+
+  @override
+  Future<void> crateApiTorrentTorrentForget({required int id}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_i_32(id, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 14, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -472,7 +502,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(downloadDir, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 14, port: port_);
+            funcId: 15, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -497,7 +527,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(downloadDir, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 15, port: port_);
+            funcId: 16, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -521,7 +551,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_i_32(id, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 16, port: port_);
+            funcId: 17, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -546,7 +576,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_i_32(id, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 17, port: port_);
+            funcId: 18, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -562,6 +592,34 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(
         debugName: "torrent_resume",
         argNames: ["id"],
+      );
+
+  @override
+  Future<String> crateApiTorrentTorrentStreamUrl(
+      {required int id, required int fileId, required String filename}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_i_32(id, serializer);
+        sse_encode_i_32(fileId, serializer);
+        sse_encode_String(filename, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 19, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_String,
+        decodeErrorData: sse_decode_String,
+      ),
+      constMeta: kCrateApiTorrentTorrentStreamUrlConstMeta,
+      argValues: [id, fileId, filename],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiTorrentTorrentStreamUrlConstMeta =>
+      const TaskConstMeta(
+        debugName: "torrent_stream_url",
+        argNames: ["id", "fileId", "filename"],
       );
 
   @protected

--- a/lib/themes/nipaplay/pages/settings/downloader_settings_page.dart
+++ b/lib/themes/nipaplay/pages/settings/downloader_settings_page.dart
@@ -38,6 +38,17 @@ class DownloaderSettingsPage extends StatelessWidget {
                     value: provider.createFolderForTask,
                     onChanged: provider.setCreateFolderForTask,
                   ),
+                  Divider(
+                    color: colorScheme.onSurface.withOpacity(0.12),
+                    height: 1,
+                  ),
+                  SettingsItem.toggle(
+                    title: '完成后自动加入媒体库',
+                    subtitle: '任务下载完成后自动把输出文件夹加入库管理并扫描',
+                    icon: Ionicons.library_outline,
+                    value: provider.autoScanCompletedTasks,
+                    onChanged: provider.setAutoScanCompletedTasks,
+                  ),
                 ],
               ),
             ),

--- a/lib/utils/settings_storage.dart
+++ b/lib/utils/settings_storage.dart
@@ -16,9 +16,21 @@ class SettingsStorage {
     await prefs.setString(key, value);
   }
 
-  static Future<String> loadString(String key, {String defaultValue = ""}) async {
+  static Future<String> loadString(String key,
+      {String defaultValue = ""}) async {
     final prefs = await SharedPreferences.getInstance();
     return prefs.getString(key) ?? defaultValue;
+  }
+
+  static Future<void> saveStringList(String key, List<String> value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(key, value);
+  }
+
+  static Future<List<String>> loadStringList(String key,
+      {List<String> defaultValue = const []}) async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getStringList(key) ?? defaultValue;
   }
 
   static Future<void> saveInt(String key, int value) async {
@@ -36,7 +48,8 @@ class SettingsStorage {
     await prefs.setDouble(key, value);
   }
 
-  static Future<double> loadDouble(String key, {double defaultValue = 0.0}) async {
+  static Future<double> loadDouble(String key,
+      {double defaultValue = 0.0}) async {
     final prefs = await SharedPreferences.getInstance();
     return prefs.getDouble(key) ?? defaultValue;
   }

--- a/lib/utils/video_player_state/video_player_state_metadata.dart
+++ b/lib/utils/video_player_state/video_player_state_metadata.dart
@@ -378,8 +378,17 @@ extension VideoPlayerStateMetadata on VideoPlayerState {
       }
 
       if (existingHistory == null) {
-        //debugPrint('未找到现有观看记录，跳过更新');
-        return;
+        debugPrint('[VideoPlayerState] 未找到现有观看记录，将创建基础记录后写入识别结果');
+        existingHistory = WatchHistoryItem(
+          filePath: path,
+          animeName: p.basenameWithoutExtension(path),
+          episodeTitle: null,
+          watchProgress: 0,
+          lastPosition: 0,
+          duration: _duration.inMilliseconds,
+          lastWatchTime: DateTime.now(),
+          isFromScan: false,
+        );
       }
 
       // 获取识别到的动画信息

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -10,6 +10,8 @@
 	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
+	<key>com.apple.security.files.downloads.read-write</key>
+	<true/>
 	<key>com.apple.security.files.bookmarks.app-scope</key>
 	<true/>
 	<key>com.apple.security.network.client</key>

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -48,7 +48,7 @@ class SecurityBookmarkPlugin: NSObject, FlutterPlugin {
         
         do {
             let bookmarkData = try url.bookmarkData(
-                options: [.withSecurityScope, .securityScopeAllowOnlyReadAccess],
+                options: [.withSecurityScope],
                 includingResourceValuesForKeys: nil,
                 relativeTo: nil
             )

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -10,6 +10,8 @@
 	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
+	<key>com.apple.security.files.downloads.read-write</key>
+	<true/>
 	<key>com.apple.security.files.bookmarks.app-scope</key>
 	<true/>
 	<key>com.apple.security.network.client</key>

--- a/rust/src/api/torrent.rs
+++ b/rust/src/api/torrent.rs
@@ -1,15 +1,33 @@
+use std::io::{Read, SeekFrom, Write};
+use std::net::{TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
+use std::thread;
 
+use librqbit::ByteBufT;
 use librqbit::{
-    AddTorrent, AddTorrentOptions, Api, Magnet, Session, SessionOptions, SessionPersistenceConfig,
+    AddTorrent, AddTorrentOptions, AddTorrentResponse, Api, ListOnlyResponse, Magnet, Session,
+    SessionOptions, SessionPersistenceConfig,
 };
+use tokio::io::{AsyncReadExt, AsyncSeekExt};
 use tokio::runtime::{Builder, Runtime};
 
 struct TorrentRuntime {
     runtime: Runtime,
     api: Mutex<Option<Api>>,
+    session: Mutex<Option<Arc<Session>>>,
     download_dir: Mutex<Option<String>>,
+    stream_server: Mutex<Option<TorrentStreamServer>>,
+}
+
+struct TorrentStreamServer {
+    port: u16,
+}
+
+#[derive(Clone, Copy)]
+struct HttpRange {
+    start: u64,
+    end: Option<u64>,
 }
 
 fn torrent_runtime() -> &'static TorrentRuntime {
@@ -22,13 +40,18 @@ fn torrent_runtime() -> &'static TorrentRuntime {
             .build()
             .expect("failed to create torrent runtime"),
         api: Mutex::new(None),
+        session: Mutex::new(None),
         download_dir: Mutex::new(None),
+        stream_server: Mutex::new(None),
     })
 }
 
 pub fn torrent_init_session(download_dir: String) -> Result<(), String> {
     let normalized_dir = normalize_download_dir(download_dir)?;
     let state = torrent_runtime();
+    torrent_log(format_args!(
+        "init_session start: download_dir={normalized_dir:?}"
+    ));
     std::fs::create_dir_all(&normalized_dir)
         .map_err(|error| format!("failed to create download directory: {error}"))?;
 
@@ -42,6 +65,9 @@ pub fn torrent_init_session(download_dir: String) -> Result<(), String> {
             .lock()
             .map_err(|_| "torrent API lock poisoned".to_string())?;
         if api_slot.is_some() {
+            torrent_log(format_args!(
+                "init_session reuse existing session: download_dir={normalized_dir:?}"
+            ));
             let mut current_dir = state
                 .download_dir
                 .lock()
@@ -53,6 +79,9 @@ pub fn torrent_init_session(download_dir: String) -> Result<(), String> {
 
     // Session does not exist or download directory changed – (re)create it.
     let session_dir = default_session_dir(&normalized_dir);
+    torrent_log(format_args!(
+        "init_session create session: download_dir={normalized_dir:?}, session_dir={session_dir:?}"
+    ));
     let session = state.runtime.block_on(async {
         Session::new_with_opts(
             PathBuf::from(&normalized_dir),
@@ -74,12 +103,19 @@ pub fn torrent_init_session(download_dir: String) -> Result<(), String> {
         .map_err(|_| "torrent API lock poisoned".to_string())?;
     *api_slot = Some(Api::new(Arc::clone(&session), None));
 
+    let mut session_slot = state
+        .session
+        .lock()
+        .map_err(|_| "torrent session lock poisoned".to_string())?;
+    *session_slot = Some(Arc::clone(&session));
+
     let mut current_dir = state
         .download_dir
         .lock()
         .map_err(|_| "torrent download directory lock poisoned".to_string())?;
     *current_dir = Some(normalized_dir);
 
+    torrent_log(format_args!("init_session success"));
     Ok(())
 }
 
@@ -88,26 +124,124 @@ pub fn torrent_add_magnet(
     download_dir: String,
     create_folder_for_task: bool,
 ) -> Result<String, String> {
+    let raw_len = magnet_uri.len();
     let magnet_uri = magnet_uri.trim().to_string();
+    let had_outer_whitespace = raw_len != magnet_uri.len();
+    torrent_log(format_args!(
+        "add_magnet start: {}, had_outer_whitespace={had_outer_whitespace}, download_dir={download_dir:?}, create_folder_for_task={create_folder_for_task}",
+        magnet_log_summary(&magnet_uri)
+    ));
     if magnet_uri.is_empty() {
+        torrent_log(format_args!("add_magnet rejected: magnet URI is empty"));
         return Err("magnet URI is empty".to_string());
     }
+
+    let parsed_magnet = match Magnet::parse(&magnet_uri) {
+        Ok(magnet) => {
+            torrent_log(format_args!(
+                "add_magnet parsed: {}",
+                parsed_magnet_log_summary(&magnet)
+            ));
+            magnet
+        }
+        Err(error) => {
+            let detail = format!("{error:#}");
+            torrent_log(format_args!(
+                "add_magnet parse failed: {}, error={}",
+                magnet_log_summary(&magnet_uri),
+                truncate_for_log(&detail, 240)
+            ));
+            return Err(format!("invalid magnet URI: {detail}"));
+        }
+    };
+
     let normalized_dir = normalize_download_dir(download_dir)?;
     torrent_init_session(normalized_dir.clone())?;
     let state = torrent_runtime();
     let api = current_api(state)?;
-    let folder_name = create_folder_for_task
-        .then(|| magnet_folder_name(&magnet_uri))
-        .flatten();
+    let magnet_trackers = parsed_magnet.trackers.clone();
+
+    if create_folder_for_task {
+        torrent_log(format_args!(
+            "add_magnet resolving metadata for task folder: {}",
+            magnet_log_summary(&magnet_uri)
+        ));
+        let metadata = resolve_magnet_metadata_for_add(state, &magnet_uri)?;
+        let fallback_folder_name = parsed_magnet
+            .name
+            .as_deref()
+            .and_then(sanitize_folder_name)
+            .or_else(|| parsed_magnet.as_id20().map(|id| id.as_string()));
+        let folder_name = torrent_metadata_folder_name(&metadata).or(fallback_folder_name);
+        let mut options = add_torrent_options(normalized_dir, folder_name.clone());
+        if !metadata.seen_peers.is_empty() {
+            options.initial_peers = Some(metadata.seen_peers.clone());
+        }
+        if !magnet_trackers.is_empty() {
+            options.trackers = Some(magnet_trackers);
+        }
+        let output_folder = options.output_folder.clone();
+        torrent_log(format_args!(
+            "add_magnet rqbit_add start: folder_name={folder_name:?}, output_folder={output_folder:?}, source=resolved_metadata"
+        ));
+
+        return state.runtime.block_on(async {
+            match api
+                .api_add_torrent(
+                    AddTorrent::from_bytes(metadata.torrent_bytes),
+                    Some(options),
+                )
+                .await
+            {
+                Ok(response) => {
+                    torrent_log(format_args!(
+                        "add_magnet rqbit_add success: {}",
+                        magnet_log_summary(&magnet_uri)
+                    ));
+                    response_to_json(&response)
+                }
+                Err(error) => {
+                    let detail = format_error_chain(&error);
+                    torrent_log(format_args!(
+                        "add_magnet rqbit_add failed: {}, output_folder={output_folder:?}, error={}",
+                        magnet_log_summary(&magnet_uri),
+                        truncate_for_log(&detail, 480)
+                    ));
+                    Err(format!("failed to add magnet: {detail}"))
+                }
+            }
+        });
+    }
+
+    let folder_name = None;
+    let options = add_torrent_options(normalized_dir, folder_name.clone());
+    let output_folder = options.output_folder.clone();
+    torrent_log(format_args!(
+        "add_magnet rqbit_add start: folder_name={folder_name:?}, output_folder={output_folder:?}"
+    ));
 
     state.runtime.block_on(async {
-        api.api_add_torrent(
-            AddTorrent::from_url(magnet_uri),
-            Some(add_torrent_options(normalized_dir, folder_name)),
-        )
-        .await
-        .map_err(|error| format!("failed to add magnet: {error:#}"))
-        .and_then(|response| response_to_json(&response))
+        match api
+            .api_add_torrent(AddTorrent::from_url(magnet_uri.clone()), Some(options))
+            .await
+        {
+            Ok(response) => {
+                torrent_log(format_args!(
+                    "add_magnet rqbit_add success: {}",
+                    magnet_log_summary(&magnet_uri)
+                ));
+                response_to_json(&response)
+            }
+            Err(error) => {
+                let detail = format_error_chain(&error);
+                torrent_log(format_args!(
+                    "add_magnet rqbit_add failed: {}, output_folder={output_folder:?}, error={}",
+                    magnet_log_summary(&magnet_uri),
+                    truncate_for_log(&detail, 480)
+                ));
+                Err(format!("failed to add magnet: {detail}"))
+            }
+        }
     })
 }
 
@@ -117,7 +251,13 @@ pub fn torrent_add_file(
     create_folder_for_task: bool,
 ) -> Result<String, String> {
     let torrent_file_path = torrent_file_path.trim().to_string();
+    torrent_log(format_args!(
+        "add_torrent_file start: torrent_file_path={torrent_file_path:?}, download_dir={download_dir:?}, create_folder_for_task={create_folder_for_task}"
+    ));
     if torrent_file_path.is_empty() {
+        torrent_log(format_args!(
+            "add_torrent_file rejected: torrent file path is empty"
+        ));
         return Err("torrent file path is empty".to_string());
     }
     let normalized_dir = normalize_download_dir(download_dir)?;
@@ -125,16 +265,37 @@ pub fn torrent_add_file(
     let state = torrent_runtime();
     let api = current_api(state)?;
     let folder_name = create_folder_for_task.then(|| file_stem_folder_name(&torrent_file_path));
+    let options = add_torrent_options(normalized_dir, folder_name.clone());
+    let output_folder = options.output_folder.clone();
+    torrent_log(format_args!(
+        "add_torrent_file rqbit_add start: folder_name={folder_name:?}, output_folder={output_folder:?}"
+    ));
 
     state.runtime.block_on(async {
-        api.api_add_torrent(
-            AddTorrent::from_local_filename(&torrent_file_path)
-                .map_err(|error| format!("failed to read torrent file: {error:#}"))?,
-            Some(add_torrent_options(normalized_dir, folder_name)),
-        )
-        .await
-        .map_err(|error| format!("failed to add torrent file: {error:#}"))
-        .and_then(|response| response_to_json(&response))
+        let add = AddTorrent::from_local_filename(&torrent_file_path).map_err(|error| {
+            let detail = format!("{error:#}");
+            torrent_log(format_args!(
+                "add_torrent_file read failed: torrent_file_path={torrent_file_path:?}, error={}",
+                truncate_for_log(&detail, 480)
+            ));
+            format!("failed to read torrent file: {detail}")
+        })?;
+        match api.api_add_torrent(add, Some(options)).await {
+            Ok(response) => {
+                torrent_log(format_args!(
+                    "add_torrent_file rqbit_add success: torrent_file_path={torrent_file_path:?}"
+                ));
+                response_to_json(&response)
+            }
+            Err(error) => {
+                let detail = format_error_chain(&error);
+                torrent_log(format_args!(
+                    "add_torrent_file rqbit_add failed: torrent_file_path={torrent_file_path:?}, output_folder={output_folder:?}, error={}",
+                    truncate_for_log(&detail, 480)
+                ));
+                Err(format!("failed to add torrent file: {detail}"))
+            }
+        }
     })
 }
 
@@ -145,6 +306,28 @@ pub fn torrent_list(download_dir: String) -> Result<String, String> {
 
     let response = api.api_torrent_list_ext(librqbit::api::ApiTorrentListOpts { with_stats: true });
     response_to_json(&response)
+}
+
+pub fn torrent_details(id: i32) -> Result<String, String> {
+    let id = normalize_torrent_id(id)?;
+    let state = torrent_runtime();
+    let api = current_api(state)?;
+    let response = api
+        .api_torrent_details(id.into())
+        .map_err(|error| format!("failed to get torrent details: {error:#}"))?;
+    response_to_json(&response)
+}
+
+pub fn torrent_stream_url(id: i32, file_id: i32, filename: String) -> Result<String, String> {
+    let id = normalize_torrent_id(id)?;
+    let file_id = normalize_torrent_id(file_id)?;
+    let state = torrent_runtime();
+    current_api(state)?;
+    let port = ensure_stream_server(state)?;
+    let filename = url_path_segment_encode(&file_stem_or_name(&filename));
+    Ok(format!(
+        "http://127.0.0.1:{port}/torrent/{id}/stream/{file_id}/{filename}"
+    ))
 }
 
 pub fn torrent_pause(id: i32) -> Result<(), String> {
@@ -205,6 +388,356 @@ fn current_api(state: &TorrentRuntime) -> Result<Api, String> {
         .ok_or_else(|| "torrent session is not initialized".to_string())
 }
 
+fn current_session(state: &TorrentRuntime) -> Result<Arc<Session>, String> {
+    state
+        .session
+        .lock()
+        .map_err(|_| "torrent session lock poisoned".to_string())?
+        .clone()
+        .ok_or_else(|| "torrent session is not initialized".to_string())
+}
+
+fn resolve_magnet_metadata_for_add(
+    state: &TorrentRuntime,
+    magnet_uri: &str,
+) -> Result<ListOnlyResponse, String> {
+    let session = current_session(state)?;
+    state.runtime.block_on(async {
+        match session
+            .add_torrent(
+                AddTorrent::from_url(magnet_uri.to_string()),
+                Some(AddTorrentOptions {
+                    list_only: true,
+                    overwrite: true,
+                    ..Default::default()
+                }),
+            )
+            .await
+        {
+            Ok(AddTorrentResponse::ListOnly(response)) => Ok(response),
+            Ok(AddTorrentResponse::Added(_, _)) => {
+                Err("unexpected torrent add response while resolving metadata".to_string())
+            }
+            Ok(AddTorrentResponse::AlreadyManaged(_, _)) => {
+                Err("unexpected managed torrent while resolving metadata".to_string())
+            }
+            Err(error) => {
+                let detail = format!("{error:#}");
+                torrent_log(format_args!(
+                    "add_magnet metadata resolve failed: {}, error={}",
+                    magnet_log_summary(magnet_uri),
+                    truncate_for_log(&detail, 480)
+                ));
+                Err(format!("failed to resolve magnet metadata: {detail}"))
+            }
+        }
+    })
+}
+
+fn torrent_log(args: std::fmt::Arguments<'_>) {
+    eprintln!("[nipaplay_torrent] {args}");
+}
+
+fn magnet_log_summary(magnet_uri: &str) -> String {
+    let has_whitespace = magnet_uri.chars().any(char::is_whitespace);
+    let starts_with_magnet_ci = magnet_uri.to_ascii_lowercase().starts_with("magnet:");
+    let mut summary = format!(
+        "len={}, starts_with_magnet={}, starts_with_magnet_ci={}, has_whitespace={has_whitespace}",
+        magnet_uri.len(),
+        magnet_uri.starts_with("magnet:"),
+        starts_with_magnet_ci
+    );
+
+    match Magnet::parse(magnet_uri) {
+        Ok(magnet) => {
+            summary.push_str(", parse=ok, ");
+            summary.push_str(&parsed_magnet_log_summary(&magnet));
+        }
+        Err(error) => {
+            let detail = format!("{error:#}");
+            summary.push_str(", parse=err(");
+            summary.push_str(&truncate_for_log(&detail, 160));
+            summary.push(')');
+        }
+    }
+
+    summary
+}
+
+fn parsed_magnet_log_summary(magnet: &Magnet) -> String {
+    let btv1 = magnet
+        .as_id20()
+        .map(|id| id.as_string())
+        .unwrap_or_else(|| "<none>".to_string());
+    let btv2 = magnet
+        .as_id32()
+        .map(|id| id.as_string())
+        .unwrap_or_else(|| "<none>".to_string());
+    let display_name = magnet
+        .name
+        .as_deref()
+        .map(|name| truncate_for_log(name, 120))
+        .unwrap_or_else(|| "<none>".to_string());
+
+    format!(
+        "btv1_info_hash={btv1}, btv2_info_hash={btv2}, tracker_count={}, dn={display_name:?}",
+        magnet.trackers.len()
+    )
+}
+
+fn format_error_chain(error: &(dyn std::error::Error + 'static)) -> String {
+    let mut message = error.to_string();
+    let mut source = error.source();
+    while let Some(error) = source {
+        message.push_str(" | caused by: ");
+        message.push_str(&error.to_string());
+        source = error.source();
+    }
+    message
+}
+
+fn truncate_for_log(value: &str, max_chars: usize) -> String {
+    let mut chars = value.chars();
+    let truncated: String = chars.by_ref().take(max_chars).collect();
+    if chars.next().is_some() {
+        format!("{truncated}...")
+    } else {
+        truncated
+    }
+}
+
+fn ensure_stream_server(state: &'static TorrentRuntime) -> Result<u16, String> {
+    let mut server_slot = state
+        .stream_server
+        .lock()
+        .map_err(|_| "torrent stream server lock poisoned".to_string())?;
+    if let Some(server) = server_slot.as_ref() {
+        return Ok(server.port);
+    }
+
+    let listener = TcpListener::bind(("127.0.0.1", 0))
+        .map_err(|error| format!("failed to bind torrent stream server: {error}"))?;
+    let port = listener
+        .local_addr()
+        .map_err(|error| format!("failed to read torrent stream server address: {error}"))?
+        .port();
+
+    thread::Builder::new()
+        .name("nipaplay-torrent-stream".to_string())
+        .spawn(move || {
+            for incoming in listener.incoming() {
+                match incoming {
+                    Ok(stream) => {
+                        let _ = thread::Builder::new()
+                            .name("nipaplay-torrent-stream-client".to_string())
+                            .spawn(move || {
+                                if let Err(error) = handle_stream_request(stream) {
+                                    eprintln!("[nipaplay_torrent_stream] request failed: {error}");
+                                }
+                            });
+                    }
+                    Err(error) => {
+                        eprintln!("[nipaplay_torrent_stream] accept failed: {error}");
+                        break;
+                    }
+                }
+            }
+        })
+        .map_err(|error| format!("failed to start torrent stream server: {error}"))?;
+
+    *server_slot = Some(TorrentStreamServer { port });
+    Ok(port)
+}
+
+fn handle_stream_request(mut socket: TcpStream) -> Result<(), String> {
+    let request = read_http_request(&mut socket)?;
+    let (method, path, range) = parse_http_request(&request)?;
+    if method != "GET" && method != "HEAD" {
+        write_simple_response(
+            &mut socket,
+            "405 Method Not Allowed",
+            "text/plain",
+            b"Method Not Allowed",
+        )?;
+        return Ok(());
+    }
+
+    let (torrent_id, file_id) =
+        parse_stream_path(&path).ok_or_else(|| format!("invalid torrent stream path: {path}"))?;
+    let state = torrent_runtime();
+    let api = current_api(state)?;
+    let mut stream = api
+        .api_stream(torrent_id.into(), file_id)
+        .map_err(|error| format!("failed to create torrent stream: {error:#}"))?;
+    let file_len = stream.len();
+
+    let start = range.map(|range| range.start).unwrap_or(0);
+    let end = range
+        .and_then(|range| range.end)
+        .unwrap_or_else(|| file_len.saturating_sub(1))
+        .min(file_len.saturating_sub(1));
+
+    if file_len > 0 && (start >= file_len || start > end) {
+        let body = b"Requested Range Not Satisfiable";
+        write!(
+            socket,
+            "HTTP/1.1 416 Range Not Satisfiable\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            body.len()
+        )
+        .map_err(|error| format!("failed to write range error response: {error}"))?;
+        socket
+            .write_all(body)
+            .map_err(|error| format!("failed to write range error body: {error}"))?;
+        return Ok(());
+    }
+
+    if start > 0 {
+        state
+            .runtime
+            .block_on(stream.seek(SeekFrom::Start(start)))
+            .map_err(|error| format!("failed to seek torrent stream: {error}"))?;
+    }
+
+    let content_type = api
+        .torrent_file_mime_type(torrent_id.into(), file_id)
+        .unwrap_or("application/octet-stream");
+    let status = if range.is_some() {
+        "206 Partial Content"
+    } else {
+        "200 OK"
+    };
+    let content_length = if file_len == 0 { 0 } else { end - start + 1 };
+
+    write!(
+        socket,
+        "HTTP/1.1 {status}\r\nAccept-Ranges: bytes\r\nContent-Type: {content_type}\r\nContent-Length: {content_length}\r\nConnection: close\r\n"
+    )
+    .map_err(|error| format!("failed to write stream headers: {error}"))?;
+    if range.is_some() && file_len > 0 {
+        write!(
+            socket,
+            "Content-Range: bytes {}-{}/{}\r\n",
+            start, end, file_len
+        )
+        .map_err(|error| format!("failed to write content range: {error}"))?;
+    }
+    socket
+        .write_all(b"\r\n")
+        .map_err(|error| format!("failed to finish stream headers: {error}"))?;
+
+    if method == "HEAD" {
+        return Ok(());
+    }
+
+    let mut buffer = vec![0_u8; 64 * 1024];
+    let mut bytes_remaining = content_length;
+    while bytes_remaining > 0 {
+        let read_len = buffer.len().min(bytes_remaining as usize);
+        let bytes_read = state
+            .runtime
+            .block_on(stream.read(&mut buffer[..read_len]))
+            .map_err(|error| format!("failed to read torrent stream: {error}"))?;
+        if bytes_read == 0 {
+            break;
+        }
+        socket
+            .write_all(&buffer[..bytes_read])
+            .map_err(|error| format!("failed to write torrent stream: {error}"))?;
+        bytes_remaining = bytes_remaining.saturating_sub(bytes_read as u64);
+    }
+
+    Ok(())
+}
+
+fn read_http_request(socket: &mut TcpStream) -> Result<String, String> {
+    let mut request = Vec::with_capacity(1024);
+    let mut buffer = [0_u8; 1024];
+    loop {
+        let bytes_read = socket
+            .read(&mut buffer)
+            .map_err(|error| format!("failed to read HTTP request: {error}"))?;
+        if bytes_read == 0 {
+            break;
+        }
+        request.extend_from_slice(&buffer[..bytes_read]);
+        if request.windows(4).any(|window| window == b"\r\n\r\n") {
+            break;
+        }
+        if request.len() > 64 * 1024 {
+            return Err("HTTP request headers are too large".to_string());
+        }
+    }
+    String::from_utf8(request).map_err(|error| format!("invalid HTTP request encoding: {error}"))
+}
+
+fn parse_http_request(request: &str) -> Result<(&str, String, Option<HttpRange>), String> {
+    let mut lines = request.lines();
+    let request_line = lines
+        .next()
+        .ok_or_else(|| "empty HTTP request".to_string())?;
+    let mut parts = request_line.split_whitespace();
+    let method = parts
+        .next()
+        .ok_or_else(|| "missing HTTP method".to_string())?;
+    let path = parts
+        .next()
+        .ok_or_else(|| "missing HTTP path".to_string())?
+        .to_string();
+
+    let range_start = lines.find_map(|line| {
+        let (name, value) = line.split_once(':')?;
+        if !name.trim().eq_ignore_ascii_case("range") {
+            return None;
+        }
+        parse_range(value.trim())
+    });
+
+    Ok((method, path, range_start))
+}
+
+fn parse_range(value: &str) -> Option<HttpRange> {
+    let range = value.strip_prefix("bytes=")?;
+    let (start, end) = range.split_once('-')?;
+    let start = start.trim().parse::<u64>().ok()?;
+    let end = if end.trim().is_empty() {
+        None
+    } else {
+        Some(end.trim().parse::<u64>().ok()?)
+    };
+    Some(HttpRange { start, end })
+}
+
+fn parse_stream_path(path: &str) -> Option<(usize, usize)> {
+    let path = path.split('?').next().unwrap_or(path);
+    let mut segments = path.trim_start_matches('/').split('/');
+    if segments.next()? != "torrent" {
+        return None;
+    }
+    let torrent_id = segments.next()?.parse::<usize>().ok()?;
+    if segments.next()? != "stream" {
+        return None;
+    }
+    let file_id = segments.next()?.parse::<usize>().ok()?;
+    Some((torrent_id, file_id))
+}
+
+fn write_simple_response(
+    socket: &mut TcpStream,
+    status: &str,
+    content_type: &str,
+    body: &[u8],
+) -> Result<(), String> {
+    write!(
+        socket,
+        "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    )
+    .map_err(|error| format!("failed to write HTTP response headers: {error}"))?;
+    socket
+        .write_all(body)
+        .map_err(|error| format!("failed to write HTTP response body: {error}"))
+}
+
 fn add_torrent_options(download_dir: String, folder_name: Option<String>) -> AddTorrentOptions {
     let output_folder = folder_name
         .map(|folder| Path::new(&download_dir).join(folder))
@@ -217,13 +750,6 @@ fn add_torrent_options(download_dir: String, folder_name: Option<String>) -> Add
     }
 }
 
-fn magnet_folder_name(magnet_uri: &str) -> Option<String> {
-    Magnet::parse(magnet_uri)
-        .ok()
-        .and_then(|magnet| magnet.name)
-        .and_then(|name| sanitize_folder_name(&name))
-}
-
 fn file_stem_folder_name(file_path: &str) -> String {
     let fallback = "torrent";
     let name = Path::new(file_path)
@@ -232,6 +758,61 @@ fn file_stem_folder_name(file_path: &str) -> String {
         .and_then(|name| name.to_str())
         .unwrap_or(fallback);
     sanitize_folder_name(name).unwrap_or_else(|| fallback.to_string())
+}
+
+fn file_stem_or_name(file_path: &str) -> String {
+    Path::new(file_path)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("video")
+        .to_string()
+}
+
+fn torrent_metadata_folder_name(metadata: &ListOnlyResponse) -> Option<String> {
+    if let Some(name) = metadata.info.name.as_ref() {
+        let name = String::from_utf8_lossy(name.as_slice());
+        if let Some(folder_name) = sanitize_folder_name(name.as_ref()) {
+            return Some(folder_name);
+        }
+    }
+
+    let mut largest_file: Option<(u64, String)> = None;
+    let files = metadata.info.iter_file_details().ok()?;
+    for file in files {
+        let file_name = match file.filename.to_string() {
+            Ok(value) => value,
+            Err(_) => continue,
+        };
+        let stem = Path::new(&file_name)
+            .file_stem()
+            .and_then(|value| value.to_str())
+            .unwrap_or(&file_name);
+        let Some(folder_name) = sanitize_folder_name(stem) else {
+            continue;
+        };
+        if largest_file
+            .as_ref()
+            .map(|(length, _)| file.len > *length)
+            .unwrap_or(true)
+        {
+            largest_file = Some((file.len, folder_name));
+        }
+    }
+
+    largest_file.map(|(_, folder_name)| folder_name)
+}
+
+fn url_path_segment_encode(input: &str) -> String {
+    let mut output = String::new();
+    for byte in input.as_bytes() {
+        match *byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                output.push(*byte as char)
+            }
+            byte => output.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    output
 }
 
 fn sanitize_folder_name(name: &str) -> Option<String> {

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 629279474;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1076023073;
 
 // Section: executor
 
@@ -450,6 +450,39 @@ fn wire__crate__api__torrent__torrent_delete_impl(
         },
     )
 }
+fn wire__crate__api__torrent__torrent_details_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "torrent_details",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_id = <i32>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::torrent::torrent_details(api_id)?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__torrent__torrent_forget_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -609,6 +642,42 @@ fn wire__crate__api__torrent__torrent_resume_impl(
             move |context| {
                 transform_result_sse::<_, String>((move || {
                     let output_ok = crate::api::torrent::torrent_resume(api_id)?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__torrent__torrent_stream_url_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "torrent_stream_url",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_id = <i32>::sse_decode(&mut deserializer);
+            let api_file_id = <i32>::sse_decode(&mut deserializer);
+            let api_filename = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok =
+                        crate::api::torrent::torrent_stream_url(api_id, api_file_id, api_filename)?;
                     Ok(output_ok)
                 })())
             }
@@ -887,13 +956,15 @@ fn pde_ffi_dispatcher_primary_impl(
         10 => wire__crate__api__torrent__torrent_add_file_impl(port, ptr, rust_vec_len, data_len),
         11 => wire__crate__api__torrent__torrent_add_magnet_impl(port, ptr, rust_vec_len, data_len),
         12 => wire__crate__api__torrent__torrent_delete_impl(port, ptr, rust_vec_len, data_len),
-        13 => wire__crate__api__torrent__torrent_forget_impl(port, ptr, rust_vec_len, data_len),
-        14 => {
+        13 => wire__crate__api__torrent__torrent_details_impl(port, ptr, rust_vec_len, data_len),
+        14 => wire__crate__api__torrent__torrent_forget_impl(port, ptr, rust_vec_len, data_len),
+        15 => {
             wire__crate__api__torrent__torrent_init_session_impl(port, ptr, rust_vec_len, data_len)
         }
-        15 => wire__crate__api__torrent__torrent_list_impl(port, ptr, rust_vec_len, data_len),
-        16 => wire__crate__api__torrent__torrent_pause_impl(port, ptr, rust_vec_len, data_len),
-        17 => wire__crate__api__torrent__torrent_resume_impl(port, ptr, rust_vec_len, data_len),
+        16 => wire__crate__api__torrent__torrent_list_impl(port, ptr, rust_vec_len, data_len),
+        17 => wire__crate__api__torrent__torrent_pause_impl(port, ptr, rust_vec_len, data_len),
+        18 => wire__crate__api__torrent__torrent_resume_impl(port, ptr, rust_vec_len, data_len),
+        19 => wire__crate__api__torrent__torrent_stream_url_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }


### PR DESCRIPTION
## Summary
- add torrent task file metadata, completed-file playback, and a file selection dialog for playable downloaded files
- hide the download-card play action until a task is finished, removing the broken unfinished-download playback entry point
- add downloader settings for automatically scanning completed tasks into the media library, with persisted tracking to avoid repeat scans
- fix same-name folder creation for magnet downloads by resolving torrent metadata before adding the task and using sanitized torrent/file names for the output folder
- add Rust torrent detail and local HTTP range streaming support plus regenerated Flutter Rust Bridge bindings
- restore macOS write access for downloader folders through Downloads entitlements and read-write security-scoped bookmarks
- create fallback watch history records when recognized playback metadata has no existing history row

## Testing
- cargo check
- git diff --cached --check

Note: cargo check still reports the existing deprecated libc::mach_task_self warning in rust/src/api/performance.rs.