### PR TITLE
Add remote access QR linking

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CAMERA" />
     <!-- 基本存储权限 - 对于Android 9及以下 -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29" />

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -199,7 +199,7 @@
 		<string>_https._tcp.</string>
 	</array>
 	<key>NSCameraUsageDescription</key>
-	<string>未来需要更新头像</string>
+	<string>NipaPlay 需要使用相机拍摄远程访问二维码以连接共享媒体库和遥控器。</string>
 	<key>NSDocumentsFolderUsageDescription</key>
 	<string>NipaPlay 需要访问文稿目录以管理您的文件。</string>
 	<key>NSLocalNetworkUsageDescription</key>

--- a/lib/constants/settings_keys.dart
+++ b/lib/constants/settings_keys.dart
@@ -24,6 +24,9 @@ class SettingsKeys {
   static const String labsEnableLargeScreenMode =
       'labs_enable_large_screen_mode';
 
+  static const String labsShowRemoteAccessQrCode =
+      'labs_show_remote_access_qr_code';
+
   static const String torrentDownloadDirectory = 'torrent_download_directory';
 
   static const String downloaderEnabled = 'downloader_enabled';

--- a/lib/providers/labs_settings_provider.dart
+++ b/lib/providers/labs_settings_provider.dart
@@ -8,14 +8,20 @@ class LabsSettingsProvider extends ChangeNotifier {
   }
 
   bool _enableLargeScreenMode = false;
+  bool _showRemoteAccessQrCode = false;
   bool _isLoaded = false;
 
   bool get enableLargeScreenMode => _enableLargeScreenMode;
+  bool get showRemoteAccessQrCode => _showRemoteAccessQrCode;
   bool get isLoaded => _isLoaded;
 
   Future<void> _loadSettings() async {
     _enableLargeScreenMode = await SettingsStorage.loadBool(
       SettingsKeys.labsEnableLargeScreenMode,
+      defaultValue: false,
+    );
+    _showRemoteAccessQrCode = await SettingsStorage.loadBool(
+      SettingsKeys.labsShowRemoteAccessQrCode,
       defaultValue: false,
     );
     _isLoaded = true;
@@ -28,6 +34,16 @@ class LabsSettingsProvider extends ChangeNotifier {
     notifyListeners();
     await SettingsStorage.saveBool(
       SettingsKeys.labsEnableLargeScreenMode,
+      enabled,
+    );
+  }
+
+  Future<void> setShowRemoteAccessQrCode(bool enabled) async {
+    if (_showRemoteAccessQrCode == enabled) return;
+    _showRemoteAccessQrCode = enabled;
+    notifyListeners();
+    await SettingsStorage.saveBool(
+      SettingsKeys.labsShowRemoteAccessQrCode,
       enabled,
     );
   }

--- a/lib/providers/shared_remote_library_provider.dart
+++ b/lib/providers/shared_remote_library_provider.dart
@@ -7,6 +7,7 @@ import 'package:http/http.dart' as http;
 import 'package:http/io_client.dart';
 import 'package:path/path.dart' as p;
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:nipaplay/services/remote_control_settings.dart';
 import 'package:nipaplay/services/web_remote_access_service.dart';
 import 'package:nipaplay/services/webdav_service.dart';
 import 'package:nipaplay/services/smb_service.dart';
@@ -137,6 +138,9 @@ class SharedRemoteLibraryProvider extends ChangeNotifier {
       _errorMessage = '加载远程媒体库配置失败: $e';
     } finally {
       _isInitializing = false;
+      if (_activeHostId != null) {
+        await _syncActiveHostToRemoteControl();
+      }
       notifyListeners();
       if (_activeHostId != null) {
         refreshLibrary();
@@ -165,12 +169,50 @@ class SharedRemoteLibraryProvider extends ChangeNotifier {
     _hosts.add(host);
     _activeHostId = id;
     await _persistHosts();
+    await _syncHostToRemoteControl(host);
     notifyListeners();
     await refreshLibrary(userInitiated: true);
     return host;
   }
 
+  Future<SharedRemoteHost> connectOrActivateHost({
+    required String displayName,
+    required String baseUrl,
+  }) async {
+    final normalizedUrl = _normalizeBaseUrl(baseUrl);
+    for (var i = 0; i < _hosts.length; i++) {
+      final host = _hosts[i];
+      if (_normalizeBaseUrl(host.baseUrl) != normalizedUrl) continue;
+
+      var shouldPersist = false;
+      final trimmedName = displayName.trim();
+      if (trimmedName.isNotEmpty &&
+          trimmedName != normalizedUrl &&
+          (host.displayName.trim().isEmpty ||
+              host.displayName == host.baseUrl)) {
+        _hosts[i] = host.copyWith(displayName: trimmedName);
+        shouldPersist = true;
+      }
+      if (shouldPersist) {
+        await _persistHosts();
+        notifyListeners();
+      }
+      await setActiveHost(_hosts[i].id);
+      return _hosts[i];
+    }
+
+    return addHost(displayName: displayName, baseUrl: normalizedUrl);
+  }
+
   Future<void> removeHost(String hostId) async {
+    SharedRemoteHost? removedHost;
+    for (final host in _hosts) {
+      if (host.id == hostId) {
+        removedHost = host;
+        break;
+      }
+    }
+
     _hosts.removeWhere((host) => host.id == hostId);
     if (_activeHostId == hostId) {
       _activeHostId = _hosts.isNotEmpty ? _hosts.first.id : null;
@@ -181,6 +223,14 @@ class SharedRemoteLibraryProvider extends ChangeNotifier {
       _managementErrorMessage = null;
     }
     await _persistHosts();
+    if (_activeHostId != null) {
+      await _syncActiveHostToRemoteControl();
+    } else if (removedHost != null) {
+      final matchedBaseUrl = await RemoteControlSettings.getMatchedBaseUrl();
+      if (matchedBaseUrl == removedHost.baseUrl) {
+        await RemoteControlSettings.clearMatchedTarget();
+      }
+    }
     notifyListeners();
     if (_activeHostId != null) {
       await refreshLibrary(userInitiated: true);
@@ -188,7 +238,10 @@ class SharedRemoteLibraryProvider extends ChangeNotifier {
   }
 
   Future<void> setActiveHost(String hostId) async {
-    if (_activeHostId == hostId) return;
+    if (_activeHostId == hostId) {
+      await _syncActiveHostToRemoteControl();
+      return;
+    }
     if (!_hosts.any((host) => host.id == hostId)) return;
     _activeHostId = hostId;
     _animeSummaries = [];
@@ -197,6 +250,7 @@ class SharedRemoteLibraryProvider extends ChangeNotifier {
     _scanStatus = null;
     _managementErrorMessage = null;
     await _persistHosts();
+    await _syncActiveHostToRemoteControl();
     notifyListeners();
     await refreshLibrary(userInitiated: true);
   }
@@ -634,6 +688,9 @@ class SharedRemoteLibraryProvider extends ChangeNotifier {
     if (index == -1) return;
     _hosts[index] = _hosts[index].copyWith(displayName: newName);
     await _persistHosts();
+    if (_activeHostId == hostId) {
+      await _syncHostToRemoteControl(_hosts[index]);
+    }
     notifyListeners();
   }
 
@@ -642,11 +699,32 @@ class SharedRemoteLibraryProvider extends ChangeNotifier {
     if (index == -1) return;
     final normalized = _normalizeBaseUrl(newUrl);
     _hosts[index] = _hosts[index].copyWith(baseUrl: normalized);
+    await _persistHosts();
     if (_activeHostId == hostId) {
+      await _syncHostToRemoteControl(_hosts[index]);
       await refreshLibrary(userInitiated: true);
     }
-    await _persistHosts();
     notifyListeners();
+  }
+
+  Future<void> _syncActiveHostToRemoteControl() async {
+    final host = activeHost;
+    if (host == null) return;
+    await _syncHostToRemoteControl(host);
+  }
+
+  Future<void> _syncHostToRemoteControl(SharedRemoteHost host) async {
+    final displayName = host.displayName.trim();
+    try {
+      await RemoteControlSettings.saveMatchedTarget(
+        baseUrl: host.baseUrl,
+        hostname: displayName.isEmpty || displayName == host.baseUrl
+            ? null
+            : displayName,
+      );
+    } catch (e) {
+      debugPrint('同步远程遥控目标失败: $e');
+    }
   }
 
   String _normalizeBaseUrl(String url) {

--- a/lib/services/remote_access_qr_service.dart
+++ b/lib/services/remote_access_qr_service.dart
@@ -1,0 +1,225 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+import 'package:image/image.dart' as img;
+import 'package:image_picker/image_picker.dart';
+import 'package:zxing2/qrcode.dart';
+
+class RemoteAccessQrPayload {
+  const RemoteAccessQrPayload({
+    required this.baseUrl,
+    this.displayName,
+  });
+
+  final String baseUrl;
+  final String? displayName;
+}
+
+class RemoteAccessServerInfo {
+  const RemoteAccessServerInfo({
+    required this.baseUrl,
+    this.hostname,
+    this.remoteControlReceiverEnabled = false,
+  });
+
+  final String baseUrl;
+  final String? hostname;
+  final bool remoteControlReceiverEnabled;
+
+  String get displayName {
+    final name = hostname?.trim() ?? '';
+    return name.isEmpty ? baseUrl : name;
+  }
+}
+
+class RemoteAccessQrService {
+  RemoteAccessQrService._();
+
+  static const String payloadType = 'nipaplay_remote_access';
+  static const int defaultPort = 1180;
+
+  static String buildPayload({required String baseUrl}) {
+    return normalizeRemoteAccessUrl(baseUrl);
+  }
+
+  static RemoteAccessQrPayload parseScannedText(String text) {
+    final trimmed = text.trim();
+    if (trimmed.isEmpty) {
+      throw const FormatException('二维码内容为空');
+    }
+
+    final jsonPayload = _tryParseJsonPayload(trimmed);
+    if (jsonPayload != null) {
+      return jsonPayload;
+    }
+
+    final uri = Uri.tryParse(trimmed);
+    if (uri != null && uri.scheme == 'nipaplay') {
+      final baseUrl =
+          uri.queryParameters['baseUrl'] ?? uri.queryParameters['url'] ?? '';
+      if (baseUrl.trim().isNotEmpty) {
+        return RemoteAccessQrPayload(
+          baseUrl: normalizeRemoteAccessUrl(baseUrl),
+          displayName: uri.queryParameters['name'],
+        );
+      }
+    }
+
+    return RemoteAccessQrPayload(
+      baseUrl: normalizeRemoteAccessUrl(trimmed),
+    );
+  }
+
+  static String normalizeRemoteAccessUrl(String input) {
+    var value = input.trim();
+    if (value.isEmpty) {
+      throw const FormatException('访问地址为空');
+    }
+
+    if (!value.contains('://')) {
+      value = 'http://$value';
+    }
+
+    var uri = Uri.tryParse(value);
+    if (uri == null || uri.host.trim().isEmpty) {
+      throw const FormatException('不是有效的访问地址');
+    }
+
+    uri = uri.replace(path: '', query: '', fragment: '');
+
+    if (!uri.hasPort && uri.scheme == 'http') {
+      uri = uri.replace(port: defaultPort);
+    }
+
+    var normalized = uri.toString();
+    while (normalized.endsWith('/')) {
+      normalized = normalized.substring(0, normalized.length - 1);
+    }
+    return normalized;
+  }
+
+  static Future<RemoteAccessServerInfo?> fetchServerInfo(
+    String baseUrl, {
+    Duration timeout = const Duration(seconds: 3),
+  }) async {
+    final normalized = normalizeRemoteAccessUrl(baseUrl);
+    try {
+      final response =
+          await http.get(Uri.parse('$normalized/api/info')).timeout(timeout);
+      if (response.statusCode != 200) return null;
+
+      final decoded = json.decode(utf8.decode(response.bodyBytes));
+      if (decoded is! Map<String, dynamic>) return null;
+      if (decoded['success'] != true || decoded['app'] != 'NipaPlay') {
+        return null;
+      }
+
+      final hostname = decoded['hostname'] is String
+          ? (decoded['hostname'] as String).trim()
+          : null;
+      return RemoteAccessServerInfo(
+        baseUrl: normalized,
+        hostname: hostname?.isEmpty == true ? null : hostname,
+        remoteControlReceiverEnabled:
+            decoded['remoteControlReceiverEnabled'] == true,
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
+  static String decodeQrImage(Uint8List bytes) {
+    final decoded = img.decodeImage(bytes);
+    if (decoded == null) {
+      throw const FormatException('无法读取拍摄的图片');
+    }
+
+    final oriented = img.bakeOrientation(decoded);
+    final candidates = <img.Image>[
+      oriented,
+      if (oriented.width > 1600 || oriented.height > 1600)
+        img.copyResize(
+          oriented,
+          width: oriented.width >= oriented.height ? 1600 : null,
+          height: oriented.height > oriented.width ? 1600 : null,
+          interpolation: img.Interpolation.average,
+        ),
+    ];
+
+    Object? lastError;
+    for (final candidate in candidates) {
+      try {
+        final rgba = candidate
+            .convert(numChannels: 4)
+            .getBytes(order: img.ChannelOrder.rgba);
+        final pixels = rgba.buffer.asInt32List(
+          rgba.offsetInBytes,
+          rgba.lengthInBytes ~/ 4,
+        );
+        final source = RGBLuminanceSource(
+          candidate.width,
+          candidate.height,
+          pixels,
+        );
+        final bitmap = BinaryBitmap(HybridBinarizer(source));
+        return QRCodeReader().decode(bitmap).text;
+      } catch (e) {
+        lastError = e;
+      }
+    }
+
+    throw FormatException('未识别到二维码', lastError);
+  }
+
+  static RemoteAccessQrPayload? _tryParseJsonPayload(String text) {
+    try {
+      final decoded = json.decode(text);
+      if (decoded is! Map<String, dynamic>) return null;
+      if (decoded['type'] != payloadType) return null;
+      final baseUrl = decoded['baseUrl']?.toString().trim() ?? '';
+      if (baseUrl.isEmpty) return null;
+      final displayName =
+          decoded['name']?.toString() ?? decoded['displayName']?.toString();
+      return RemoteAccessQrPayload(
+        baseUrl: normalizeRemoteAccessUrl(baseUrl),
+        displayName: displayName,
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+}
+
+class RemoteAccessQrCameraScanner {
+  RemoteAccessQrCameraScanner._();
+
+  static bool get isSupported {
+    if (kIsWeb) return false;
+    return defaultTargetPlatform == TargetPlatform.android ||
+        defaultTargetPlatform == TargetPlatform.iOS;
+  }
+
+  static Future<RemoteAccessQrPayload?> scan() async {
+    if (!isSupported) {
+      throw UnsupportedError('当前平台不支持相机扫码');
+    }
+
+    final image = await ImagePicker().pickImage(
+      source: ImageSource.camera,
+      imageQuality: 95,
+      maxWidth: 2400,
+      maxHeight: 2400,
+    );
+    if (image == null) return null;
+
+    final bytes = await image.readAsBytes();
+    final scannedText = await compute(decodeRemoteAccessQrImage, bytes);
+    return RemoteAccessQrService.parseScannedText(scannedText);
+  }
+}
+
+String decodeRemoteAccessQrImage(Uint8List bytes) {
+  return RemoteAccessQrService.decodeQrImage(bytes);
+}

--- a/lib/themes/cupertino/pages/cupertino_media_library_page.dart
+++ b/lib/themes/cupertino/pages/cupertino_media_library_page.dart
@@ -35,6 +35,7 @@ import 'package:nipaplay/services/local_media_share_service.dart';
 import 'package:nipaplay/services/scan_service.dart';
 import 'package:nipaplay/services/dandanplay_service.dart';
 import 'package:nipaplay/services/manual_danmaku_matcher.dart';
+import 'package:nipaplay/services/remote_access_qr_service.dart';
 import 'package:nipaplay/utils/android_storage_helper.dart';
 import 'package:nipaplay/utils/storage_service.dart';
 import 'package:nipaplay/utils/media_filename_parser.dart';
@@ -473,6 +474,37 @@ class _CupertinoMediaLibraryPageState extends State<CupertinoMediaLibraryPage> {
                               fontSize: 15, color: CupertinoColors.white),
                         ),
                       ),
+                      if (RemoteAccessQrCameraScanner.isSupported) ...[
+                        const SizedBox(height: 10),
+                        CupertinoButton(
+                          onPressed: () => _connectSharedHostByQr(provider),
+                          color: CupertinoDynamicColor.resolve(
+                              CupertinoColors.systemGrey5, context),
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 20, vertical: 10),
+                          borderRadius: BorderRadius.circular(14),
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Icon(
+                                CupertinoIcons.camera,
+                                size: 18,
+                                color: CupertinoDynamicColor.resolve(
+                                    CupertinoColors.label, context),
+                              ),
+                              const SizedBox(width: 6),
+                              Text(
+                                '拍摄二维码',
+                                style: TextStyle(
+                                  fontSize: 15,
+                                  color: CupertinoDynamicColor.resolve(
+                                      CupertinoColors.label, context),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ],
                       const SizedBox(height: 10),
                       CupertinoButton(
                         onPressed: () => _openLanScanDialog(provider),
@@ -610,6 +642,13 @@ class _CupertinoMediaLibraryPageState extends State<CupertinoMediaLibraryPage> {
                       icon: CupertinoIcons.add,
                       onPressed: () => _openAddHostDialog(provider),
                     ),
+                    if (RemoteAccessQrCameraScanner.isSupported)
+                      _buildActionButton(
+                        context,
+                        label: '拍摄二维码',
+                        icon: CupertinoIcons.camera,
+                        onPressed: () => _connectSharedHostByQr(provider),
+                      ),
                     _buildActionButton(
                       context,
                       label: '扫描局域网',
@@ -1216,6 +1255,47 @@ class _CupertinoMediaLibraryPageState extends State<CupertinoMediaLibraryPage> {
           );
         }
       }
+    }
+  }
+
+  Future<void> _connectSharedHostByQr(
+    SharedRemoteLibraryProvider provider,
+  ) async {
+    try {
+      final payload = await RemoteAccessQrCameraScanner.scan();
+      if (payload == null) return;
+
+      final info = await RemoteAccessQrService.fetchServerInfo(payload.baseUrl);
+      if (!mounted) return;
+      if (info == null) {
+        AdaptiveSnackBar.show(
+          context,
+          message: '未识别到可访问的 NipaPlay 远程访问服务',
+          type: AdaptiveSnackBarType.error,
+        );
+        return;
+      }
+
+      final displayName = payload.displayName?.trim().isNotEmpty == true
+          ? payload.displayName!.trim()
+          : info.displayName;
+      await provider.connectOrActivateHost(
+        displayName: displayName,
+        baseUrl: info.baseUrl,
+      );
+      if (!mounted) return;
+      AdaptiveSnackBar.show(
+        context,
+        message: '已连接共享媒体库与遥控器',
+        type: AdaptiveSnackBarType.success,
+      );
+    } catch (e) {
+      if (!mounted) return;
+      AdaptiveSnackBar.show(
+        context,
+        message: '扫码连接失败：$e',
+        type: AdaptiveSnackBarType.error,
+      );
     }
   }
 

--- a/lib/themes/cupertino/pages/settings/pages/cupertino_labs_settings_page.dart
+++ b/lib/themes/cupertino/pages/settings/pages/cupertino_labs_settings_page.dart
@@ -63,11 +63,32 @@ class CupertinoLabsSettingsPage extends StatelessWidget {
                       ),
                       CupertinoSettingsTile(
                         leading: Icon(
+                          CupertinoIcons.qrcode,
+                          color: resolveSettingsIconColor(context),
+                        ),
+                        title: const Text('显示远程访问二维码'),
+                        subtitle: const Text('开启后，远程访问服务页面会显示供手机扫码连接的二维码'),
+                        trailing: AdaptiveSwitch(
+                          value: labsSettings.showRemoteAccessQrCode,
+                          onChanged: (value) {
+                            labsSettings.setShowRemoteAccessQrCode(value);
+                          },
+                        ),
+                        onTap: () {
+                          labsSettings.setShowRemoteAccessQrCode(
+                            !labsSettings.showRemoteAccessQrCode,
+                          );
+                        },
+                        backgroundColor: resolveSettingsTileBackground(context),
+                      ),
+                      CupertinoSettingsTile(
+                        leading: Icon(
                           CupertinoIcons.cloud,
                           color: resolveSettingsIconColor(context),
                         ),
                         title: const Text('WebDAV 快捷设置'),
-                        subtitle: const Text('配置底部 WebDAV 快捷 Tab，快速访问 WebDAV 服务器'),
+                        subtitle:
+                            const Text('配置底部 WebDAV 快捷 Tab，快速访问 WebDAV 服务器'),
                         trailing: Icon(
                           CupertinoIcons.chevron_forward,
                           color: CupertinoDynamicColor.resolve(
@@ -79,7 +100,8 @@ class CupertinoLabsSettingsPage extends StatelessWidget {
                         onTap: () {
                           Navigator.of(context).push(
                             CupertinoPageRoute(
-                              builder: (_) => const CupertinoWebDAVQuickSettingsPage(),
+                              builder: (_) =>
+                                  const CupertinoWebDAVQuickSettingsPage(),
                             ),
                           );
                         },

--- a/lib/themes/cupertino/pages/settings/pages/cupertino_remote_controller_settings_page.dart
+++ b/lib/themes/cupertino/pages/settings/pages/cupertino_remote_controller_settings_page.dart
@@ -2,14 +2,17 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/services.dart';
+import 'package:nipaplay/providers/shared_remote_library_provider.dart';
 import 'package:nipaplay/services/remote_control_client_service.dart';
 import 'package:nipaplay/services/remote_control_settings.dart';
+import 'package:nipaplay/services/remote_access_qr_service.dart';
 import 'package:nipaplay/themes/cupertino/cupertino_adaptive_platform_ui.dart';
 import 'package:nipaplay/themes/cupertino/cupertino_imports.dart';
 import 'package:nipaplay/themes/cupertino/widgets/cupertino_bottom_sheet.dart';
 import 'package:nipaplay/themes/cupertino/widgets/cupertino_settings_group_card.dart';
 import 'package:nipaplay/themes/cupertino/widgets/cupertino_settings_tile.dart';
 import 'package:nipaplay/utils/cupertino_settings_colors.dart';
+import 'package:provider/provider.dart';
 
 class CupertinoRemoteControllerSettingsPage extends StatefulWidget {
   const CupertinoRemoteControllerSettingsPage({super.key});
@@ -64,6 +67,10 @@ class _CupertinoRemoteControllerSettingsPageState
         _matchedBaseUrl = matched.baseUrl;
         _matchedHostname = matched.hostname;
       });
+      await _syncSharedLibraryTarget(
+        baseUrl: matched.baseUrl,
+        hostname: matched.hostname,
+      );
       await _refreshRemoteState();
       if (!mounted) return;
       AdaptiveSnackBar.show(
@@ -79,6 +86,66 @@ class _CupertinoRemoteControllerSettingsPageState
           _isScanning = false;
         });
       }
+    }
+  }
+
+  Future<void> _scanQrAndConnect() async {
+    try {
+      final payload = await RemoteAccessQrCameraScanner.scan();
+      if (payload == null) return;
+
+      final info = await RemoteAccessQrService.fetchServerInfo(payload.baseUrl);
+      if (!mounted) return;
+      if (info == null) {
+        AdaptiveSnackBar.show(
+          context,
+          message: '未识别到可访问的 NipaPlay 远程访问服务',
+        );
+        return;
+      }
+
+      final hostname = payload.displayName?.trim().isNotEmpty == true
+          ? payload.displayName!.trim()
+          : info.hostname;
+      await RemoteControlSettings.saveMatchedTarget(
+        baseUrl: info.baseUrl,
+        hostname: hostname,
+      );
+      await _syncSharedLibraryTarget(
+        baseUrl: info.baseUrl,
+        hostname: hostname,
+      );
+      if (!mounted) return;
+      setState(() {
+        _matchedBaseUrl = info.baseUrl;
+        _matchedHostname = hostname;
+      });
+      await _refreshRemoteState();
+      if (!mounted) return;
+      AdaptiveSnackBar.show(
+        context,
+        message: '已连接共享媒体库与遥控器',
+        type: AdaptiveSnackBarType.success,
+      );
+    } catch (e) {
+      if (!mounted) return;
+      AdaptiveSnackBar.show(context, message: '扫码连接失败: $e');
+    }
+  }
+
+  Future<void> _syncSharedLibraryTarget({
+    required String baseUrl,
+    String? hostname,
+  }) async {
+    try {
+      final provider = context.read<SharedRemoteLibraryProvider>();
+      await provider.connectOrActivateHost(
+        displayName:
+            hostname?.trim().isNotEmpty == true ? hostname!.trim() : baseUrl,
+        baseUrl: baseUrl,
+      );
+    } catch (e) {
+      debugPrint('同步共享媒体库目标失败: $e');
     }
   }
 
@@ -217,6 +284,17 @@ class _CupertinoRemoteControllerSettingsPageState
                     backgroundColor: tileBackground,
                     onTap: _isScanning ? null : _scanAndMatch,
                   ),
+                  if (RemoteAccessQrCameraScanner.isSupported)
+                    CupertinoSettingsTile(
+                      leading: Icon(
+                        CupertinoIcons.camera,
+                        color: resolveSettingsIconColor(context),
+                      ),
+                      title: const Text('拍摄二维码连接'),
+                      subtitle: const Text('同时连接共享媒体库与遥控器'),
+                      backgroundColor: tileBackground,
+                      onTap: _scanQrAndConnect,
+                    ),
                   CupertinoSettingsTile(
                     leading: Icon(
                       CupertinoIcons.refresh,

--- a/lib/themes/nipaplay/pages/settings/labs_page.dart
+++ b/lib/themes/nipaplay/pages/settings/labs_page.dart
@@ -29,6 +29,19 @@ class LabsPage extends StatelessWidget {
               color: colorScheme.onSurface.withValues(alpha: 0.12),
               height: 1,
             ),
+            SettingsItem.toggle(
+              title: '显示远程访问二维码',
+              subtitle: '开启后，远程访问服务页面会显示供手机扫码连接的二维码',
+              icon: Ionicons.qr_code_outline,
+              value: labsSettings.showRemoteAccessQrCode,
+              onChanged: (bool value) {
+                labsSettings.setShowRemoteAccessQrCode(value);
+              },
+            ),
+            Divider(
+              color: colorScheme.onSurface.withValues(alpha: 0.12),
+              height: 1,
+            ),
             SettingsItem.button(
               title: 'WebDAV 快捷设置',
               subtitle: '配置底部 WebDAV 快捷 Tab，快速访问 WebDAV 服务器',

--- a/lib/themes/nipaplay/pages/settings/remote_access_page.dart
+++ b/lib/themes/nipaplay/pages/settings/remote_access_page.dart
@@ -1,6 +1,7 @@
 // remote_access_page.dart
 import 'package:flutter/material.dart';
 import 'package:kmbal_ionicons/kmbal_ionicons.dart';
+import 'package:nipaplay/providers/labs_settings_provider.dart';
 import 'package:nipaplay/providers/service_provider.dart';
 import 'package:nipaplay/services/remote_control_access_guard_service.dart';
 import 'package:nipaplay/services/remote_access_qr_service.dart';
@@ -13,6 +14,7 @@ import 'package:http/http.dart' as http;
 import 'package:nipaplay/services/remote_control_settings.dart';
 import 'package:nipaplay/utils/remote_access_address_utils.dart';
 import 'package:nipaplay/utils/app_accent_color.dart';
+import 'package:provider/provider.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 
 class RemoteAccessPage extends StatefulWidget {
@@ -377,6 +379,8 @@ class _RemoteAccessPageState extends State<RemoteAccessPage> {
 
   Widget _buildWebServerSection() {
     final colorScheme = Theme.of(context).colorScheme;
+    final showRemoteAccessQrCode =
+        context.watch<LabsSettingsProvider>().showRemoteAccessQrCode;
     return DefaultTextStyle.merge(
       style: _pageTextStyle(context),
       child: Column(
@@ -463,7 +467,7 @@ class _RemoteAccessPageState extends State<RemoteAccessPage> {
           if (_webServerEnabled) ...[
             // 访问地址
             _buildAccessAddressSection(),
-            _buildRemoteAccessQrSection(),
+            if (showRemoteAccessQrCode) _buildRemoteAccessQrSection(),
 
             SizedBox(height: 8),
             Divider(

--- a/lib/themes/nipaplay/pages/settings/remote_access_page.dart
+++ b/lib/themes/nipaplay/pages/settings/remote_access_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:kmbal_ionicons/kmbal_ionicons.dart';
 import 'package:nipaplay/providers/service_provider.dart';
 import 'package:nipaplay/services/remote_control_access_guard_service.dart';
+import 'package:nipaplay/services/remote_access_qr_service.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_snackbar.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_dialog.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/fluent_settings_switch.dart';
@@ -12,6 +13,7 @@ import 'package:http/http.dart' as http;
 import 'package:nipaplay/services/remote_control_settings.dart';
 import 'package:nipaplay/utils/remote_access_address_utils.dart';
 import 'package:nipaplay/utils/app_accent_color.dart';
+import 'package:qr_flutter/qr_flutter.dart';
 
 class RemoteAccessPage extends StatefulWidget {
   const RemoteAccessPage({super.key});
@@ -461,6 +463,7 @@ class _RemoteAccessPageState extends State<RemoteAccessPage> {
           if (_webServerEnabled) ...[
             // 访问地址
             _buildAccessAddressSection(),
+            _buildRemoteAccessQrSection(),
 
             SizedBox(height: 8),
             Divider(
@@ -483,6 +486,26 @@ class _RemoteAccessPageState extends State<RemoteAccessPage> {
         ],
       ),
     );
+  }
+
+  String? get _recommendedQrUrl {
+    String? firstLan;
+    String? firstReachable;
+
+    for (final url in _accessUrls) {
+      final type = RemoteAccessAddressUtils.classifyUrl(url);
+      if (type == RemoteAccessAddressType.lan) {
+        firstLan ??= url;
+      }
+      if (type != RemoteAccessAddressType.local) {
+        firstReachable ??= url;
+      }
+    }
+
+    return firstLan ??
+        _publicIpUrl ??
+        firstReachable ??
+        (_accessUrls.isNotEmpty ? _accessUrls.first : null);
   }
 
   Widget _buildAccessAddressSection() {
@@ -562,6 +585,113 @@ class _RemoteAccessPageState extends State<RemoteAccessPage> {
                   _buildAddressItem(_publicIpUrl!),
               ],
             ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildRemoteAccessQrSection() {
+    final colorScheme = Theme.of(context).colorScheme;
+    final qrUrl = _recommendedQrUrl;
+
+    return Padding(
+      padding: const EdgeInsets.only(top: 14.0, bottom: 8.0),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(
+            Icons.qr_code_2,
+            color: colorScheme.onSurface.withValues(alpha: 0.7),
+            size: 20,
+          ),
+          SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '手机扫码连接',
+                  style: TextStyle(
+                    color: colorScheme.onSurface,
+                    fontWeight: FontWeight.w500,
+                    fontSize: 15,
+                  ),
+                ),
+                SizedBox(height: 6),
+                Text(
+                  '手机端在共享媒体库或远程访问页面点击扫码，拍摄此二维码后会同时连接共享媒体库与遥控器。',
+                  style: TextStyle(
+                    color: colorScheme.onSurface.withValues(alpha: 0.7),
+                    fontSize: 13,
+                    height: 1.35,
+                  ),
+                ),
+                SizedBox(height: 12),
+                if (qrUrl == null)
+                  Text(
+                    '正在生成二维码...',
+                    style: TextStyle(
+                      color: colorScheme.onSurface.withValues(alpha: 0.7),
+                    ),
+                  )
+                else
+                  Wrap(
+                    spacing: 16,
+                    runSpacing: 12,
+                    crossAxisAlignment: WrapCrossAlignment.center,
+                    children: [
+                      Container(
+                        padding: const EdgeInsets.all(10),
+                        decoration: BoxDecoration(
+                          color: Colors.white,
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: QrImageView(
+                          data: RemoteAccessQrService.buildPayload(
+                            baseUrl: qrUrl,
+                          ),
+                          version: QrVersions.auto,
+                          size: 168,
+                          backgroundColor: Colors.white,
+                        ),
+                      ),
+                      ConstrainedBox(
+                        constraints: const BoxConstraints(maxWidth: 420),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(
+                              '二维码地址',
+                              style: TextStyle(
+                                color: colorScheme.onSurface
+                                    .withValues(alpha: 0.55),
+                                fontSize: 12,
+                              ),
+                            ),
+                            SizedBox(height: 6),
+                            SelectableText(
+                              qrUrl,
+                              style: _monospaceStyle(
+                                context,
+                                colorScheme.onSurface.withValues(alpha: 0.75),
+                              ).copyWith(fontSize: 13),
+                            ),
+                            SizedBox(height: 8),
+                            HoverScaleTextButton(
+                              text: '复制地址',
+                              idleColor: colorScheme.primary,
+                              hoverColor: colorScheme.primary,
+                              onPressed: () => _copyUrl(qrUrl),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+              ],
+            ),
+          ),
         ],
       ),
     );

--- a/lib/themes/nipaplay/widgets/shared_remote_library_settings_section.dart
+++ b/lib/themes/nipaplay/widgets/shared_remote_library_settings_section.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import 'package:nipaplay/providers/shared_remote_library_provider.dart';
+import 'package:nipaplay/services/remote_access_qr_service.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_dialog.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_snackbar.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_login_dialog.dart';
@@ -96,15 +97,7 @@ class SharedRemoteLibrarySettingsSection extends StatelessWidget {
           style: TextStyle(color: colorScheme.onSurface.withOpacity(0.7)),
         ),
         SizedBox(height: 16),
-        SizedBox(
-          width: double.infinity,
-          child: _buildGlassButton(
-            context: context,
-            onPressed: () => _showAddHostDialog(context, provider),
-            icon: Icons.add,
-            label: '新增客户端',
-          ),
-        ),
+        _buildConnectButtons(context, provider),
       ],
     );
   }
@@ -235,17 +228,74 @@ class SharedRemoteLibrarySettingsSection extends StatelessWidget {
           );
         }).toList(),
         SizedBox(height: 12),
-        SizedBox(
-          width: double.infinity,
-          child: _buildGlassButton(
-            context: context,
-            onPressed: () => _showAddHostDialog(context, provider),
-            icon: Icons.add,
-            label: '新增客户端',
-          ),
-        ),
+        _buildConnectButtons(context, provider),
       ],
     );
+  }
+
+  Widget _buildConnectButtons(
+    BuildContext context,
+    SharedRemoteLibraryProvider provider,
+  ) {
+    final addButton = _buildGlassButton(
+      context: context,
+      onPressed: () => _showAddHostDialog(context, provider),
+      icon: Icons.add,
+      label: '新增客户端',
+    );
+
+    if (!RemoteAccessQrCameraScanner.isSupported) {
+      return SizedBox(width: double.infinity, child: addButton);
+    }
+
+    return Row(
+      children: [
+        Expanded(
+          child: _buildGlassButton(
+            context: context,
+            onPressed: () => _connectByQr(context, provider),
+            icon: Icons.qr_code_scanner,
+            label: '扫码连接',
+          ),
+        ),
+        SizedBox(width: 12),
+        Expanded(child: addButton),
+      ],
+    );
+  }
+
+  Future<void> _connectByQr(
+    BuildContext context,
+    SharedRemoteLibraryProvider provider,
+  ) async {
+    try {
+      final payload = await RemoteAccessQrCameraScanner.scan();
+      if (payload == null) return;
+
+      final info = await RemoteAccessQrService.fetchServerInfo(payload.baseUrl);
+      if (info == null) {
+        if (context.mounted) {
+          BlurSnackBar.show(context, '未识别到可访问的 NipaPlay 远程访问服务');
+        }
+        return;
+      }
+
+      final displayName = payload.displayName?.trim().isNotEmpty == true
+          ? payload.displayName!.trim()
+          : info.displayName;
+      await provider.connectOrActivateHost(
+        displayName: displayName,
+        baseUrl: info.baseUrl,
+      );
+
+      if (context.mounted) {
+        BlurSnackBar.show(context, '已连接共享媒体库与遥控器');
+      }
+    } catch (e) {
+      if (context.mounted) {
+        BlurSnackBar.show(context, '扫码连接失败：$e');
+      }
+    }
   }
 
   Future<void> _showAddHostDialog(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1813,6 +1813,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
+  zxing2:
+    dependency: "direct main"
+    description:
+      name: zxing2
+      sha256: "2677c49a3b9ca9457cb1d294fd4bd5041cac6aab8cdb07b216ba4e98945c684f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.4"
 sdks:
   dart: ">=3.10.3 <4.0.0"
   flutter: ">=3.38.4"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -82,6 +82,7 @@ dependencies:
   media_kit_libs_video:
     path: third_party/media-kit-upstream/libs/universal/media_kit_libs_video
   qr_flutter: ^4.1.0  # 用于生成二维码
+  zxing2: ^0.2.4  # 用于识别远程访问二维码
   flutter_svg: ^2.0.14  # 用于显示SVG图标
   flutter_markdown: ^0.7.1
   desktop_drop: ^0.6.1


### PR DESCRIPTION
## Summary
- Add an off-by-default Labs switch for showing the remote access QR code, so the untested QR display stays hidden unless explicitly enabled.
- Show a QR code on the remote access settings page only when remote access is enabled and the Labs switch is on, preferring a LAN/reachable address for phones to scan.
- Add mobile camera-based QR connection flows in the shared media library and remote controller pages.
- Keep shared media library hosts and the remote controller matched target in sync so one connection also enables the other side.

## Testing
- /Library/Afolder/FlutterProject/flutter/bin/dart format lib/constants/settings_keys.dart lib/providers/labs_settings_provider.dart lib/themes/nipaplay/pages/settings/labs_page.dart lib/themes/cupertino/pages/settings/pages/cupertino_labs_settings_page.dart lib/themes/nipaplay/pages/settings/remote_access_page.dart
- /Library/Afolder/FlutterProject/flutter/bin/dart analyze lib/constants/settings_keys.dart lib/providers/labs_settings_provider.dart lib/themes/nipaplay/pages/settings/labs_page.dart lib/themes/cupertino/pages/settings/pages/cupertino_labs_settings_page.dart lib/themes/nipaplay/pages/settings/remote_access_page.dart (passes with existing prefer_const_constructors info in remote_access_page.dart)
- flutter pub get --offline
- dart format lib/services/remote_access_qr_service.dart lib/themes/nipaplay/pages/settings/remote_access_page.dart lib/themes/nipaplay/widgets/shared_remote_library_settings_section.dart lib/themes/cupertino/pages/cupertino_media_library_page.dart lib/themes/cupertino/pages/settings/pages/cupertino_remote_controller_settings_page.dart lib/providers/shared_remote_library_provider.dart
- dart analyze lib/services/remote_access_qr_service.dart lib/themes/cupertino/pages/settings/pages/cupertino_remote_controller_settings_page.dart

Note: the downloader history persistence experiment was reverted before this PR; this branch does not include those changes.