### PR TITLE
optimize next danmaku performance and default mobile outline to stroke

### DIFF
--- a/lib/danmaku_abstraction/positioned_danmaku_item.dart
+++ b/lib/danmaku_abstraction/positioned_danmaku_item.dart
@@ -1,14 +1,14 @@
-import 'package:flutter/material.dart';
 import 'danmaku_content_item.dart';
 
-/// A data class that represents a danmaku item with its calculated position.
-/// This is used to pass layout information from the CPU logic (DanmakuContainer)
-/// to the GPU renderer (GPUDanmakuOverlay).
+/// Mutable layout result for a danmaku item.
+///
+/// x/y/offstageX are intentionally mutable so layout results can be reused
+/// across frames without creating new objects every tick.
 class PositionedDanmakuItem {
   final DanmakuContentItem content;
-  final double x;
-  final double y;
-  final double offstageX; // The starting X position when it's off-screen
+  double x;
+  double y;
+  double offstageX;
   final double time; // The original time of the danmaku
 
   PositionedDanmakuItem({
@@ -18,4 +18,4 @@ class PositionedDanmakuItem {
     required this.offstageX,
     required this.time,
   });
-} 
+}

--- a/lib/danmaku_next/nipaplay_next_canvas_painter.dart
+++ b/lib/danmaku_next/nipaplay_next_canvas_painter.dart
@@ -1,22 +1,28 @@
 import 'dart:math' as math;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:nipaplay/danmaku_abstraction/danmaku_content_item.dart';
-import 'package:nipaplay/danmaku_abstraction/positioned_danmaku_item.dart';
 import 'package:nipaplay/utils/video_player_state.dart';
+
+import 'nipaplay_next_engine.dart';
 
 class NipaPlayNextCanvasPainter extends CustomPainter {
   NipaPlayNextCanvasPainter({
-    required this.items,
+    required this.engine,
+    required this.playbackTimeMs,
+    required this.timeOffsetSeconds,
     required this.fontSize,
     required this.fontFamily,
     required this.fontFamilyFallback,
     required this.locale,
     required this.outlineStyle,
     required this.shadowStyle,
-  });
+  }) : super(repaint: playbackTimeMs);
 
-  final List<PositionedDanmakuItem> items;
+  final NipaPlayNextEngine engine;
+  final ValueListenable<double> playbackTimeMs;
+  final double timeOffsetSeconds;
   final double fontSize;
   final String? fontFamily;
   final List<String>? fontFamilyFallback;
@@ -35,6 +41,8 @@ class NipaPlayNextCanvasPainter extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
+    final items =
+        engine.layout(playbackTimeMs.value / 1000.0 + timeOffsetSeconds);
     if (items.isEmpty) return;
 
     for (final item in items) {
@@ -355,8 +363,8 @@ class NipaPlayNextCanvasPainter extends CustomPainter {
       fillPainter.width + expanded * 2,
       fillPainter.height + expanded * 2,
     );
-    final filterPaint =
-        Paint()..colorFilter = ColorFilter.mode(outlineColor, BlendMode.srcIn);
+    final filterPaint = Paint()
+      ..colorFilter = ColorFilter.mode(outlineColor, BlendMode.srcIn);
 
     for (final offset in _buildUniformOffsets(radius)) {
       canvas.saveLayer(baseBounds.shift(offset), filterPaint);
@@ -367,7 +375,8 @@ class NipaPlayNextCanvasPainter extends CustomPainter {
 
   @override
   bool shouldRepaint(covariant NipaPlayNextCanvasPainter oldDelegate) {
-    return oldDelegate.items != items ||
+    return oldDelegate.engine != engine ||
+        oldDelegate.timeOffsetSeconds != timeOffsetSeconds ||
         oldDelegate.fontSize != fontSize ||
         oldDelegate.fontFamily != fontFamily ||
         oldDelegate.outlineStyle != outlineStyle ||

--- a/lib/danmaku_next/nipaplay_next_canvas_painter.dart
+++ b/lib/danmaku_next/nipaplay_next_canvas_painter.dart
@@ -1,3 +1,4 @@
+import 'dart:collection';
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
@@ -29,11 +30,19 @@ class NipaPlayNextCanvasPainter extends CustomPainter {
   final Locale? locale;
   final DanmakuOutlineStyle outlineStyle;
   final DanmakuShadowStyle shadowStyle;
+  late final String? _fontFamilyFallbackKey =
+      fontFamilyFallback?.join('\u0000');
 
   static const int _cacheLimit = 2000;
-  static final Map<_TextCacheKey, TextPainter> _fillCache = {};
-  static final Map<_TextCacheKey, TextPainter> _strokeCache = {};
-  static final Map<_TextCacheKey, TextPainter> _shadowCache = {};
+  static const int _emojiCacheLimit = 4000;
+  static final LinkedHashMap<_TextCacheKey, TextPainter> _fillCache =
+      LinkedHashMap<_TextCacheKey, TextPainter>();
+  static final LinkedHashMap<_TextCacheKey, TextPainter> _strokeCache =
+      LinkedHashMap<_TextCacheKey, TextPainter>();
+  static final LinkedHashMap<_TextCacheKey, TextPainter> _shadowCache =
+      LinkedHashMap<_TextCacheKey, TextPainter>();
+  static final LinkedHashMap<String, bool> _emojiCache =
+      LinkedHashMap<String, bool>();
   static final Paint _selfSendPaint = Paint()
     ..style = PaintingStyle.stroke
     ..strokeWidth = 1.5
@@ -48,15 +57,6 @@ class NipaPlayNextCanvasPainter extends CustomPainter {
     for (final item in items) {
       final content = item.content;
       final adjustedFontSize = fontSize * content.fontSizeMultiplier;
-      final containsEmoji = _containsEmoji(content.text);
-      final strokeColor = _getStrokeColor(
-        textColor: content.color,
-      );
-      final shadowConfig = _resolveShadowStyle(adjustedFontSize);
-      final strokeWidth = _resolveStrokeWidth(adjustedFontSize);
-      final uniformOutlineRadius =
-          _resolveUniformOutlineRadius(adjustedFontSize);
-
       final fillPainter = _getFillPainter(
         content: content,
         fontSize: adjustedFontSize,
@@ -64,20 +64,28 @@ class NipaPlayNextCanvasPainter extends CustomPainter {
       );
 
       final baseOffset = Offset(item.x, item.y);
-      if (shadowConfig != null) {
-        final shadowPainter = _getShadowPainter(
-          content: content,
-          fontSize: adjustedFontSize,
-          color: Color.fromRGBO(0, 0, 0, shadowConfig.opacity),
-          blurSigma: shadowConfig.blurSigma,
-        );
-        shadowPainter.paint(canvas, baseOffset + shadowConfig.offset);
+      if (shadowStyle != DanmakuShadowStyle.none) {
+        final shadowConfig = _resolveShadowStyle(adjustedFontSize);
+        if (shadowConfig != null) {
+          final shadowPainter = _getShadowPainter(
+            content: content,
+            fontSize: adjustedFontSize,
+            color: Color.fromRGBO(0, 0, 0, shadowConfig.opacity),
+            blurSigma: shadowConfig.blurSigma,
+          );
+          shadowPainter.paint(canvas, baseOffset + shadowConfig.offset);
+        }
       }
 
       switch (outlineStyle) {
         case DanmakuOutlineStyle.none:
           break;
         case DanmakuOutlineStyle.stroke:
+          final containsEmoji = _containsEmojiCached(content.text);
+          final strokeColor = _getStrokeColor(
+            textColor: content.color,
+          );
+          final strokeWidth = _resolveStrokeWidth(adjustedFontSize);
           if (containsEmoji) {
             _paintEmojiOutline(
               canvas: canvas,
@@ -97,6 +105,12 @@ class NipaPlayNextCanvasPainter extends CustomPainter {
           }
           break;
         case DanmakuOutlineStyle.uniform:
+          final containsEmoji = _containsEmojiCached(content.text);
+          final strokeColor = _getStrokeColor(
+            textColor: content.color,
+          );
+          final uniformOutlineRadius =
+              _resolveUniformOutlineRadius(adjustedFontSize);
           if (containsEmoji) {
             _paintEmojiOutline(
               canvas: canvas,
@@ -111,9 +125,12 @@ class NipaPlayNextCanvasPainter extends CustomPainter {
               fontSize: adjustedFontSize,
               color: strokeColor,
             );
-            for (final offset in _buildUniformOffsets(uniformOutlineRadius)) {
-              outlinePainter.paint(canvas, baseOffset + offset);
-            }
+            _paintUniformOutline(
+              canvas: canvas,
+              painter: outlinePainter,
+              baseOffset: baseOffset,
+              radius: uniformOutlineRadius,
+            );
           }
           break;
       }
@@ -181,7 +198,6 @@ class NipaPlayNextCanvasPainter extends CustomPainter {
     required _PainterVariant variant,
     double effectValue = 0.0,
   }) {
-    final fallbackKey = fontFamilyFallback?.join('\u0000');
     final key = _TextCacheKey(
       text: content.text,
       countText: content.countText,
@@ -190,7 +206,7 @@ class NipaPlayNextCanvasPainter extends CustomPainter {
       variant: variant,
       effectValue: effectValue,
       fontFamily: fontFamily,
-      fontFamilyFallbackKey: fallbackKey,
+      fontFamilyFallbackKey: _fontFamilyFallbackKey,
       locale: locale,
     );
 
@@ -200,7 +216,11 @@ class NipaPlayNextCanvasPainter extends CustomPainter {
       _PainterVariant.shadow => _shadowCache,
     };
     final cached = cache[key];
-    if (cached != null) return cached;
+    if (cached != null) {
+      cache.remove(key);
+      cache[key] = cached;
+      return cached;
+    }
 
     final paint = Paint()
       ..color = color
@@ -239,24 +259,20 @@ class NipaPlayNextCanvasPainter extends CustomPainter {
       locale: locale,
     )..layout(minWidth: 0, maxWidth: double.infinity);
 
-    if (cache.length > _cacheLimit) {
-      cache.clear();
-    }
-    cache[key] = painter;
+    _insertWithBound(cache, key, painter, _cacheLimit);
     return painter;
   }
 
-  List<Offset> _buildUniformOffsets(double radius) {
-    return <Offset>[
-      Offset(-radius, 0),
-      Offset(radius, 0),
-      Offset(0, -radius),
-      Offset(0, radius),
-      Offset(-radius, -radius),
-      Offset(radius, -radius),
-      Offset(-radius, radius),
-      Offset(radius, radius),
-    ];
+  static void _insertWithBound<K, V>(
+    LinkedHashMap<K, V> cache,
+    K key,
+    V value,
+    int limit,
+  ) {
+    if (cache.length >= limit && cache.isNotEmpty) {
+      cache.remove(cache.keys.first);
+    }
+    cache[key] = value;
   }
 
   _ShadowConfig? _resolveShadowStyle(double targetFontSize) {
@@ -334,6 +350,18 @@ class NipaPlayNextCanvasPainter extends CustomPainter {
     return color.r <= epsilon && color.g <= epsilon && color.b <= epsilon;
   }
 
+  bool _containsEmojiCached(String text) {
+    final cached = _emojiCache[text];
+    if (cached != null) {
+      _emojiCache.remove(text);
+      _emojiCache[text] = cached;
+      return cached;
+    }
+    final result = _containsEmoji(text);
+    _insertWithBound(_emojiCache, text, result, _emojiCacheLimit);
+    return result;
+  }
+
   bool _containsEmoji(String text) {
     for (final rune in text.runes) {
       if (_isEmojiRune(rune)) return true;
@@ -366,11 +394,121 @@ class NipaPlayNextCanvasPainter extends CustomPainter {
     final filterPaint = Paint()
       ..colorFilter = ColorFilter.mode(outlineColor, BlendMode.srcIn);
 
-    for (final offset in _buildUniformOffsets(radius)) {
-      canvas.saveLayer(baseBounds.shift(offset), filterPaint);
-      fillPainter.paint(canvas, baseOffset + offset);
-      canvas.restore();
-    }
+    _paintEmojiOutlineDirection(
+      canvas: canvas,
+      fillPainter: fillPainter,
+      baseOffset: baseOffset,
+      baseBounds: baseBounds,
+      filterPaint: filterPaint,
+      dx: -radius,
+      dy: 0,
+    );
+    _paintEmojiOutlineDirection(
+      canvas: canvas,
+      fillPainter: fillPainter,
+      baseOffset: baseOffset,
+      baseBounds: baseBounds,
+      filterPaint: filterPaint,
+      dx: radius,
+      dy: 0,
+    );
+    _paintEmojiOutlineDirection(
+      canvas: canvas,
+      fillPainter: fillPainter,
+      baseOffset: baseOffset,
+      baseBounds: baseBounds,
+      filterPaint: filterPaint,
+      dx: 0,
+      dy: -radius,
+    );
+    _paintEmojiOutlineDirection(
+      canvas: canvas,
+      fillPainter: fillPainter,
+      baseOffset: baseOffset,
+      baseBounds: baseBounds,
+      filterPaint: filterPaint,
+      dx: 0,
+      dy: radius,
+    );
+    _paintEmojiOutlineDirection(
+      canvas: canvas,
+      fillPainter: fillPainter,
+      baseOffset: baseOffset,
+      baseBounds: baseBounds,
+      filterPaint: filterPaint,
+      dx: -radius,
+      dy: -radius,
+    );
+    _paintEmojiOutlineDirection(
+      canvas: canvas,
+      fillPainter: fillPainter,
+      baseOffset: baseOffset,
+      baseBounds: baseBounds,
+      filterPaint: filterPaint,
+      dx: radius,
+      dy: -radius,
+    );
+    _paintEmojiOutlineDirection(
+      canvas: canvas,
+      fillPainter: fillPainter,
+      baseOffset: baseOffset,
+      baseBounds: baseBounds,
+      filterPaint: filterPaint,
+      dx: -radius,
+      dy: radius,
+    );
+    _paintEmojiOutlineDirection(
+      canvas: canvas,
+      fillPainter: fillPainter,
+      baseOffset: baseOffset,
+      baseBounds: baseBounds,
+      filterPaint: filterPaint,
+      dx: radius,
+      dy: radius,
+    );
+  }
+
+  void _paintUniformOutline({
+    required Canvas canvas,
+    required TextPainter painter,
+    required Offset baseOffset,
+    required double radius,
+  }) {
+    painter.paint(canvas, Offset(baseOffset.dx - radius, baseOffset.dy));
+    painter.paint(canvas, Offset(baseOffset.dx + radius, baseOffset.dy));
+    painter.paint(canvas, Offset(baseOffset.dx, baseOffset.dy - radius));
+    painter.paint(canvas, Offset(baseOffset.dx, baseOffset.dy + radius));
+    painter.paint(
+      canvas,
+      Offset(baseOffset.dx - radius, baseOffset.dy - radius),
+    );
+    painter.paint(
+      canvas,
+      Offset(baseOffset.dx + radius, baseOffset.dy - radius),
+    );
+    painter.paint(
+      canvas,
+      Offset(baseOffset.dx - radius, baseOffset.dy + radius),
+    );
+    painter.paint(
+      canvas,
+      Offset(baseOffset.dx + radius, baseOffset.dy + radius),
+    );
+  }
+
+  void _paintEmojiOutlineDirection({
+    required Canvas canvas,
+    required TextPainter fillPainter,
+    required Offset baseOffset,
+    required Rect baseBounds,
+    required Paint filterPaint,
+    required double dx,
+    required double dy,
+  }) {
+    final shift = Offset(dx, dy);
+    canvas.saveLayer(baseBounds.shift(shift), filterPaint);
+    fillPainter.paint(canvas, baseOffset + shift);
+    canvas.restore();
   }
 
   @override

--- a/lib/danmaku_next/nipaplay_next_canvas_painter.dart
+++ b/lib/danmaku_next/nipaplay_next_canvas_painter.dart
@@ -30,6 +30,7 @@ class NipaPlayNextCanvasPainter extends CustomPainter {
   final Locale? locale;
   final DanmakuOutlineStyle outlineStyle;
   final DanmakuShadowStyle shadowStyle;
+  late final int _layoutVersion = engine.layoutVersion;
   late final String? _fontFamilyFallbackKey =
       fontFamilyFallback?.join('\u0000');
 
@@ -513,7 +514,8 @@ class NipaPlayNextCanvasPainter extends CustomPainter {
 
   @override
   bool shouldRepaint(covariant NipaPlayNextCanvasPainter oldDelegate) {
-    return oldDelegate.engine != engine ||
+    return oldDelegate._layoutVersion != _layoutVersion ||
+        oldDelegate.engine != engine ||
         oldDelegate.timeOffsetSeconds != timeOffsetSeconds ||
         oldDelegate.fontSize != fontSize ||
         oldDelegate.fontFamily != fontFamily ||

--- a/lib/danmaku_next/nipaplay_next_engine.dart
+++ b/lib/danmaku_next/nipaplay_next_engine.dart
@@ -28,6 +28,7 @@ class NipaPlayNextEngine {
 
   final List<_NextItem> _items = [];
   final List<double> _itemTimes = [];
+  final List<PositionedDanmakuItem> _positionedBuffer = [];
   bool _layoutDirty = true;
 
   void configure({
@@ -109,7 +110,7 @@ class NipaPlayNextEngine {
     final left = _lowerBound(windowStart);
     final right = _upperBound(currentTimeSeconds);
 
-    final List<PositionedDanmakuItem> positioned = [];
+    _positionedBuffer.clear();
 
     for (int i = left; i < right; i++) {
       final item = _items[i];
@@ -122,29 +123,23 @@ class NipaPlayNextEngine {
         case DanmakuItemType.scroll:
           if (elapsed > _scrollDurationSeconds) continue;
           final x = _size.width - item.scrollSpeed * elapsed;
-          positioned.add(
-            PositionedDanmakuItem(
-              content: item.content,
-              x: x,
-              y: item.yPosition,
-              offstageX: _size.width + item.width,
-              time: item.timeSeconds,
-            ),
-          );
+          _positionedBuffer.add(_toPositionedItem(
+            source: item,
+            x: x,
+            y: item.yPosition,
+            offstageX: _size.width + item.width,
+          ));
           break;
         case DanmakuItemType.top:
         case DanmakuItemType.bottom:
           if (elapsed > _staticDurationSeconds) continue;
           final x = (_size.width - item.width) / 2;
-          positioned.add(
-            PositionedDanmakuItem(
-              content: item.content,
-              x: x,
-              y: item.yPosition,
-              offstageX: _size.width,
-              time: item.timeSeconds,
-            ),
-          );
+          _positionedBuffer.add(_toPositionedItem(
+            source: item,
+            x: x,
+            y: item.yPosition,
+            offstageX: _size.width,
+          ));
           break;
       }
     }
@@ -152,10 +147,35 @@ class NipaPlayNextEngine {
     DanmakuNextLog.d(
       'Engine',
       'layout time=${currentTimeSeconds.toStringAsFixed(2)} window=[$windowStart..$currentTimeSeconds] '
-      'range=[$left,$right) out=${positioned.length}',
+          'range=[$left,$right) out=${_positionedBuffer.length}',
       throttle: const Duration(seconds: 1),
     );
-    return positioned;
+    return _positionedBuffer;
+  }
+
+  PositionedDanmakuItem _toPositionedItem({
+    required _NextItem source,
+    required double x,
+    required double y,
+    required double offstageX,
+  }) {
+    final existing = source.positionedItem;
+    if (existing == null) {
+      final created = PositionedDanmakuItem(
+        content: source.content,
+        x: x,
+        y: y,
+        offstageX: offstageX,
+        time: source.timeSeconds,
+      );
+      source.positionedItem = created;
+      return created;
+    }
+
+    existing.x = x;
+    existing.y = y;
+    existing.offstageX = offstageX;
+    return existing;
   }
 
   void _parseDanmakuList(List<Map<String, dynamic>> danmakuList) {
@@ -182,9 +202,8 @@ class NipaPlayNextEngine {
         type: type,
         color: color,
         isMe: isMe,
-        fontSizeMultiplier: isMerged
-            ? _calcMergedFontSizeMultiplier(mergeCount)
-            : 1.0,
+        fontSizeMultiplier:
+            isMerged ? _calcMergedFontSizeMultiplier(mergeCount) : 1.0,
         countText: isMerged ? 'x$mergeCount' : null,
       );
 
@@ -246,7 +265,7 @@ class NipaPlayNextEngine {
     DanmakuNextLog.d(
       'Engine',
       'layout rebuild tracks=$trackCount font=${_fontSize.toStringAsFixed(1)} area=${_displayArea.toStringAsFixed(2)} '
-      'scroll=${_scrollDurationSeconds.toStringAsFixed(1)} stacking=$_allowStacking',
+          'scroll=${_scrollDurationSeconds.toStringAsFixed(1)} stacking=$_allowStacking',
       throttle: Duration.zero,
     );
 
@@ -334,8 +353,7 @@ class NipaPlayNextEngine {
 
     final List<double> scrollTrackOffsets =
         List<double>.filled(trackCount, 0.0);
-    final List<double> topTrackOffsets =
-        List<double>.filled(trackCount, 0.0);
+    final List<double> topTrackOffsets = List<double>.filled(trackCount, 0.0);
     final List<double> bottomTrackOffsets =
         List<double>.filled(trackCount, 0.0);
 
@@ -697,6 +715,7 @@ class _NextItem {
   final DanmakuContentItem content;
   final DanmakuItemType type;
 
+  PositionedDanmakuItem? positionedItem;
   int trackIndex = -1;
   double yPosition = 0.0;
   double width = 0.0;

--- a/lib/danmaku_next/nipaplay_next_engine.dart
+++ b/lib/danmaku_next/nipaplay_next_engine.dart
@@ -32,6 +32,9 @@ class NipaPlayNextEngine {
   final List<double> _itemTimes = [];
   final List<PositionedDanmakuItem> _positionedBuffer = [];
   bool _layoutDirty = true;
+  int _layoutVersion = 0;
+
+  int get layoutVersion => _layoutVersion;
 
   void configure({
     required List<Map<String, dynamic>> danmakuList,
@@ -238,6 +241,7 @@ class NipaPlayNextEngine {
 
   void _rebuildLayout() {
     _layoutDirty = false;
+    _layoutVersion++;
 
     if (_items.isEmpty || _size.isEmpty) {
       DanmakuNextLog.d(

--- a/lib/danmaku_next/nipaplay_next_engine.dart
+++ b/lib/danmaku_next/nipaplay_next_engine.dart
@@ -1,3 +1,4 @@
+import 'dart:collection';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
@@ -20,7 +21,8 @@ class NipaPlayNextEngine {
   Locale? _locale;
   int _sourceListIdentity = 0;
 
-  final Map<String, double> _textWidthCache = {};
+  final LinkedHashMap<String, double> _textWidthCache =
+      LinkedHashMap<String, double>();
   static const int _textWidthCacheLimit = 5000;
   static const double _mergeWindowSeconds = 45.0;
   static const double _minTrackGap = 2.0;
@@ -633,7 +635,11 @@ class NipaPlayNextEngine {
   double _measureTextWidth(String text, double fontSize) {
     final key = '$fontSize|$text';
     final cached = _textWidthCache[key];
-    if (cached != null) return cached;
+    if (cached != null) {
+      _textWidthCache.remove(key);
+      _textWidthCache[key] = cached;
+      return cached;
+    }
 
     final tp = TextPainter(
       text: TextSpan(
@@ -650,8 +656,9 @@ class NipaPlayNextEngine {
     )..layout(minWidth: 0, maxWidth: double.infinity);
 
     final width = tp.size.width;
-    if (_textWidthCache.length > _textWidthCacheLimit) {
-      _textWidthCache.clear();
+    if (_textWidthCache.length >= _textWidthCacheLimit &&
+        _textWidthCache.isNotEmpty) {
+      _textWidthCache.remove(_textWidthCache.keys.first);
     }
     _textWidthCache[key] = width;
     return width;

--- a/lib/danmaku_next/nipaplay_next_overlay.dart
+++ b/lib/danmaku_next/nipaplay_next_overlay.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 import 'package:nipaplay/danmaku_abstraction/positioned_danmaku_item.dart';
 import 'package:nipaplay/danmaku_next/nipaplay_next_canvas_painter.dart';
 import 'package:nipaplay/danmaku_next/nipaplay_next_engine.dart';
@@ -13,6 +14,7 @@ const Locale _danmakuLocale = Locale.fromSubtags(
 
 class NipaPlayNextOverlay extends StatefulWidget {
   final List<Map<String, dynamic>> danmakuList;
+  final ValueListenable<double> playbackTimeMs;
   final double currentTimeSeconds;
   final double fontSize;
   final bool isVisible;
@@ -30,6 +32,7 @@ class NipaPlayNextOverlay extends StatefulWidget {
   const NipaPlayNextOverlay({
     super.key,
     required this.danmakuList,
+    required this.playbackTimeMs,
     required this.currentTimeSeconds,
     required this.fontSize,
     required this.isVisible,
@@ -52,11 +55,14 @@ class NipaPlayNextOverlay extends StatefulWidget {
 class _NipaPlayNextOverlayState extends State<NipaPlayNextOverlay> {
   final NipaPlayNextEngine _engine = NipaPlayNextEngine();
   int _listIdentity = 0;
+  Size _lastConfiguredSize = Size.zero;
+  bool _layoutSnapshotPending = false;
 
   @override
   void initState() {
     super.initState();
     _listIdentity = identityHashCode(widget.danmakuList);
+    _layoutSnapshotPending = true;
     DanmakuNextLog.d(
       'Overlay',
       'init list=${widget.danmakuList.length} font=${widget.fontSize} visible=${widget.isVisible}',
@@ -79,6 +85,7 @@ class _NipaPlayNextOverlayState extends State<NipaPlayNextOverlay> {
     final listIdentity = identityHashCode(widget.danmakuList);
     if (listIdentity != _listIdentity) {
       _listIdentity = listIdentity;
+      _layoutSnapshotPending = true;
       DanmakuNextLog.d(
         'Overlay',
         'danmaku list changed size=${widget.danmakuList.length}',
@@ -120,6 +127,9 @@ class _NipaPlayNextOverlayState extends State<NipaPlayNextOverlay> {
           return const SizedBox.expand();
         }
 
+        final previousSize = _lastConfiguredSize;
+        _lastConfiguredSize = size;
+
         _engine.configure(
           danmakuList: widget.danmakuList,
           size: size,
@@ -133,18 +143,12 @@ class _NipaPlayNextOverlayState extends State<NipaPlayNextOverlay> {
           locale: _danmakuLocale,
         );
 
-        final effectiveTime = widget.currentTimeSeconds + widget.timeOffset;
-        final positioned = _engine.layout(effectiveTime);
-
-        DanmakuNextLog.d(
-          'Overlay',
-          'build size=${size.width.toStringAsFixed(1)}x${size.height.toStringAsFixed(1)} '
-              'time=${effectiveTime.toStringAsFixed(2)} items=${positioned.length}',
-          throttle: const Duration(seconds: 1),
-        );
-
-        if (widget.onLayoutCalculated != null) {
-          final snapshot = positioned;
+        if (widget.onLayoutCalculated != null &&
+            (_layoutSnapshotPending || previousSize != size)) {
+          final snapshot = List<PositionedDanmakuItem>.from(
+            _engine.layout(widget.currentTimeSeconds + widget.timeOffset),
+          );
+          _layoutSnapshotPending = false;
           WidgetsBinding.instance.addPostFrameCallback((_) {
             if (!mounted) return;
             widget.onLayoutCalculated?.call(snapshot);
@@ -155,7 +159,9 @@ class _NipaPlayNextOverlayState extends State<NipaPlayNextOverlay> {
           opacity: widget.opacity.clamp(0.0, 1.0),
           child: CustomPaint(
             painter: NipaPlayNextCanvasPainter(
-              items: positioned,
+              engine: _engine,
+              playbackTimeMs: widget.playbackTimeMs,
+              timeOffsetSeconds: widget.timeOffset,
               fontSize: widget.fontSize,
               fontFamily: fontFamily,
               fontFamilyFallback: fontFamilyFallback,

--- a/lib/themes/cupertino/pages/cupertino_play_video_page.dart
+++ b/lib/themes/cupertino/pages/cupertino_play_video_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart' hide Text;
 import 'package:flutter/services.dart';
+import 'package:nipaplay/danmaku_abstraction/danmaku_kernel_factory.dart';
 import 'package:provider/provider.dart';
 import 'package:nipaplay/services/system_share_service.dart';
 import 'package:nipaplay/utils/video_player_state.dart';
@@ -90,6 +91,41 @@ class _CupertinoPlayVideoPageState extends State<CupertinoPlayVideoPage> {
     final focusedContext = FocusManager.instance.primaryFocus?.context;
     if (focusedContext == null) return false;
     return focusedContext.widget is EditableText;
+  }
+
+  Widget _buildDanmakuOverlay(VideoPlayerState videoState) {
+    final isNextKernel = DanmakuKernelFactory.getKernelType() ==
+        DanmakuRenderEngine.nipaplayNext;
+    return ValueListenableBuilder<double>(
+      valueListenable: videoState.playbackTimeMs,
+      child: DanmakuOverlay(
+        key: ValueKey(
+          'danmaku_${videoState.danmakuOverlayKey}',
+        ),
+        currentPosition: videoState.playbackTimeMs.value,
+        videoDuration: videoState.duration.inMilliseconds.toDouble(),
+        isPlaying: videoState.status == PlayerStatus.playing,
+        fontSize: videoState.actualDanmakuFontSize,
+        isVisible: videoState.danmakuVisible,
+        opacity: videoState.mappedDanmakuOpacity,
+      ),
+      builder: (context, posMs, child) {
+        if (isNextKernel && child != null) {
+          return child;
+        }
+        return DanmakuOverlay(
+          key: ValueKey(
+            'danmaku_${videoState.danmakuOverlayKey}',
+          ),
+          currentPosition: posMs,
+          videoDuration: videoState.duration.inMilliseconds.toDouble(),
+          isPlaying: videoState.status == PlayerStatus.playing,
+          fontSize: videoState.actualDanmakuFontSize,
+          isVisible: videoState.danmakuVisible,
+          opacity: videoState.mappedDanmakuOpacity,
+        );
+      },
+    );
   }
 
   KeyEventResult _handleKeyEvent(FocusNode node, KeyEvent event) {
@@ -337,9 +373,8 @@ class _CupertinoPlayVideoPageState extends State<CupertinoPlayVideoPage> {
           AdaptiveSnackBar.show(
             context,
             message: ok ? '截图已保存到相册' : '截图失败',
-            type: ok
-                ? AdaptiveSnackBarType.success
-                : AdaptiveSnackBarType.error,
+            type:
+                ok ? AdaptiveSnackBarType.success : AdaptiveSnackBarType.error,
           );
           return;
         }
@@ -518,8 +553,7 @@ class _CupertinoPlayVideoPageState extends State<CupertinoPlayVideoPage> {
             debugLabel: videoState.currentVideoPath?.split('/').last,
           )
         : null;
-    final hasVideo =
-        videoState.hasVideo &&
+    final hasVideo = videoState.hasVideo &&
         (kIsWeb ||
             videoState.player.prefersPlatformVideoSurface ||
             (textureId != null && textureId >= 0));
@@ -599,8 +633,8 @@ class _CupertinoPlayVideoPageState extends State<CupertinoPlayVideoPage> {
                             aspectRatio: videoState.aspectRatio,
                             child: kIsWeb
                                 ? (controller == null
-                                      ? const SizedBox.shrink()
-                                      : VideoPlayer(controller))
+                                    ? const SizedBox.shrink()
+                                    : VideoPlayer(controller))
                                 : (nativeVideoView ??
                                     (textureId == null
                                         ? const SizedBox.shrink()
@@ -614,23 +648,7 @@ class _CupertinoPlayVideoPageState extends State<CupertinoPlayVideoPage> {
                 Positioned.fill(
                   child: IgnorePointer(
                     ignoring: true,
-                    child: ValueListenableBuilder<double>(
-                      valueListenable: videoState.playbackTimeMs,
-                      builder: (context, posMs, __) {
-                        return DanmakuOverlay(
-                          key: ValueKey(
-                            'danmaku_${videoState.danmakuOverlayKey}',
-                          ),
-                          currentPosition: posMs,
-                          videoDuration:
-                              videoState.duration.inMilliseconds.toDouble(),
-                          isPlaying: videoState.status == PlayerStatus.playing,
-                          fontSize: videoState.actualDanmakuFontSize,
-                          isVisible: videoState.danmakuVisible,
-                          opacity: videoState.mappedDanmakuOpacity,
-                        );
-                      },
-                    ),
+                    child: _buildDanmakuOverlay(videoState),
                   ),
                 ),
               if (videoState.hasVideo)
@@ -640,7 +658,8 @@ class _CupertinoPlayVideoPageState extends State<CupertinoPlayVideoPage> {
                     child: ValueListenableBuilder<double>(
                       valueListenable: videoState.playbackTimeMs,
                       builder: (context, posMs, __) {
-                        return ExternalSubtitleOverlay(currentPositionMs: posMs);
+                        return ExternalSubtitleOverlay(
+                            currentPositionMs: posMs);
                       },
                     ),
                   ),
@@ -675,8 +694,7 @@ class _CupertinoPlayVideoPageState extends State<CupertinoPlayVideoPage> {
 
   Widget _buildNipaplayControls(VideoPlayerState videoState) {
     final bool uiLocked = globals.isPhone ? _isUiLocked : false;
-    final bool showLockButton =
-        globals.isPhone &&
+    final bool showLockButton = globals.isPhone &&
         (videoState.showControls || (uiLocked && _showUiLockButton));
     final bool showShareButton =
         SystemShareService.isSupported && !globals.isDesktop;
@@ -818,14 +836,12 @@ class _CupertinoPlayVideoPageState extends State<CupertinoPlayVideoPage> {
                           if (showShareButton) ...[
                             const SizedBox(width: 12),
                             ShadowActionButton(
-                              tooltip:
-                                  (!kIsWeb &&
+                              tooltip: (!kIsWeb &&
                                       defaultTargetPlatform ==
                                           TargetPlatform.iOS)
                                   ? '分享 / AirDrop'
                                   : '分享',
-                              icon:
-                                  (!kIsWeb &&
+                              icon: (!kIsWeb &&
                                       defaultTargetPlatform ==
                                           TargetPlatform.iOS)
                                   ? Icons.ios_share_rounded
@@ -963,8 +979,8 @@ class _CupertinoPlayVideoPageState extends State<CupertinoPlayVideoPage> {
 
     final TabController? tabController =
         context.findAncestorWidgetOfExactType<DefaultTabController>() != null
-        ? DefaultTabController.of(context)
-        : null;
+            ? DefaultTabController.of(context)
+            : null;
 
     if (tabController == null) {
       _horizontalDragDistance = 0.0;
@@ -1539,9 +1555,8 @@ class _CupertinoPlayVideoPageState extends State<CupertinoPlayVideoPage> {
                   ),
                   SizedBox(height: isPhone ? 6 : 8),
                   AdaptiveSlider(
-                    value: totalMillis > 0
-                        ? progressValue.clamp(0.0, 1.0)
-                        : 0.0,
+                    value:
+                        totalMillis > 0 ? progressValue.clamp(0.0, 1.0) : 0.0,
                     min: 0.0,
                     max: 1.0,
                     activeColor: CupertinoColors.activeBlue,

--- a/lib/themes/nipaplay/widgets/video_player_ui.dart
+++ b/lib/themes/nipaplay/widgets/video_player_ui.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:nipaplay/danmaku_abstraction/danmaku_kernel_factory.dart';
 import 'package:nipaplay/services/system_share_service.dart';
 import 'package:nipaplay/utils/globals.dart' as globals;
 import 'package:nipaplay/utils/platform_utils.dart';
@@ -88,6 +89,41 @@ class _VideoPlayerUIState extends State<VideoPlayerUI>
     return kind == PointerDeviceKind.touch ||
         kind == PointerDeviceKind.stylus ||
         kind == PointerDeviceKind.invertedStylus;
+  }
+
+  Widget _buildDanmakuOverlay(VideoPlayerState videoState) {
+    final isNextKernel = DanmakuKernelFactory.getKernelType() ==
+        DanmakuRenderEngine.nipaplayNext;
+    return ValueListenableBuilder<double>(
+      valueListenable: videoState.playbackTimeMs,
+      child: DanmakuOverlay(
+        key: ValueKey(
+          'danmaku_${videoState.danmakuOverlayKey}',
+        ),
+        currentPosition: videoState.playbackTimeMs.value,
+        videoDuration: videoState.videoDuration.inMilliseconds.toDouble(),
+        isPlaying: videoState.status == PlayerStatus.playing,
+        fontSize: getFontSize(videoState),
+        isVisible: videoState.danmakuVisible,
+        opacity: videoState.mappedDanmakuOpacity,
+      ),
+      builder: (context, posMs, child) {
+        if (isNextKernel && child != null) {
+          return child;
+        }
+        return DanmakuOverlay(
+          key: ValueKey(
+            'danmaku_${videoState.danmakuOverlayKey}',
+          ),
+          currentPosition: posMs,
+          videoDuration: videoState.videoDuration.inMilliseconds.toDouble(),
+          isPlaying: videoState.status == PlayerStatus.playing,
+          fontSize: getFontSize(videoState),
+          isVisible: videoState.danmakuVisible,
+          opacity: videoState.mappedDanmakuOpacity,
+        );
+      },
+    );
   }
 
   bool _isShiftPressed() {
@@ -898,33 +934,8 @@ class _VideoPlayerUIState extends State<VideoPlayerUI>
                                           ignoring: true,
                                           child: Consumer<VideoPlayerState>(
                                             builder: (context, videoState, _) {
-                                              // 使用高频时间轴驱动弹幕帧率
-                                              return ValueListenableBuilder<
-                                                  double>(
-                                                valueListenable:
-                                                    videoState.playbackTimeMs,
-                                                builder: (context, posMs, __) {
-                                                  return DanmakuOverlay(
-                                                    key: ValueKey(
-                                                      'danmaku_${videoState.danmakuOverlayKey}',
-                                                    ),
-                                                    currentPosition: posMs,
-                                                    videoDuration: videoState
-                                                        .videoDuration
-                                                        .inMilliseconds
-                                                        .toDouble(),
-                                                    isPlaying: videoState
-                                                            .status ==
-                                                        PlayerStatus.playing,
-                                                    fontSize: getFontSize(
-                                                      videoState,
-                                                    ),
-                                                    isVisible: videoState
-                                                        .danmakuVisible,
-                                                    opacity: videoState
-                                                        .mappedDanmakuOpacity,
-                                                  );
-                                                },
+                                              return _buildDanmakuOverlay(
+                                                videoState,
                                               );
                                             },
                                           ),
@@ -1006,34 +1017,8 @@ class _VideoPlayerUIState extends State<VideoPlayerUI>
                                             child: Consumer<VideoPlayerState>(
                                               builder:
                                                   (context, videoState, _) {
-                                                // 使用高频时间轴驱动弹幕帧率
-                                                return ValueListenableBuilder<
-                                                    double>(
-                                                  valueListenable:
-                                                      videoState.playbackTimeMs,
-                                                  builder:
-                                                      (context, posMs, __) {
-                                                    return DanmakuOverlay(
-                                                      key: ValueKey(
-                                                        'danmaku_${videoState.danmakuOverlayKey}',
-                                                      ),
-                                                      currentPosition: posMs,
-                                                      videoDuration: videoState
-                                                          .videoDuration
-                                                          .inMilliseconds
-                                                          .toDouble(),
-                                                      isPlaying: videoState
-                                                              .status ==
-                                                          PlayerStatus.playing,
-                                                      fontSize: getFontSize(
-                                                        videoState,
-                                                      ),
-                                                      isVisible: videoState
-                                                          .danmakuVisible,
-                                                      opacity: videoState
-                                                          .mappedDanmakuOpacity,
-                                                    );
-                                                  },
+                                                return _buildDanmakuOverlay(
+                                                  videoState,
                                                 );
                                               },
                                             ),

--- a/lib/utils/video_player_state.dart
+++ b/lib/utils/video_player_state.dart
@@ -460,7 +460,9 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
   final String _danmakuFontFamilyKey = 'danmaku_font_family';
   String _danmakuFontFamily = '';
   final String _danmakuOutlineStyleKey = 'danmaku_outline_style';
-  DanmakuOutlineStyle _danmakuOutlineStyle = DanmakuOutlineStyle.uniform;
+  DanmakuOutlineStyle _danmakuOutlineStyle = globals.isMobilePlatform
+      ? DanmakuOutlineStyle.stroke
+      : DanmakuOutlineStyle.uniform;
   final String _danmakuShadowStyleKey = 'danmaku_shadow_style';
   DanmakuShadowStyle _danmakuShadowStyle = globals.isMobilePlatform
       ? DanmakuShadowStyle.none

--- a/lib/utils/video_player_state/video_player_state_preferences.dart
+++ b/lib/utils/video_player_state/video_player_state_preferences.dart
@@ -1198,7 +1198,9 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
   }
 
   DanmakuOutlineStyle _resolveDanmakuOutlineStyle(int? index) {
-    const DanmakuOutlineStyle fallback = DanmakuOutlineStyle.uniform;
+    final DanmakuOutlineStyle fallback = globals.isMobilePlatform
+        ? DanmakuOutlineStyle.stroke
+        : DanmakuOutlineStyle.uniform;
     if (index == null ||
         index < 0 ||
         index >= DanmakuOutlineStyle.values.length) {

--- a/lib/widgets/danmaku_overlay.dart
+++ b/lib/widgets/danmaku_overlay.dart
@@ -122,6 +122,7 @@ class _DanmakuOverlayState extends State<DanmakuOverlay> {
         if (kernelType == DanmakuRenderEngine.nipaplayNext) {
           return NipaPlayNextOverlay(
             danmakuList: activeDanmakuList,
+            playbackTimeMs: videoState.playbackTimeMs,
             currentTimeSeconds: widget.currentPosition / 1000,
             fontSize: widget.fontSize,
             isVisible: widget.isVisible,


### PR DESCRIPTION
Summary: optimize next danmaku layout and painter hot paths, reduce per-frame allocations and cache thrash, keep seek-follow behavior, and change mobile default/fallback outline style to stroke (desktop remains uniform). Verification: dart analyze on changed files passed with no new issues.